### PR TITLE
Fix #define order in Tcdefs.h

### DIFF
--- a/src/Common/Tcdefs.h
+++ b/src/Common/Tcdefs.h
@@ -54,14 +54,14 @@ extern unsigned short _rotl16(unsigned short value, unsigned char shift);
 
 #define TC_APP_NAME						"VeraCrypt"
 
+// Version displayed to user 
+#define VERSION_STRING					"1.24-Beta6"
+
 #ifdef VC_EFI_CUSTOM_MODE
 #define VERSION_STRING_SUFFIX			"-CustomEFI"
 #else
 #define VERSION_STRING_SUFFIX			""
 #endif
-
-// Version displayed to user 
-#define VERSION_STRING					"1.24-Beta6"
 
 // Version number to compare against driver
 #define VERSION_NUM						0x0124


### PR DESCRIPTION
`#define VERSION_STRING XXX` must come before `#define VERSION_STRING_SUFFIX YYY` in `'src/Common/Tcdefs.h` in order for `export TC_VERSION := $(shell grep VERSION_STRING ../Common/Tcdefs.h | head -n 1 | cut -d'"' -f 2)` in `src/Main/Main.make` to actually return the version rather than `-CustomEFI`.