### PR TITLE
UNIX: make sector size mismatch error more verbose (#552)

### DIFF
--- a/src/Core/Unix/CoreUnix.cpp
+++ b/src/Core/Unix/CoreUnix.cpp
@@ -473,8 +473,10 @@ namespace VeraCrypt
 
 		if (options.Path->IsDevice())
 		{
-			if (volume->GetFile()->GetDeviceSectorSize() != volume->GetSectorSize())
-				throw ParameterIncorrect (SRC_POS);
+			const uint32 devSectorSize = volume->GetFile()->GetDeviceSectorSize();
+			const size_t volSectorSize = volume->GetSectorSize();
+			if (devSectorSize != volSectorSize)
+				throw DeviceSectorSizeMismatch (SRC_POS, StringConverter::ToWide(devSectorSize) + L" != " + StringConverter::ToWide(volSectorSize));
 		}
 
 		// Find a free mount point for FUSE service

--- a/src/Main/Forms/WaitDialog.cpp
+++ b/src/Main/Forms/WaitDialog.cpp
@@ -45,6 +45,7 @@ namespace VeraCrypt
 		VC_CONVERT_EXCEPTION (RootDeviceUnavailable);
 		VC_CONVERT_EXCEPTION (DriveLetterUnavailable);
 		VC_CONVERT_EXCEPTION (DriverError);
+		VC_CONVERT_EXCEPTION (DeviceSectorSizeMismatch);
 		VC_CONVERT_EXCEPTION (EncryptedSystemRequired);
 		VC_CONVERT_EXCEPTION (HigherFuseVersionRequired);
 		VC_CONVERT_EXCEPTION (KernelCryptoServiceTestFailed);

--- a/src/Main/UserInterface.cpp
+++ b/src/Main/UserInterface.cpp
@@ -444,6 +444,7 @@ namespace VeraCrypt
 	{
 #define EX2MSG(exception, message) do { if (ex == typeid (exception)) return (message); } while (false)
 		EX2MSG (DriveLetterUnavailable,				LangString["DRIVE_LETTER_UNAVAILABLE"]);
+		EX2MSG (DeviceSectorSizeMismatch,			_("Storage device and VC volume sector size mismatch"));
 		EX2MSG (EncryptedSystemRequired,			_("This operation must be performed only when the system hosted on the volume is running."));
 		EX2MSG (ExternalException,					LangString["EXCEPTION_OCCURRED"]);
 		EX2MSG (InsufficientData,					_("Not enough data available."));
@@ -1588,6 +1589,7 @@ namespace VeraCrypt
 		VC_CONVERT_EXCEPTION (RootDeviceUnavailable);
 		VC_CONVERT_EXCEPTION (DriveLetterUnavailable);
 		VC_CONVERT_EXCEPTION (DriverError);
+		VC_CONVERT_EXCEPTION (DeviceSectorSizeMismatch);
 		VC_CONVERT_EXCEPTION (EncryptedSystemRequired);
 		VC_CONVERT_EXCEPTION (HigherFuseVersionRequired);
 		VC_CONVERT_EXCEPTION (KernelCryptoServiceTestFailed);

--- a/src/Platform/Exception.h
+++ b/src/Platform/Exception.h
@@ -82,6 +82,7 @@ namespace VeraCrypt
 	TC_EXCEPTION_NODECL (ExecutedProcessFailed); \
 	TC_EXCEPTION (AlreadyInitialized); \
 	TC_EXCEPTION (AssertionFailed); \
+	TC_EXCEPTION (DeviceSectorSizeMismatch); \
 	TC_EXCEPTION (ExternalException); \
 	TC_EXCEPTION (InsufficientData); \
 	TC_EXCEPTION (NotApplicable); \


### PR DESCRIPTION
Here's the PR to increase the verbosity of the error message we throw upon device and VC volume size mismatch, to hopefully make it more self-explaining and actionable.

Tested manually on Linux.

Fixes #552 

![dev-vol-sector-size-mismatch](https://user-images.githubusercontent.com/45139988/69914500-897a1600-1445-11ea-8e13-f21f4ff5d539.png)
