### PR TITLE
Fix typo

### DIFF
--- a/src/Main/LanguageStrings.cpp
+++ b/src/Main/LanguageStrings.cpp
@@ -60,7 +60,7 @@ namespace VeraCrypt
 		Map["NO"] = _("No");
 		Map["NO_VOLUMES_MOUNTED"] = _("No volumes mounted.");
 		Map["OPEN_NEW_VOLUME"] = _("Specify a New VeraCrypt Volume");
-		Map["PARAMETER_INCORRECT"] = _("Parameter incorrrect");
+		Map["PARAMETER_INCORRECT"] = _("Parameter incorrect");
 		Map["SELECT_KEYFILES"] = _("Select Keyfiles");
 		Map["START_TC"] = _("Start VeraCrypt");
 		Map["VOLUME_ALREADY_MOUNTED"] = _("The volume \"{0}\" is already mounted.");


### PR DESCRIPTION
`incorrrect` -> `incorrect`