### PR TITLE
Make sure password gets deleted in case of exception in CoreUnix::Mou…

### DIFF
--- a/src/Core/Unix/CoreUnix.cpp
+++ b/src/Core/Unix/CoreUnix.cpp
@@ -465,6 +465,7 @@ namespace VeraCrypt
 					continue;
 				}
 
+				options.Password.reset();
 				throw;
 			}
 


### PR DESCRIPTION
…ntVolume

In the function CoreUnix::MountVolume there's a call to OpenVolume in a try/catch block. When OpenVolume is executed successfully then the password is cleared in memory for safety reasons ("options.Password.reset();"). However if there's an exception a different code path runs that in one instance will retry with readonly mode and in another instance calls itself throw. The latter code path does not clear the password, leaving it potentially in memory and vulnerable in case of memory disclosure problems.

Attached patch adds a call to options.Password.reset() in that codepath.