### PR TITLE
Revert "Makefile: fix build under gcc6"

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -40,7 +40,7 @@ export AS := nasm
 export RANLIB ?= ranlib
 
 export CFLAGS := -Wall
-export CXXFLAGS := -Wall -Wno-unused-parameter -std=c++98
+export CXXFLAGS := -Wall -Wno-unused-parameter
 C_CXX_FLAGS := -MMD -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_LARGE_FILES -I$(BASE_DIR) -I$(BASE_DIR)/Crypto
 export ASFLAGS := -Ox -D __GNUC__
 export LFLAGS :=


### PR DESCRIPTION
Reverts veracrypt/VeraCrypt#66 which introduce usage of gcc c++98 compatibility switch since it causes errors when linking against the system wxWidgets library.

A previous commit has already solved gcc-6 compilation issues.