### PR TITLE
Linux : Added missing 'mkdir' before installing in case $DESTDIR does not exist

### DIFF
--- a/src/Main/Main.make
+++ b/src/Main/Main.make
@@ -254,6 +254,7 @@ endif
 
 
 install: prepare
+	mkdir -p $(DESTDIR)
 	cp -R $(BASE_DIR)/Setup/Linux/usr $(DESTDIR)/
 
 ifeq "$(TC_BUILD_CONFIG)" "Release"
@@ -303,6 +304,7 @@ endif
 
 
 install: prepare
+	mkdir -p $(DESTDIR)
 	cp -R $(BASE_DIR)/Setup/FreeBSD/usr $(DESTDIR)/.
 
 ifeq "$(TC_BUILD_CONFIG)" "Release"


### PR DESCRIPTION
`make install $DESTDIR="/some/path"` fails in case `$DESTDIR` does not exist.
This fixes the issue by prepending `mkdir -p $DESTDIR` to the `cp` command.