### PR TITLE
fixed typo "This [is] not a bug in VeraCrypt"

### DIFF
--- a/src/Main/Forms/VolumeCreationWizard.cpp
+++ b/src/Main/Forms/VolumeCreationWizard.cpp
@@ -175,7 +175,7 @@ namespace VeraCrypt
 				else if (SelectedVolumeType == VolumeType::Hidden)
 				{
 					pageTitle = LangString["SIZE_HIDVOL_TITLE"];
-					pageText = LangString["SIZE_HELP_HIDDEN_VOL"] + L"\n\n" + _("Please note that if your operating system does not allocate files from the beginning of the free space, the maximum possible hidden volume size may be much smaller than the size of the free space on the outer volume. This not a bug in VeraCrypt but a limitation of the operating system.");
+					pageText = LangString["SIZE_HELP_HIDDEN_VOL"] + L"\n\n" + _("Please note that if your operating system does not allocate files from the beginning of the free space, the maximum possible hidden volume size may be much smaller than the size of the free space on the outer volume. This is not a bug in VeraCrypt but a limitation of the operating system.");
 					freeSpaceText = StringFormatter (_("Maximum possible hidden volume size for this volume is {0}."), Gui->SizeToString (MaxHiddenVolumeSize));
 				}
 				else


### PR DESCRIPTION
Original text: `This not a bug in VeraCrypt but a limitation of the operating system.`
Corrected: `This is not a bug in VeraCrypt but a limitation of the operating system.`

I am not sure if there should be a comma (", but a limitation...").
