### PR TITLE
Fix "error "SSSE3 instruction set not enabled" when compiling using GCC version < 4.9 without -mssse3 option

### DIFF
--- a/src/Crypto/cpu.h
+++ b/src/Crypto/cpu.h
@@ -144,6 +144,7 @@ extern __m128i _mm_set1_epi64x (__int64 a);
 #endif
 
 #if CRYPTOPP_SSSE3_AVAILABLE || defined(__INTEL_COMPILER)
+#if defined (_MSC_VER) && !defined (TC_WINDOWS_BOOT)
 #if defined(TC_WINDOWS_DRIVER) || defined (_UEFI)
 #if defined(__cplusplus)
 extern "C" {
@@ -154,6 +155,7 @@ extern __m128i _mm_shuffle_epi8 (__m128i a, __m128i b);
 #endif
 #else
 #include <tmmintrin.h>
+#endif
 #endif
 
 #if defined(__SSE4_1__) || defined(__INTEL_COMPILER) || defined(_MSC_VER)


### PR DESCRIPTION
Compiling with `-mxxx` defines the corresponding macro of the intrinsics.
For example, `-mssse3` defines `__SSSE3__` macro to `1`.

In **GCC versions < 4.9**, it is **not possible** to use and call x86 intrinsics **only at runtime** without
compiling the entire file with the `-mxxx `option.

For example, if we want to call `SSSE3` intrinsics without compiling with `-mssse3`, the macro `__SSSE3__` is not defined.
Therefore, when including `<tmmintrin.h>`, this results in **"error "SSSE3 instruction set not enabled""** because of :

> 
	#ifndef __SSSE3__
	# error "SSSE3 instruction set not enabled"

**This happens when compiling VeraCrypt under CentOS 6 and 7.**

Since **GCC 4.9**, this has been **fixed** and it is possible to call x86 intrinsics from select functions in a file that are tagged with the corresponding target attribute **without having to compile the entire file with the `-mxxx` option.**
This can be seen in `<tmmintrin.h>` which in **recent versions (>= 4.9)** contains :

> 
	#ifndef __SSSE3__
	#pragma GCC push_options
	#pragma GCC target("ssse3")
	#define __DISABLE_SSSE3__

Since SSSE3 is **only used** under **Windows** for **ChaCha256**, this can be fixed by preceding `#include <tmmintrin.h>` with
`#if defined (_MSC_VER) && !defined (TC_WINDOWS_BOOT).`

See [this](https://gcc.gnu.org/gcc-4.9/changes.html)