### PR TITLE
Linux: workaround to mount system-encrypted partition on nvme drive

### DIFF
--- a/src/Platform/Unix/FilesystemPath.cpp
+++ b/src/Platform/Unix/FilesystemPath.cpp
@@ -72,6 +72,14 @@ namespace VeraCrypt
 
 		path = StringConverter::StripTrailingNumber (StringConverter::ToSingle (Path));
 
+		// If the system-encrypted partition is on a nvme drive, partition name will be
+		// something like /dev/nvme0n1p<partition_number>, therefore we have to remove
+		// the last 'p' as well to get the name of the host drive.
+		string pathStr = StringConverter::ToSingle (path);
+		size_t t = pathStr.find("nvme");
+		if(t != string::npos)
+			path = pathStr.substr (0, pathStr.size() - 1);
+
 #elif defined (TC_MACOSX)
 
 		string pathStr = StringConverter::StripTrailingNumber (StringConverter::ToSingle (Path));


### PR DESCRIPTION
The naming scheme of Linux block devices representing partitions hosted on NVME drives differs from the usual (e.g. /dev/nvme0n1p2 instead of /dev/sda2). This prevents mounting of Windows encrypted system partitions from Linux, since the name of the hosting drive, which is required in this case, is not correctly deduced by VeraCrypt. Therefore I suggest this simple workaround, maybe not ideal but at least it doesn't seem to cause any harm.