### PR TITLE
MacOSX: Fixed devices / partitions not showing in the device selection dialog

### DIFF
--- a/src/Main/Forms/DeviceSelectionDialog.cpp
+++ b/src/Main/Forms/DeviceSelectionDialog.cpp
@@ -48,13 +48,31 @@ namespace VeraCrypt
 
 		foreach_ref (HostDevice &device, DeviceList)
 		{
-			if (device.Size == 0)
-				continue;
-
 			vector <wstring> fields (DeviceListCtrl->GetColumnCount());
-
+			
 			if (DeviceListCtrl->GetItemCount() > 0)
 				Gui->AppendToListCtrl (DeviceListCtrl, fields);
+			
+			//	i.e. /dev/rdisk0 might have size = 0 in case open() fails because, for example on OSX, 
+			//	SIP is enabled on the machine ; 
+			//	This does not mean that it does not have partitions that have been successfully opened
+			//	and have a size != 0 ;
+			//	Therefore, we do not show the device ONLY if it does not have partitions with size != 0 ;
+			if (device.Size == 0)
+			{
+				bool bHasNonEmptyPartition = false;
+				foreach_ref (HostDevice &partition, device.Partitions)
+				{
+					if (partition.Size)
+					{
+						bHasNonEmptyPartition = true;
+						break;
+					}
+				}
+				
+				if (!bHasNonEmptyPartition)
+					continue;
+			}
 
 #ifdef TC_WINDOWS
 			fields[ColumnDevice] = StringFormatter (L"{0} {1}:", _("Harddisk"), device.SystemNumber);
@@ -64,11 +82,20 @@ namespace VeraCrypt
 			fields[ColumnDevice] = wstring (device.Path) + L":";
 			fields[ColumnMountPoint] = device.MountPoint;
 #endif
-			fields[ColumnSize] = Gui->SizeToString (device.Size);
+			//	If the size of the device is 0, we do not show the size to avoid confusing the user ;
+			if (device.Size)
+				fields[ColumnSize] = Gui->SizeToString (device.Size);
+			else
+				fields[ColumnSize] = L"";
 			Gui->AppendToListCtrl (DeviceListCtrl, fields, 0, &device);
 
 			foreach_ref (HostDevice &partition, device.Partitions)
 			{
+				//	If a partition's size is 0, there is no need to show it in the list 
+				//	since this means it is not usable (i.e on OSX, because of SIP enabled in the machine) ;
+				if (!partition.Size)
+					continue;
+
 				fields[ColumnDevice] =
 #ifndef TC_WINDOWS
 					wstring (L"      ") +
@@ -113,7 +140,8 @@ namespace VeraCrypt
 	void DeviceSelectionDialog::OnListItemSelected (wxListEvent& event)
 	{
 		HostDevice *device = (HostDevice *) (event.GetItem().GetData());
-		if (device)
+		//	If a device's size is 0, we do not enable the 'OK' button since it is not usable
+		if (device && device->Size)
 		{
 			SelectedDevice = *device;
 			StdButtonsOK->Enable();


### PR DESCRIPTION
To get the size of each device / partition on the system, the method `GetDeviceSize()` in `src/Core/Unix/CoreUnix.cpp` first opens
the device / partition using `open()` function to get a File Descriptor, then retrieves its size using this File Descriptor.

Starting **OS X 10.11 ("El Capitan")**, a feature called **"System Integrity Protection (SIP)"** or less formally, **"rootless mode"** has been added.
This feature blocks access to certain critical aspects of the OS and Hardware by 3rd-Party programs.
Specifically, low-level access to the system disks, devices and partitions is forbidden ; namely functions like `open()` for instance fail with the error code : "EPERM = Operation Not Permitted".

Therefore, for system devices / partitions, `GetDeviceSize()` fails because of the failure of the `open()` function, and throws an exception, which is then caught inside the method `GetHostDevices()` in `/src/Core/Unix/FreeBSD/CoreFreeBSD.cpp` : this leads to the size of the device / partition being set to `0`.

Therefore, in the constructor of `DeviceSelectionDialog` in `src/Main/Forms/DeviceSelectionDialog.cpp`, when the size of a device is `0`, the whole device is skipped, leading to all of its partitions not being treated or shown, even though some of these partitions may have a size which is != 0.

This commit fixes the issue by :
1 - First, checking whether the device size is `0`. If it is the case, the code loops through all the devices partitions : if there is at least one partition with a size != 0, the device is not skipped. Otherwise, it is.
2 - Then, if the size of the device is `0`, the size of the device is not shown to avoid confusing the user.
Also, since the device is not usable, the `OK` button is not active when the device is selected.
3 - Finally, if a partition`s size is `0`, it is not shown since it is not usable : we cannot open it.

Signed-off-by: El Mostafa IDRASSI <el-mostafa.idrassi@prestalab.net>