### PR TITLE
Updated and fixed build and packaging scripts.

### DIFF
--- a/src/Build/CMakeLists.txt
+++ b/src/Build/CMakeLists.txt
@@ -53,21 +53,22 @@ endif( )
 
 # - Detect OSX, CentOS, Debian, Ubuntu or openSUSE platform of the build system
 #   The following variable(s) will be set
-#   	$PLATFORM						Debian		Ubuntu 		CentOS		openSUSE 
+#   	$PLATFORM						Debian		Ubuntu 		CentOS		openSUSE (TODO)
 #   	$PLATFORM_VERSION	
 #										9.x 		16.04		7.X			42.3
 #										10.X		18.04		8.X			15.0
+#										...			...			...			...
 # 		$DISTRO_NAME					${PLATFORM}-${PLATFORM_VERSION}
 if ( UNIX )
 
 	# /etc/debian_version exists for both Debian and Ubuntu
-	if(EXISTS "/etc/debian_version")		
+	if(EXISTS "/etc/debian_version")
 	
 		set ( PLATFORM "Debian" )
 	
 		# Read lsb-release to get flavour name and flavour release version (only supported one for now is Ubuntu)
 		if(EXISTS "/etc/lsb-release")		
-		
+			
 			file(READ "/etc/lsb-release" LSB_RELEASE_ID)
 			string(REGEX MATCH "DISTRIB_ID=([a-zA-Z0-9 /\\.]+)" _ ${LSB_RELEASE_ID})
 			set(FULL_FLAVOUR ${CMAKE_MATCH_1})
@@ -83,22 +84,18 @@ if ( UNIX )
 			else()
 			
 				file(READ "/etc/debian_version" DEBIAN_RELEASE)
-				string(REGEX MATCH "[a-zA-Z0-9 /\\.]+" _ ${DEBIAN_RELEASE})
+				string(REGEX MATCH "([0-9]+\\.[0-9]+)" _ ${DEBIAN_RELEASE})
 				set(PLATFORM_VERSION ${CMAKE_MATCH_1})
-				
-				if( PLATFORM_VERSION STREQUAL "stretch/sid" )
-					set( PLATFORM_VERSION "9" )
-				endif( PLATFORM_VERSION STREQUAL "stretch/sid" )
 				
 			endif()
 			
 		# Get debian release version
 		elseif(EXISTS "/etc/debian_version")
-		
+			
 			file(READ "/etc/debian_version" DEBIAN_RELEASE)
-			string(REGEX MATCH "[a-zA-Z0-9 /\\.]+" _ ${DEBIAN_RELEASE})
+			string(REGEX MATCH "([0-9]+\\.[0-9]+)" _ ${DEBIAN_RELEASE})
 			set(PLATFORM_VERSION ${CMAKE_MATCH_1})
-					
+			
 		endif()
 	
 	# Get centos release version
@@ -158,30 +155,24 @@ if ( PLATFORM STREQUAL "Debian" OR PLATFORM STREQUAL "Ubuntu" )
 		elseif (SUFFIX STREQUAL "64")
 			SET(ARCHITECTURE amd64)
 		endif()
-	else(NOT DPKG_CMD)
+	else( )
 		execute_process(COMMAND dpkg --print-architecture OUTPUT_VARIABLE ARCHITECTURE OUTPUT_STRIP_TRAILING_WHITESPACE)
-	endif(NOT DPKG_CMD)
+	endif( )
 	
 elseif ( ( PLATFORM STREQUAL "CentOS" ) OR ( PLATFORM STREQUAL "openSUSE" ) )
 
 	execute_process(COMMAND arch OUTPUT_VARIABLE ARCHITECTURE OUTPUT_STRIP_TRAILING_WHITESPACE)
 	
-elseif ( PLATFORM STREQUAL "OSX" )
+else ()
 
-	if ( UNIVERSAL )
-		set ( ARCHITECTURE "Univesal-Binary" )
-	else ( UNIVERSAL )
-		# arch reports Intel using the i386 label rather than intel
-		# We use uname -m instead
-		execute_process(COMMAND uname -m OUTPUT_VARIABLE ARCHITECTURE OUTPUT_STRIP_TRAILING_WHITESPACE)
-	endif( UNIVERSAL )
+	MESSAGE(FATAL_ERROR "Unrecognized / unsupported distribution")
 	
 endif ( )
 MESSAGE ( STATUS "Architecture = ${ARCHITECTURE}" )
 
 # - Create installation folder directory at install time
 #	This won't lead to the files being actually installed (in CMAKE_INSTALL_PREFIX)
