### PR TITLE
Fix password-only example in help text (pim missing)

### DIFF
--- a/src/Main/UserInterface.cpp
+++ b/src/Main/UserInterface.cpp
@@ -1307,7 +1307,7 @@ namespace VeraCrypt
 					"veracrypt --filesystem=none volume.hc\n"
 					"\n"
 					"Mount a volume prompting only for its password:\n"
-					"veracrypt -t -k \"\" --protect-hidden=no volume.hc /media/veracrypt1\n"
+					"veracrypt -t -k \"\" --pim=0 --protect-hidden=no volume.hc /media/veracrypt1\n"
 					"\n"
 					"Dismount a volume:\n"
 					"veracrypt -d volume.hc\n"


### PR DESCRIPTION
Under `veracrypt -t -h` there is this example:
```
Mount a volume prompting only for its password:
veracrypt -t -k "" --protect-hidden=no volume.hc /media/veracrypt1
```
which seems not be outdated to the addition of the "pim" variable. This commit adds `--pim=0` to prevent the resulting execution from prompting for a pim.