### PR TITLE
Linux/FreeBSD: Use of 'sudo -n uptime' instead of a 'dummy' password to check for active sudo session.

### DIFF
--- a/src/Core/Unix/CoreService.cpp
+++ b/src/Core/Unix/CoreService.cpp
@@ -288,6 +288,41 @@ namespace VeraCrypt
 			request.FastElevation = !ElevatedServiceAvailable;
 			request.ApplicationExecutablePath = Core->GetApplicationExecutablePath();
 
+			//	Test if the user has an active "sudo" session.
+			//	This is only done under Linux / FreeBSD by executing the command 'sudo -n uptime'.
+			//	In case a "sudo" session is active, the result of the command contains the string 'load average'.
+			//	Otherwise, the result contains "sudo: a password is required".
+			//	This may not work on all OSX versions because of a bug in sudo in its version 1.7.10,
+			//	therefore we keep the old behaviour of sending a 'dummy' password under OSX.
+			//	See : https://superuser.com/questions/902826/why-does-sudo-n-on-mac-os-x-always-return-0
+			
+#if defined(TC_LINUX ) || defined (TC_FREEBSD)
+			
+			//	Set to false to force the 'WarningEvent' to be raised in case of and elevation exception.
+			request.FastElevation = false;
+			
+			std::vector<char> buffer(128, 0);
+			std::string result;
+			
+			FILE* pipe = popen("sudo -n uptime 2>&1 | grep 'load average' | wc -l", "r");	//	We redirect stderr to stdout (2>&1) to be able to catch the result of the command
+			if (pipe)
+			{
+				while (!feof(pipe))
+				{
+					if (fgets(buffer.data(), 128, pipe) != nullptr)
+						result += buffer.data();
+				}
+				
+				fflush(pipe);
+				pclose(pipe);
+				pipe = NULL;
+				
+				if (!result.empty() && strlen(result.c_str()) != 0 && !memcmp(result.c_str(), "0", 1))
+				{
+					(*AdminPasswordCallback) (request.AdminPassword);
+				}
+			}
+#endif
 			while (!ElevatedServiceAvailable)
 			{
 				try
@@ -396,6 +431,7 @@ namespace VeraCrypt
 		vector <char> adminPassword (request.AdminPassword.size() + 1);
 		int timeout = 6000;
 
+		//	'request.FastElevation' is always false under Linux / FreeBSD
 		if (request.FastElevation)
 		{
 			string dummyPassword = "dummy\n";
@@ -457,6 +493,7 @@ namespace VeraCrypt
 				outPipe->Close();
 				errPipe.Close();
 
+				//	'request.FastElevation' is always false under Linux / FreeBSD
 				if (request.FastElevation)
 				{
 					// Prevent defunct process


### PR DESCRIPTION
We execute the command `sudo -n uptime` in order to check whether the user has an active `sudo` session. If it is the case, the result of the command contains the string `load average`.
Otherwise, the result contains `sudo: a password is required`.

This has the advantage of not triggering any security mechanisms compared to the use of a `dummy` password. However, for now, this is only to be used under **Linux / FreeBSD**, as **some OSX versions** ship with a **bugged version of sudo** which may lead to this command not working properly.

See [this](https://superuser.com/questions/902826/why-does-sudo-n-on-mac-os-x-always-return-0).

Signed-off-by: El Mostafa IDRASSI <el-mostafa.idrassi@prestalab.net>