### PR TITLE
Added two line to enable support for retina ui on retina Macs.

### DIFF
--- a/src/Build/Resources/MacOSX/Info.plist.xml
+++ b/src/Build/Resources/MacOSX/Info.plist.xml
@@ -40,5 +40,11 @@
 
 	<key>CSResourcesFileMapped</key>
 	<true/>
+
+    <key>NSHighResolutionCapable</key>
+    <true/>
+
+    <key>NSPrincipalClass</key>
+    <string>NSApplication</string>
 </dict>
 </plist>


### PR DESCRIPTION
Currently Veracrypt ui is "low resolution" only when installed on Mac.
Adding these two lines enables Veracrypt to run as a retina app.