-#	unless "cmake --build . --target install" is executed, which is not the case here/
+#	unless "cmake --build . --target install" is executed, which is not the case here.
 # 	
 #	Doing things like the following
 #		-	install(DIRECTORY 	${VERACRYPT_BUILD_DIR}/usr DESTINATION /)
@@ -261,16 +252,27 @@ if ( ( PLATFORM STREQUAL "Debian" ) OR ( PLATFORM STREQUAL "Ubuntu" ) )
 	set( CPACK_DEBIAN_PACKAGE_RELEASE 		${CPACK_PACKAGE_RELEASE} )
 	set( CPACK_DEBIAN_PACKAGE_ARCHITECTURE 	${ARCHITECTURE} )																	# mandatory
 	
-	set( CPACK_DEBIAN_PACKAGE_DEPENDS 		"libwxgtk3.0-0v5, libfuse2, dmsetup")
+	# Link against gtk3 version of wxWidgets if >= Debian 10 or >= Ubuntu 18.04
+	# Otherwise, link against gtk2 version of wxWidgets
+	if ( ( ( PLATFORM STREQUAL "Debian" ) AND ( PLATFORM_VERSION VERSION_GREATER_EQUAL "10" ) ) 
+		OR ( ( PLATFORM STREQUAL "Ubuntu" ) AND ( PLATFORM_VERSION VERSION_GREATER_EQUAL "18.04" ) ) )
+		
+		set( CPACK_DEBIAN_PACKAGE_DEPENDS 		"libwxgtk3.0-gtk3-0v5, libfuse2, dmsetup" )										
+		
+	else ()
+	
+		set( CPACK_DEBIAN_PACKAGE_DEPENDS 		"libwxgtk3.0-0v5, libfuse2, dmsetup" )
+		
+	endif()
 		
 	set( CPACK_DEBIAN_PACKAGE_MAINTAINER 	${CONTACT} )																		# mandatory
 	set( CPACK_DEBIAN_PACKAGE_DESCRIPTION 	${CPACK_PACKAGE_DESCRIPTION_SUMMARY} )												# mandatory
 	set( CPACK_DEBIAN_ARCHIVE_TYPE 			"gnutar")																			# mandatory
 	set( CPACK_DEBIAN_COMPRESSION_TYPE 		"gzip")																				# mandatory
 	set( CPACK_DEBIAN_PACKAGE_PRIORITY 		"optional" )																		# mandatory
-	set( CPACK_DEBIAN_PACKAGE_SECTION 		"libs" )		 																	# recommended, to do, Section relative to Debian sections (https://www.debian.org/doc/debian-policy/ch-archive.html#s-subsections)
+	set( CPACK_DEBIAN_PACKAGE_SECTION 		"libs" )		 																	# recommended, Section relative to Debian sections (https://www.debian.org/doc/debian-policy/ch-archive.html#s-subsections)
 	set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA 	${DEBIAN_PREINST};${DEBIAN_POSTINST};${DEBIAN_PRERM};${DEBIAN_POSTRM})
-	set(CPACK_DEBIAN_PACKAGE_CONFLICTS 		${CONFLICT_PACKAGE})
+	set(CPACK_DEBIAN_PACKAGE_CONFLICTS 		"${CONFLICT_PACKAGE}")
 	
 elseif ( ( PLATFORM STREQUAL "CentOS" ) OR ( PLATFORM STREQUAL "openSUSE" ) )
 	
@@ -293,9 +295,17 @@ elseif ( ( PLATFORM STREQUAL "CentOS" ) OR ( PLATFORM STREQUAL "openSUSE" ) )
 	set( CPACK_RPM_PACKAGE_AUTOREQ 		"no" ) 																					# disable automatic shared libraries dependency detection (most of the time buggy)
 	
 	if ( PLATFORM STREQUAL "CentOS" )
-		set( CPACK_RPM_PACKAGE_REQUIRES 	"fuse, device-mapper, gtk3")
+			
+		if ( DEFINED WITHGTK3 AND WITHGTK3 )
+			set( CPACK_RPM_PACKAGE_REQUIRES 	"fuse, device-mapper, gtk3" )
+		else ()
+			set( CPACK_RPM_PACKAGE_REQUIRES 	"fuse, device-mapper, gtk2" )
+		endif()
+		
 	elseif ( PLATFORM STREQUAL "openSUSE" )
