### PR TITLE
Debug build: fix ParameterIncorrect error on hash benchmark start (#542)

### DIFF
--- a/src/Volume/Hash.cpp
+++ b/src/Volume/Hash.cpp
@@ -40,7 +40,7 @@ namespace VeraCrypt
 
 	void Hash::ValidateDigestParameters (const BufferPtr &buffer) const
 	{
-		if (buffer.Size() != GetDigestSize ())
+		if (buffer.Size() < GetDigestSize ())
 			throw ParameterIncorrect (SRC_POS);
 	}
 


### PR DESCRIPTION
As discussed, fix the buffer size check to pass anything that's larger than what's necessary.

Tested by building in both debug and release mode on Linux and running the hash algorithm benchmark on two randomly selected buffer sizes. The error message doesn't appear after the fix in debug mode and nothing changes in the release mode, as expected.

Fixes #542.