### PR TITLE
Fixes so that 'make install' works

### DIFF
--- a/src/Main/Main.make
+++ b/src/Main/Main.make
@@ -254,7 +254,8 @@ endif
 
 
 install: prepare
-	cp -R $(CURDIR)/Setup/Linux/usr $(DESTDIR)/.
+	mkdir -p $(DESTDIR)
+	cp -R $(CURDIR)/../Setup/Linux/usr $(DESTDIR)/.
 
 ifeq "$(TC_BUILD_CONFIG)" "Release"
 package: prepare
@@ -303,7 +304,8 @@ endif
 
 
 install: prepare
-	cp -R $(CURDIR)/Setup/FreeBSD/usr $(DESTDIR)/.
+	mkdir -p $(DESTDIR)
+	cp -R $(CURDIR)/../Setup/FreeBSD/usr $(DESTDIR)/.
 
 ifeq "$(TC_BUILD_CONFIG)" "Release"
 package: prepare


### PR DESCRIPTION
In `src/Makefile`, Lines `399` and `402`, `make install` is called using `-C Main`. This changes `CURDIR` to be `src/Main`.
In `src/Main/Main.make`, Lines `257` and `306`, `cp` command will not work because it is executed on `$(CURDIR)/Setup/Linux/usr` and `$(CURDIR)/Setup/FreeBSD/usr`,
which translate to `src/Main/Setup/Linux/usr` and `src/Main/Setup/FreeBSD/usr`, which do not exist.

To fix this, we append `..` to `$(CURDIR)/` in order to return to the parent directory `src`.

Also `$(DESTDIR)` might not exist, therefore we create it using `mkdir -p` beforehand.