+		
 		#	TODO
+	
 	endif()
 	
 	set( CPACK_RPM_PRE_UNINSTALL_SCRIPT_FILE 			${RPM_PRERM})															# optional

--- a/src/Build/build_cmake_deb.sh
+++ b/src/Build/build_cmake_deb.sh
@@ -20,6 +20,7 @@ make 		|| exit 1
 make install DESTDIR="$PARENTDIR/VeraCrypt_Setup/GUI"	|| exit 1
 
 echo "Building console version of VeraCrypt for DEB using system wxWidgets"
+
 # This is to avoid " Error: Unable to initialize GTK+, is DISPLAY set properly?" 
 # when building over SSH without X11 Forwarding
 # export DISPLAY=:0.0
@@ -29,13 +30,14 @@ make NOGUI=1 		|| exit 1
 make NOGUI=1 install DESTDIR="$PARENTDIR/VeraCrypt_Setup/Console"	|| exit 1
 
 echo "Creating VeraCrypt DEB packages"
+
 # -DCPACK_RPM_PACKAGE_DEBUG=TRUE for debugging cpack DEB
 # -DCPACK_RPM_PACKAGE_DEBUG=TRUE for debugging cpack DEB
 
-mkdir $PARENTDIR/VeraCrypt_Packaging
+mkdir -p $PARENTDIR/VeraCrypt_Packaging/GUI
+mkdir -p $PARENTDIR/VeraCrypt_Packaging/Console
 
-cmake -H$SCRIPTPATH -B$PARENTDIR/VeraCrypt_Packaging -DVERACRYPT_BUILD_DIR="$PARENTDIR/VeraCrypt_Setup/GUI" -DNOGUI=FALSE || exit 1
-cpack --config $PARENTDIR/VeraCrypt_Packaging/CPackConfig.cmake || exit 1
-
-cmake -H$SCRIPTPATH -B$PARENTDIR/VeraCrypt_Packaging -DVERACRYPT_BUILD_DIR="$PARENTDIR/VeraCrypt_Setup/Console" -DNOGUI=TRUE || exit 1
-cpack --config $PARENTDIR/VeraCrypt_Packaging/CPackConfig.cmake	|| exit 1
+cmake -H$SCRIPTPATH -B$PARENTDIR/VeraCrypt_Packaging/GUI -DVERACRYPT_BUILD_DIR="$PARENTDIR/VeraCrypt_Setup/GUI" -DNOGUI=FALSE || exit 1
+cpack --config $PARENTDIR/VeraCrypt_Packaging/GUI/CPackConfig.cmake || exit 1
+cmake -H$SCRIPTPATH -B$PARENTDIR/VeraCrypt_Packaging/Console -DVERACRYPT_BUILD_DIR="$PARENTDIR/VeraCrypt_Setup/Console" -DNOGUI=TRUE || exit 1
+cpack --config $PARENTDIR/VeraCrypt_Packaging/Console/CPackConfig.cmake	|| exit 1

--- a/src/Build/build_cmake_rpm_gtk2.sh
+++ b/src/Build/build_cmake_rpm_gtk2.sh
@@ -23,12 +23,13 @@ echo "Building GUI version of VeraCrypt for RPM using wxWidgets static libraries
 # This will be the temporary wxWidgets directory
 export WX_BUILD_DIR=$PARENTDIR/wxBuildGui
 
-make WXSTATIC=1 WITHGTK3=1 wxbuild || exit 1
-make WXSTATIC=1 clean 	|| exit 1
-make WXSTATIC=1 		|| exit 1
+# To build wxWidgets using GTK-2
+make WXSTATIC=1 wxbuild 			|| exit 1
+make WXSTATIC=1 clean 				|| exit 1
+make WXSTATIC=1 					|| exit 1
 make WXSTATIC=1 install DESTDIR="$PARENTDIR/VeraCrypt_Setup/GUI"	|| exit 1
 
-# Uncomment below and comment line above to reuse existing wxWidgets build
+# Uncomment below and comment lines above to reuse existing wxWidgets build
 # make WXSTATIC=1 clean || exit 1
 # make WXSTATIC=1		|| exit 1
 # make WXSTATIC=1 install DESTDIR="$PARENTDIR/VeraCrypt_Setup/GUI"	|| exit 1
