### PR TITLE
Makefile: fix build under gcc6

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -40,7 +40,7 @@ export AS := nasm
 export RANLIB ?= ranlib
 
 export CFLAGS := -Wall
-export CXXFLAGS := -Wall -Wno-unused-parameter
+export CXXFLAGS := -Wall -Wno-unused-parameter -std=c++98
 C_CXX_FLAGS := -MMD -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_LARGE_FILES -I$(BASE_DIR) -I$(BASE_DIR)/Crypto
 export ASFLAGS := -Ox -D __GNUC__
 export LFLAGS :=


### PR DESCRIPTION
Veracrypt for build under GCC6 required using compatibility flag `-std=c++98` against change default C++ frontend in GCC6.

The C++ frontend now defaults to C++14 standard instead of C++98 it has
been defaulting to previously, for compiling older C++ code that might
require either explicitly compiling with selected older C++ standards,
or might require some code adjustment, see
http://gcc.gnu.org/gcc-6/porting_to.html for details.  The experimental
C++17 support has been enhanced in this release.

from: https://gcc.gnu.org/ml/gcc-announce/2016/msg00000.html