### PR TITLE
Fix TrueCrypt mode checkbox is always set

### DIFF
--- a/src/Main/Forms/MountOptionsDialog.cpp
+++ b/src/Main/Forms/MountOptionsDialog.cpp
@@ -38,7 +38,7 @@ namespace VeraCrypt
 		PasswordPanel->SetCacheCheckBoxValidator (wxGenericValidator (&Options.CachePassword));
 		
 		if (options.Path && options.Path->HasTrueCryptExtension() && !disableMountOptions 
-			&& !options.TrueCryptMode && (options.Pim <= 0))
+			&& options.TrueCryptMode && (options.Pim <= 0))
 		{
 			PasswordPanel->SetTrueCryptMode (true);	
 		}


### PR DESCRIPTION
BUG: "TrueCrypt mode" checkbox in the Mount Dialog is always set despite the state of the corresponding flag in Default Mount Options.