### PR TITLE
Add burn calls for temporary ss variable

### DIFF
--- a/src/Crypto/Aeskey.c
+++ b/src/Crypto/Aeskey.c
@@ -27,6 +27,7 @@
 
 #include "Aesopt.h"
 #include "Aestab.h"
+#include "Common/Tcdefs.h"
 
 #ifdef USE_VIA_ACE_IF_PRESENT
 #  include "aes_via_ace.h"
@@ -95,6 +96,8 @@ AES_RETURN aes_encrypt_key128(const unsigned char *key, aes_encrypt_ctx cx[1])
         cx->inf.b[1] = 0xff;
 #endif
 
+    burn(ss, sizeof(ss));
+
 #if defined( AES_ERR_CHK )
     return EXIT_SUCCESS;
 #endif
@@ -146,6 +149,8 @@ AES_RETURN aes_encrypt_key192(const unsigned char *key, aes_encrypt_ctx cx[1])
     if(VIA_ACE_AVAILABLE)
         cx->inf.b[1] = 0xff;
 #endif
+
+    burn(ss, sizeof(ss));
 
 #if defined( AES_ERR_CHK )
     return EXIT_SUCCESS;
@@ -201,6 +206,8 @@ AES_RETURN aes_encrypt_key256(const unsigned char *key, aes_encrypt_ctx cx[1])
     if(VIA_ACE_AVAILABLE)
         cx->inf.b[1] = 0xff;
 #endif
+
+    burn(ss, sizeof(ss));
 
 #if defined( AES_ERR_CHK )
     return EXIT_SUCCESS;
@@ -352,6 +359,8 @@ AES_RETURN aes_decrypt_key128(const unsigned char *key, aes_decrypt_ctx cx[1])
         cx->inf.b[1] = 0xff;
 #endif
 
+    burn(ss, sizeof(ss));
+
 #if defined( AES_ERR_CHK )
     return EXIT_SUCCESS;
 #endif
@@ -438,6 +447,8 @@ AES_RETURN aes_decrypt_key192(const unsigned char *key, aes_decrypt_ctx cx[1])
     if(VIA_ACE_AVAILABLE)
         cx->inf.b[1] = 0xff;
 #endif
+
+    burn(ss, sizeof(ss));
 
 #if defined( AES_ERR_CHK )
     return EXIT_SUCCESS;
@@ -537,6 +548,8 @@ AES_RETURN aes_decrypt_key256(const unsigned char *key, aes_decrypt_ctx cx[1])
     if(VIA_ACE_AVAILABLE)
         cx->inf.b[1] = 0xff;
 #endif
+
+    burn(ss, sizeof(ss));
 
 #if defined( AES_ERR_CHK )
     return EXIT_SUCCESS;


### PR DESCRIPTION
The functions aes_{en,de}crypt_key{128,192,256} in Aeskey.c use a temporary variable ss that contains key material. To make sure the key bits don't stay in memory we should add burn calls.

This code only gets used with NOASM builds on modern systems, using patch from https://github.com/veracrypt/VeraCrypt/pull/568 to make it build.