### PR TITLE
Fixed buttons not being correctly aligned

### DIFF
--- a/src/Main/Forms/Forms.cpp
+++ b/src/Main/Forms/Forms.cpp
@@ -351,6 +351,7 @@ MainFrameBase::MainFrameBase( wxWindow* parent, wxWindowID id, const wxString& t
 
 	wxStaticBoxSizer* sbSizer41;
 	sbSizer41 = new wxStaticBoxSizer( new wxStaticBox( MainPanel, wxID_ANY, wxEmptyString ), wxVERTICAL );
+	sbSizer41->SetMinSize( wxSize( 139,-1 ) );
 
 	MountAllDevicesButton = new wxButton( MainPanel, wxID_ANY, _("&Auto-Mount Devices"), wxDefaultPosition, wxDefaultSize, 0 );
 	MountAllDevicesButton->SetMinSize( wxSize( -1,32 ) );
@@ -358,10 +359,11 @@ MainFrameBase::MainFrameBase( wxWindow* parent, wxWindowID id, const wxString& t
 	sbSizer41->Add( MountAllDevicesButton, 1, wxALIGN_CENTER_HORIZONTAL|wxEXPAND|wxTOP, 2 );
 
 
-	gSizer2->Add( sbSizer41, 1, wxALIGN_CENTER_HORIZONTAL|wxEXPAND, 5 );
+	gSizer2->Add( sbSizer41, 1, wxEXPAND, 5 );
 
 	wxStaticBoxSizer* sbSizer42;
 	sbSizer42 = new wxStaticBoxSizer( new wxStaticBox( MainPanel, wxID_ANY, wxEmptyString ), wxVERTICAL );
+	sbSizer42->SetMinSize( wxSize( 139,-1 ) );
 
 	DismountAllButton = new wxButton( MainPanel, wxID_ANY, _("Di&smount All"), wxDefaultPosition, wxDefaultSize, 0 );
 	DismountAllButton->SetMinSize( wxSize( -1,32 ) );
@@ -369,10 +371,11 @@ MainFrameBase::MainFrameBase( wxWindow* parent, wxWindowID id, const wxString& t
 	sbSizer42->Add( DismountAllButton, 1, wxALIGN_CENTER_HORIZONTAL|wxEXPAND|wxTOP, 2 );
 
 
-	gSizer2->Add( sbSizer42, 1, wxALIGN_CENTER_HORIZONTAL|wxEXPAND, 5 );
+	gSizer2->Add( sbSizer42, 1, wxEXPAND, 5 );
 
 	wxStaticBoxSizer* sbSizer43;
 	sbSizer43 = new wxStaticBoxSizer( new wxStaticBox( MainPanel, wxID_ANY, wxEmptyString ), wxVERTICAL );
+	sbSizer43->SetMinSize( wxSize( 139,-1 ) );
 
 	ExitButton = new wxButton( MainPanel, wxID_ANY, _("E&xit"), wxDefaultPosition, wxDefaultSize, 0 );
 	ExitButton->SetMinSize( wxSize( -1,32 ) );
@@ -380,7 +383,7 @@ MainFrameBase::MainFrameBase( wxWindow* parent, wxWindowID id, const wxString& t
 	sbSizer43->Add( ExitButton, 1, wxALIGN_CENTER_HORIZONTAL|wxEXPAND|wxTOP, 2 );
 
 
-	gSizer2->Add( sbSizer43, 1, wxALIGN_RIGHT|wxEXPAND, 5 );
+	gSizer2->Add( sbSizer43, 1, wxEXPAND, 5 );
 
 
 	LowStaticBoxSizer->Add( gSizer2, 0, wxEXPAND, 5 );

--- a/src/Main/Forms/TrueCrypt.fbp
+++ b/src/Main/Forms/TrueCrypt.fbp
@@ -2103,12 +2103,12 @@
                                                     </object>
                                                     <object class="sizeritem" expanded="1">
                                                         <property name="border">5</property>
-                                                        <property name="flag">wxALIGN_CENTER_HORIZONTAL|wxEXPAND</property>
+                                                        <property name="flag">wxEXPAND</property>
                                                         <property name="proportion">1</property>
                                                         <object class="wxStaticBoxSizer" expanded="1">
                                                             <property name="id">wxID_ANY</property>
                                                             <property name="label"></property>
-                                                            <property name="minimum_size">-1,-1</property>
+                                                            <property name="minimum_size">139,-1</property>
                                                             <property name="name">sbSizer41</property>
                                                             <property name="orient">wxVERTICAL</property>
                                                             <property name="permission">none</property>
@@ -2205,12 +2205,12 @@
                                                     </object>
                                                     <object class="sizeritem" expanded="1">
                                                         <property name="border">5</property>
-                                                        <property name="flag">wxALIGN_CENTER_HORIZONTAL|wxEXPAND</property>
+                                                        <property name="flag">wxEXPAND</property>
                                                         <property name="proportion">1</property>
                                                         <object class="wxStaticBoxSizer" expanded="1">
                                                             <property name="id">wxID_ANY</property>
                                                             <property name="label"></property>
-                                                            <property name="minimum_size">-1,-1</property>
+                                                            <property name="minimum_size">139,-1</property>
                                                             <property name="name">sbSizer42</property>
                                                             <property name="orient">wxVERTICAL</property>
                                                             <property name="permission">none</property>
@@ -2307,12 +2307,12 @@
                                                     </object>
                                                     <object class="sizeritem" expanded="1">
                                                         <property name="border">5</property>
-                                                        <property name="flag">wxALIGN_RIGHT|wxEXPAND</property>
+                                                        <property name="flag">wxEXPAND</property>
                                                         <property name="proportion">1</property>
                                                         <object class="wxStaticBoxSizer" expanded="1">
                                                             <property name="id">wxID_ANY</property>
                                                             <property name="label"></property>
-                                                            <property name="minimum_size">-1,-1</property>
+                                                            <property name="minimum_size">139,-1</property>
                                                             <property name="name">sbSizer43</property>
                                                             <property name="orient">wxVERTICAL</property>
                                                             <property name="permission">none</property>


### PR DESCRIPTION
For example, the "Close" button is far to the right on OSX, and the other buttons are not correctly aligned. This fixes the issue by removing unnecessary flags and setting the minimum size of the sizers.