### PR TITLE
Fix issues related to "foreach" macro

### DIFF
--- a/src/Platform/Unix/Process.cpp
+++ b/src/Platform/Unix/Process.cpp
@@ -56,9 +56,9 @@ namespace VeraCrypt
 					if (!execFunctor)
 						args[argIndex++] = const_cast <char*> (processName.c_str());
 
-					for (list<string>::const_iterator it = arguments.begin(); it != arguments.end(); it++)
+					foreach (const string &arg, arguments)
 					{
-						args[argIndex++] = const_cast <char*> (it->c_str());
+						args[argIndex++] = const_cast <char*> (arg.c_str());
 					}
 					args[argIndex] = nullptr;
 


### PR DESCRIPTION
Proposed alternative solution of "Invalid characters..." issue on mount (#453) is not to use the "foreach" macro in one particular case. This macro is used in many other places and
-   is inefficient (makes unnecessary copies)
-   is unsafe in some sense (see #453)
-   has a safe and efficient equivalent in the "new" C++ standard (can we still consider C++11 new?))

Here is yet another variant based on "range for" operator (requires C++11). The "friends" of the "foreach" macro with reversing/dereferencing cannot be expressed by "range for" directly, so they use simple container adapters.
