### PR TITLE
Platform/Unix: include <sys/sysmacros.h> for major/minor macros

### DIFF
--- a/src/Platform/Unix/FilesystemPath.cpp
+++ b/src/Platform/Unix/FilesystemPath.cpp
@@ -15,6 +15,7 @@
 #include "Platform/StringConverter.h"
 #include <stdio.h>
 #include <sys/stat.h>
+#include <sys/sysmacros.h>
 
 namespace VeraCrypt
 {


### PR DESCRIPTION
Starting with glibc 2.26, macros "major" and "minor" are only
available from <sys/sysmacros.h> [0]. The build fails with the
following without including this header:

Unix/FilesystemPath.cpp:84:49: error: ‘major’ was not declared in this scope
Unix/FilesystemPath.cpp:84:113: error: ‘minor’ was not declared in this scope

[0] https://sourceware.org/ml/libc-alpha/2017-02/msg00079.html