### PR TITLE
Align section types of Whirlpool_C and SHA256_K

### DIFF
--- a/src/Crypto/Sha2.c
+++ b/src/Crypto/Sha2.c
@@ -318,7 +318,7 @@ extern "C"
 
 #endif
 
-CRYPTOPP_ALIGN_DATA(16) uint_32t SHA256_K[64] CRYPTOPP_SECTION_ALIGN16 = {
+CRYPTOPP_ALIGN_DATA(16) static const uint_32t SHA256_K[64] CRYPTOPP_SECTION_ALIGN16 = {
 		0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4, 0xab1c5ed5,
 		0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174,
 		0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,


### PR DESCRIPTION
in order to fix LTO linking.

After switching to LTO for openSUSE Tumbleweed, veracrypt build failed with:
[  185s] ../Crypto/Whirlpool.c:105:45: error: 'Whirlpool_C' causes a section type conflict with 'SHA256_K'
[  185s]   105 | CRYPTOPP_ALIGN_DATA(16) static const uint64 Whirlpool_C[8*256+R] CRYPTOPP_SECTION_ALIGN16 = {
[  185s]       |                                             ^
[  185s] ../Crypto/Sha2.c:321:34: note: 'SHA256_K' was declared here
[  185s]   321 | CRYPTOPP_ALIGN_DATA(16) uint_32t SHA256_K[64] CRYPTOPP_SECTION_ALIGN16 = {
[  185s]       |                                  ^
[  185s] lto-wrapper: fatal error: g++ returned 1 exit status

Aligning section types of Whirlpool_C and SHA256_K fixes this.