@@ -42,9 +43,10 @@ echo "Building console version of VeraCrypt for RPM using wxWidgets static libra
 # This will be the temporary wxWidgets directory
 export WX_BUILD_DIR=$PARENTDIR/wxBuildConsole
 
-make WXSTATIC=1 WITHGTK3=1 NOGUI=1 wxbuild || exit 1
-make WXSTATIC=1 NOGUI=1 clean 	|| exit 1
-make WXSTATIC=1 NOGUI=1 		|| exit 1
+# To build wxWidgets using GTK-2
+make WXSTATIC=1 NOGUI=1 wxbuild 			|| exit 1
+make WXSTATIC=1 NOGUI=1 clean 				|| exit 1
+make WXSTATIC=1 NOGUI=1 					|| exit 1
 make WXSTATIC=1 NOGUI=1 install DESTDIR="$PARENTDIR/VeraCrypt_Setup/Console"	|| exit 1
 
 # Uncomment below and comment lines above to reuse existing wxWidgets build
@@ -53,13 +55,15 @@ make WXSTATIC=1 NOGUI=1 install DESTDIR="$PARENTDIR/VeraCrypt_Setup/Console"	|| 
 # make WXSTATIC=1 NOGUI=1 install DESTDIR="$PARENTDIR/VeraCrypt_Setup/Console"	|| exit 1
 
 echo "Creating VeraCrypt RPM packages "
+
 # -DCPACK_RPM_PACKAGE_DEBUG=TRUE for debugging cpack RPM
 # -DCPACK_RPM_PACKAGE_DEBUG=TRUE for debugging cpack RPM
 
-mkdir $PARENTDIR/VeraCrypt_Packaging
+mkdir -p $PARENTDIR/VeraCrypt_Packaging/GUI
+mkdir -p $PARENTDIR/VeraCrypt_Packaging/Console
 
-cmake -H$SCRIPTPATH -B$PARENTDIR/VeraCrypt_Packaging -DVERACRYPT_BUILD_DIR="$PARENTDIR/VeraCrypt_Setup/GUI" -DNOGUI=FALSE || exit 1		
-cpack --config $PARENTDIR/VeraCrypt_Packaging/CPackConfig.cmake || exit 1
-
-cmake -H$SCRIPTPATH -B$PARENTDIR/VeraCrypt_Packaging -DVERACRYPT_BUILD_DIR="$PARENTDIR/VeraCrypt_Setup/Console" -DNOGUI=TRUE || exit 1
-cpack --config $PARENTDIR/VeraCrypt_Packaging/CPackConfig.cmake|| exit 1
+# wxWidgets was built using GTK-2
+cmake -H$SCRIPTPATH -B$PARENTDIR/VeraCrypt_Packaging/GUI -DVERACRYPT_BUILD_DIR="$PARENTDIR/VeraCrypt_Setup/GUI" -DWITHGTK3=FALSE -DNOGUI=FALSE || exit 1
+cpack --config $PARENTDIR/VeraCrypt_Packaging/GUI/CPackConfig.cmake || exit 1
+cmake -H$SCRIPTPATH -B$PARENTDIR/VeraCrypt_Packaging/Console -DVERACRYPT_BUILD_DIR="$PARENTDIR/VeraCrypt_Setup/Console" -DWITHGTK3=FALSE -DNOGUI=TRUE || exit 1
+cpack --config $PARENTDIR/VeraCrypt_Packaging/Console/CPackConfig.cmake || exit 1

