### PR TITLE
Fixed drag and drop not showing correct path, specifically when linking against GTK-3

### DIFF
--- a/src/Main/Forms/KeyfilesPanel.cpp
+++ b/src/Main/Forms/KeyfilesPanel.cpp
@@ -59,10 +59,8 @@ namespace VeraCrypt
 
 		SetDropTarget (new FileDropTarget (this));
 		KeyfilesListCtrl->SetDropTarget (new FileDropTarget (this));
-#ifdef TC_MACOSX
 		foreach (wxWindow *c, GetChildren())
 			c->SetDropTarget (new FileDropTarget (this));
-#endif
 
 		UpdateButtons();
 	}

--- a/src/Main/Forms/MainFrame.cpp
+++ b/src/Main/Forms/MainFrame.cpp
@@ -393,10 +393,8 @@ namespace VeraCrypt
 		};
 
 		SetDropTarget (new FileDropTarget (this));
-#ifdef TC_MACOSX
 		foreach (wxWindow *c, MainPanel->GetChildren())
 			c->SetDropTarget (new FileDropTarget (this));
-#endif
 
 		// Volume history
 		VolumeHistory::ConnectComboBox (VolumePathComboBox);

--- a/src/Main/Forms/VolumePasswordPanel.cpp
+++ b/src/Main/Forms/VolumePasswordPanel.cpp
@@ -159,10 +159,8 @@ namespace VeraCrypt
 		if (enableKeyfiles)
 		{
 			SetDropTarget (new FileDropTarget (this));
-#ifdef TC_MACOSX
 			foreach (wxWindow *c, GetChildren())
 				c->SetDropTarget (new FileDropTarget (this));
-#endif
 		}
 
 		Layout();


### PR DESCRIPTION
For example, when veracrypt is linked against GTK-3 version of wxWidgets, when dragging a container into the 'Volume' combo box field, the field does not contain the actual correct path of the container but instead, the path starts with `file://` and may contain **junk characters**. This is due to the fact that the drop target of the combo box is not set to be a `FileDropTarget` instance.

**Note that when veracrypt is linked against GTK-2 version of wxWidgets, this does not seem to be the case as the path is shown correctly.**

This commit fixes this by setting the drop targets of all of the children of the top level window to be instances of `FileDropTarget` as it is done under `OSX`.