### PR TITLE
Fix the compilation against WxWidgets when NOGUI=1

### DIFF
--- a/src/Main/Main.make
+++ b/src/Main/Main.make
@@ -81,7 +81,15 @@ CXXFLAGS += -I$(BASE_DIR)/Main
 
 #------ wxWidgets configuration ------
 
+ifdef TC_NO_GUI
+ifdef VC_WX_STATIC
+WX_CONFIG_LIBS := base
+else
 WX_CONFIG_LIBS := adv,core,base
+endif
+else
+WX_CONFIG_LIBS := adv,core,base
+endif
 
 ifeq "$(TC_BUILD_CONFIG)" "Release"
 

--- a/src/Main/Main.make
+++ b/src/Main/Main.make
@@ -82,11 +82,7 @@ CXXFLAGS += -I$(BASE_DIR)/Main
 #------ wxWidgets configuration ------
 
 ifdef TC_NO_GUI
-ifdef VC_WX_STATIC
 WX_CONFIG_LIBS := base
-else
-WX_CONFIG_LIBS := adv,core,base
-endif
 else
 WX_CONFIG_LIBS := adv,core,base
 endif

--- a/src/Main/TextUserInterface.h
+++ b/src/Main/TextUserInterface.h
@@ -47,7 +47,9 @@ namespace VeraCrypt
 		virtual void ExportSecurityTokenKeyfile () const;
 		virtual shared_ptr <GetStringFunctor> GetAdminPasswordRequestHandler ();
 		virtual void ImportSecurityTokenKeyfiles () const;
+#ifndef TC_NO_GUI
 		virtual bool Initialize (int &argc, wxChar **argv) { return wxAppBase::Initialize(argc, argv); }
+#endif
 		virtual void InitSecurityTokenLibrary () const;
 		virtual void ListSecurityTokenKeyfiles () const;
 		virtual VolumeInfoList MountAllDeviceHostedVolumes (MountOptions &options) const;

--- a/src/Makefile
+++ b/src/Makefile
@@ -69,7 +69,7 @@ endif
 
 ifeq "$(origin NOGUI)" "command line"
 	export TC_NO_GUI := 1
-	C_CXX_FLAGS += -DTC_NO_GUI
+	C_CXX_FLAGS += -DTC_NO_GUI -DwxUSE_GUI=0
 	WX_CONFIGURE_FLAGS += --disable-gui
 endif
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -70,6 +70,7 @@ endif
 ifeq "$(origin NOGUI)" "command line"
 	export TC_NO_GUI := 1
 	C_CXX_FLAGS += -DTC_NO_GUI
+	WX_CONFIGURE_FLAGS += --disable-gui
 endif
 
 ifdef PKCS11_INC


### PR DESCRIPTION
VC fails to build with system wxGTK compiled with '--disable-gui':

```
In file included from TextUserInterface.cpp:27:
TextUserInterface.h: In member function ‘virtual bool VeraCrypt::TextUserInterface::Initialize(int&, wxChar**)’:
TextUserInterface.h:50:63: error: ‘wxAppBase’ has not been declared
   50 |   virtual bool Initialize (int &argc, wxChar **argv) { return wxAppBase::Initialize(argc, argv); }
```

wxAppBase is only defined when wxGTK is built with `--enable-gui`, which is unlikely with headless systems. Therefore, revert the commits that introduced the breakage, simplify the WX_CONFIG_LIBS logic, and pass `-DwxUSE_GUI=0` when `NOGUI=1`