### PR TITLE
Allow $(ARCH) to be defined during build

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -132,7 +132,7 @@ export PLATFORM_UNSUPPORTED := 0
 export CPU_ARCH ?= unknown
 export SIMD_SUPPORTED := 0
 
-ARCH = $(shell uname -m)
+ARCH ?= $(shell uname -m)
 
 ifneq (,$(filter i386 i486 i586 i686 x86,$(ARCH)))
 	CPU_ARCH = x86


### PR DESCRIPTION
This can be useful when crossbuilding or building in a chroot where using
uname -m would cause the wrong compiler options.

One could define CPU_ARCH, but then other options aren't set right and it still tries to autodetect.  I tested this patch in a i386 chroot on an amd64 host, worked as expected.