--- a/src/Build/build_cmake_rpm_gtk3.sh
+++ b/src/Build/build_cmake_rpm_gtk3.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+
+# Errors should cause script to exit
+set -e
+
+# Absolute path to this script
+export SCRIPT=$(readlink -f "$0")
+# Absolute path this script is in
+export SCRIPTPATH=$(dirname "$SCRIPT")
+# Source directory which contains the Makefile
+export SOURCEPATH=$(readlink -f "$SCRIPTPATH/..")
+# Directory where the VeraCrypt has been checked out
+export PARENTDIR=$(readlink -f "$SCRIPTPATH/../../..")
+
+# The sources of wxWidgets 3.0.4 must be extracted to the parent directory
+export WX_ROOT=$PARENTDIR/wxWidgets-3.0.4
+echo "Using wxWidgets sources in $WX_ROOT"
+
+cd $SOURCEPATH
+
+echo "Building GUI version of VeraCrypt for RPM using wxWidgets static libraries"
+
+# This will be the temporary wxWidgets directory
+export WX_BUILD_DIR=$PARENTDIR/wxBuildGui
+
+# To build wxWidgets using GTK-3
+make WXSTATIC=1 WITHGTK3=1 wxbuild 	|| exit 1
+make WXSTATIC=1 clean 				|| exit 1
+make WXSTATIC=1 					|| exit 1
+make WXSTATIC=1 install DESTDIR="$PARENTDIR/VeraCrypt_Setup/GUI"	|| exit 1
+
+# Uncomment below and comment lines above to reuse existing wxWidgets build
+# make WXSTATIC=1 clean || exit 1
+# make WXSTATIC=1		|| exit 1
+# make WXSTATIC=1 install DESTDIR="$PARENTDIR/VeraCrypt_Setup/GUI"	|| exit 1
+
+echo "Building console version of VeraCrypt for RPM using wxWidgets static libraries"
+
+# This is to avoid " Error: Unable to initialize GTK+, is DISPLAY set properly?" 
+# when building over SSH without X11 Forwarding
+# export DISPLAY=:0.0
+
+# This will be the temporary wxWidgets directory
+export WX_BUILD_DIR=$PARENTDIR/wxBuildConsole
+
+# To build wxWidgets using GTK-3
+make WXSTATIC=1 WITHGTK3=1 NOGUI=1 wxbuild 	|| exit 1
+make WXSTATIC=1 NOGUI=1 clean 				|| exit 1
+make WXSTATIC=1 NOGUI=1 					|| exit 1
+make WXSTATIC=1 NOGUI=1 install DESTDIR="$PARENTDIR/VeraCrypt_Setup/Console"	|| exit 1
+
+# Uncomment below and comment lines above to reuse existing wxWidgets build
+# make WXSTATIC=1 NOGUI=1 clean || exit 1
+# make WXSTATIC=1 NOGUI=1		|| exit 1
+# make WXSTATIC=1 NOGUI=1 install DESTDIR="$PARENTDIR/VeraCrypt_Setup/Console"	|| exit 1
+
+echo "Creating VeraCrypt RPM packages "
+
+# -DCPACK_RPM_PACKAGE_DEBUG=TRUE for debugging cpack RPM
+# -DCPACK_RPM_PACKAGE_DEBUG=TRUE for debugging cpack RPM
+
+mkdir -p $PARENTDIR/VeraCrypt_Packaging/GUI
+mkdir -p $PARENTDIR/VeraCrypt_Packaging/Console
+
+# wxWidgets was built using GTK-3
+cmake -H$SCRIPTPATH -B$PARENTDIR/VeraCrypt_Packaging/GUI -DVERACRYPT_BUILD_DIR="$PARENTDIR/VeraCrypt_Setup/GUI" -DWITHGTK3=TRUE -DNOGUI=FALSE || exit 1		
+cpack --config $PARENTDIR/VeraCrypt_Packaging/GUI/CPackConfig.cmake || exit 1
+cmake -H$SCRIPTPATH -B$PARENTDIR/VeraCrypt_Packaging/Console -DVERACRYPT_BUILD_DIR="$PARENTDIR/VeraCrypt_Setup/Console" -DWITHGTK3=TRUE -DNOGUI=TRUE || exit 1
+cpack --config $PARENTDIR/VeraCrypt_Packaging/Console/CPackConfig.cmake|| exit 1


### PR DESCRIPTION
Now, under `Debian 10+` and `Ubuntu 18.04+`, we link against the `GTK-3` version of `wxWidgets (libwxgtk3.0-gtk3-0v5).` Under `Debian 9-` and `Ubuntu 16.04-`, we link against the `GTK-2` version of `wxWidgets (libwxgtk3.0-0v5)` which is the only one available.

Also, we now have 2 separate RPM scripts : `build_cmake_rpm_gtk2.sh` which builds `wxWidgets` and links it against `GTK-2`, then links VeraCrypt against `gtk2 package` (typically to be used under **CentOS 6**) and `build_cmake_rpm_gtk3` which builds `wxWidgets` and links it against `GTK-3`, then links VeraCrypt against `gtk3` package (typically to be used under **CentOS 7+**).