### PR TITLE
Linux/MacOS: text mode did not recognize Unicode in passwords (#540)

### DIFF
--- a/src/Main/TextUserInterface.cpp
+++ b/src/Main/TextUserInterface.cpp
@@ -41,7 +41,9 @@ namespace VeraCrypt
 #endif
 		{
 			FInputStream.reset (new wxFFileInputStream (stdin));
-			TextInputStream.reset (new wxTextInputStream (*FInputStream));
+			// Set fallback encoding of the stream converter to UTF-8
+			// to make sure we interpret multibyte symbols properly
+			TextInputStream.reset (new wxTextInputStream (*FInputStream, wxT(" \t"), wxConvAuto(wxFONTENCODING_UTF8)));
 		}
 	}
 


### PR DESCRIPTION
Here's the fix that essentially tells the wxConvAuto object (used by out text input stream) to use UTF-8 as the fallback encoding if it's not able to recognize it automatically. VeraCrypt only supports UTF-8 as the input encoding, so this is a sensible choice.

Fixes #540 