### PR TITLE
Switch from auto_ptr to unique_ptr

### DIFF
--- a/src/Common/BaseCom.cpp
+++ b/src/Common/BaseCom.cpp
@@ -130,7 +130,7 @@ DWORD BaseCom::ReadWriteFile (BOOL write, BOOL device, BSTR filePath, BSTR *buff
 {
 	try
 	{
-		auto_ptr <File> file (device ? new Device (filePath, !write) : new File (filePath, !write));
+		unique_ptr <File> file (device ? new Device (filePath, !write) : new File (filePath, !write));
 		file->CheckOpened (SRC_POS);
 		file->SeekAt (offset);
 
@@ -194,7 +194,7 @@ DWORD BaseCom::DeviceIoControl (BOOL readOnly, BOOL device, BSTR filePath, DWORD
 {
 	try
 	{
-		auto_ptr <File> file (device ? new Device (filePath, readOnly == TRUE) : new File (filePath, readOnly == TRUE));
+		unique_ptr <File> file (device ? new Device (filePath, readOnly == TRUE) : new File (filePath, readOnly == TRUE));
 		file->CheckOpened (SRC_POS);
 		if (!file->IoCtl (dwIoControlCode, (BYTE *) input, !(BYTE *) input ? 0 : ((DWORD *) ((BYTE *) input))[-1],
 			(BYTE *) *output, !(BYTE *) *output ? 0 : ((DWORD *) ((BYTE *) *output))[-1]))

--- a/src/Common/Dlgcode.c
+++ b/src/Common/Dlgcode.c
@@ -12104,7 +12104,7 @@ BOOL InitSecurityTokenLibrary (HWND hwndDlg)
 
 	try
 	{
-		SecurityToken::InitLibrary (SecurityTokenLibraryPath, auto_ptr <GetPinFunctor> (new PinRequestHandler(MainDlg)), auto_ptr <SendExceptionFunctor> (new WarningHandler(MainDlg)));
+		SecurityToken::InitLibrary (SecurityTokenLibraryPath, unique_ptr <GetPinFunctor> (new PinRequestHandler(MainDlg)), unique_ptr <SendExceptionFunctor> (new WarningHandler(MainDlg)));
 	}
 	catch (Exception &e)
 	{

--- a/src/Common/SecurityToken.cpp
+++ b/src/Common/SecurityToken.cpp
@@ -513,9 +513,9 @@ namespace VeraCrypt
 	}
 
 #ifdef TC_WINDOWS
-	void SecurityToken::InitLibrary (const wstring &pkcs11LibraryPath, auto_ptr <GetPinFunctor> pinCallback, auto_ptr <SendExceptionFunctor> warningCallback)
+	void SecurityToken::InitLibrary (const wstring &pkcs11LibraryPath, unique_ptr <GetPinFunctor> pinCallback, unique_ptr <SendExceptionFunctor> warningCallback)
 #else
-	void SecurityToken::InitLibrary (const string &pkcs11LibraryPath, auto_ptr <GetPinFunctor> pinCallback, auto_ptr <SendExceptionFunctor> warningCallback)
+	void SecurityToken::InitLibrary (const string &pkcs11LibraryPath, unique_ptr <GetPinFunctor> pinCallback, unique_ptr <SendExceptionFunctor> warningCallback)
 #endif
 	{
 		if (Initialized)
@@ -548,8 +548,8 @@ namespace VeraCrypt
 		if (status != CKR_OK)
 			throw Pkcs11Exception (status);
 
-		PinCallback = pinCallback;
-		WarningCallback = warningCallback;
+		PinCallback = std::move(pinCallback);
+		WarningCallback = std::move(warningCallback);
 
 		Initialized = true;
 	}
@@ -728,8 +728,8 @@ namespace VeraCrypt
 	}
 #endif // TC_HEADER_Common_Exception
 
-	auto_ptr <GetPinFunctor> SecurityToken::PinCallback;
-	auto_ptr <SendExceptionFunctor> SecurityToken::WarningCallback;
+	unique_ptr <GetPinFunctor> SecurityToken::PinCallback;
+	unique_ptr <SendExceptionFunctor> SecurityToken::WarningCallback;
 
 	bool SecurityToken::Initialized;
 	CK_FUNCTION_LIST_PTR SecurityToken::Pkcs11Functions;

--- a/src/Common/SecurityToken.h
+++ b/src/Common/SecurityToken.h
@@ -191,9 +191,9 @@ namespace VeraCrypt
 		static list <SecurityTokenInfo> GetAvailableTokens ();
 		static SecurityTokenInfo GetTokenInfo (CK_SLOT_ID slotId);
 #ifdef TC_WINDOWS
-		static void InitLibrary (const wstring &pkcs11LibraryPath, auto_ptr <GetPinFunctor> pinCallback, auto_ptr <SendExceptionFunctor> warningCallback);
+		static void InitLibrary (const wstring &pkcs11LibraryPath, unique_ptr <GetPinFunctor> pinCallback, unique_ptr <SendExceptionFunctor> warningCallback);
 #else
-		static void InitLibrary (const string &pkcs11LibraryPath, auto_ptr <GetPinFunctor> pinCallback, auto_ptr <SendExceptionFunctor> warningCallback);
+		static void InitLibrary (const string &pkcs11LibraryPath, unique_ptr <GetPinFunctor> pinCallback, unique_ptr <SendExceptionFunctor> warningCallback);
 #endif
 		static bool IsInitialized () { return Initialized; }
 		static bool IsKeyfilePathValid (const wstring &securityTokenKeyfilePath);
@@ -211,7 +211,7 @@ namespace VeraCrypt
 		static void CheckLibraryStatus ();
 
 		static bool Initialized;
-		static auto_ptr <GetPinFunctor> PinCallback;
+		static unique_ptr <GetPinFunctor> PinCallback;
 		static CK_FUNCTION_LIST_PTR Pkcs11Functions;
 #ifdef TC_WINDOWS
 		static HMODULE Pkcs11LibraryHandle;
@@ -219,7 +219,7 @@ namespace VeraCrypt
 		static void *Pkcs11LibraryHandle;
 #endif
 		static map <CK_SLOT_ID, Pkcs11Session> Sessions;
-		static auto_ptr <SendExceptionFunctor> WarningCallback;
+		static unique_ptr <SendExceptionFunctor> WarningCallback;
 	};
 }
 

--- a/src/Core/Core.h
+++ b/src/Core/Core.h
@@ -17,8 +17,8 @@
 
 namespace VeraCrypt
 {
-	extern auto_ptr <CoreBase> Core;
-	extern auto_ptr <CoreBase> CoreDirect;
+	extern unique_ptr <CoreBase> Core;
+	extern unique_ptr <CoreBase> CoreDirect;
 
 	class WaitThreadRoutine
 	{

--- a/src/Core/Unix/CoreService.h
+++ b/src/Core/Unix/CoreService.h
@@ -39,17 +39,17 @@ namespace VeraCrypt
 		static void Stop ();
 
 	protected:
-		template <class T> static auto_ptr <T> GetResponse ();
-		template <class T> static auto_ptr <T> SendRequest (CoreServiceRequest &request);
+		template <class T> static unique_ptr <T> GetResponse ();
+		template <class T> static unique_ptr <T> SendRequest (CoreServiceRequest &request);
 		static void StartElevated (const CoreServiceRequest &request);
 
 		static shared_ptr <GetStringFunctor> AdminPasswordCallback;
 
-		static auto_ptr <Pipe> AdminInputPipe;
-		static auto_ptr <Pipe> AdminOutputPipe;
+		static unique_ptr <Pipe> AdminInputPipe;
+		static unique_ptr <Pipe> AdminOutputPipe;
 
-		static auto_ptr <Pipe> InputPipe;
-		static auto_ptr <Pipe> OutputPipe;
+		static unique_ptr <Pipe> InputPipe;
+		static unique_ptr <Pipe> OutputPipe;
 		static shared_ptr <Stream> ServiceInputStream;
 		static shared_ptr <Stream> ServiceOutputStream;
 

--- a/src/Core/Unix/FreeBSD/CoreFreeBSD.cpp
+++ b/src/Core/Unix/FreeBSD/CoreFreeBSD.cpp
@@ -200,7 +200,7 @@ namespace VeraCrypt
 	}
 
 #ifdef TC_FREEBSD
-	auto_ptr <CoreBase> Core (new CoreServiceProxy <CoreFreeBSD>);
-	auto_ptr <CoreBase> CoreDirect (new CoreFreeBSD);
+	unique_ptr <CoreBase> Core (new CoreServiceProxy <CoreFreeBSD>);
+	unique_ptr <CoreBase> CoreDirect (new CoreFreeBSD);
 #endif
 }

--- a/src/Core/Unix/Linux/CoreLinux.cpp
+++ b/src/Core/Unix/Linux/CoreLinux.cpp
@@ -489,6 +489,6 @@ namespace VeraCrypt
 		}
 	}
 
-	auto_ptr <CoreBase> Core (new CoreServiceProxy <CoreLinux>);
-	auto_ptr <CoreBase> CoreDirect (new CoreLinux);
+	unique_ptr <CoreBase> Core (new CoreServiceProxy <CoreLinux>);
+	unique_ptr <CoreBase> CoreDirect (new CoreLinux);
 }

--- a/src/Core/Unix/MacOSX/CoreMacOSX.cpp
+++ b/src/Core/Unix/MacOSX/CoreMacOSX.cpp
@@ -229,6 +229,6 @@ namespace VeraCrypt
 		}
 	}
 
-	auto_ptr <CoreBase> Core (new CoreServiceProxy <CoreMacOSX>);
-	auto_ptr <CoreBase> CoreDirect (new CoreMacOSX);
+	unique_ptr <CoreBase> Core (new CoreServiceProxy <CoreMacOSX>);
+	unique_ptr <CoreBase> CoreDirect (new CoreMacOSX);
 }

--- a/src/Core/Unix/Solaris/CoreSolaris.cpp
+++ b/src/Core/Unix/Solaris/CoreSolaris.cpp
@@ -173,6 +173,6 @@ namespace VeraCrypt
 		}
 	}
 
-	auto_ptr <CoreBase> Core (new CoreServiceProxy <CoreSolaris>);
-	auto_ptr <CoreBase> CoreDirect (new CoreSolaris);
+	unique_ptr <CoreBase> Core (new CoreServiceProxy <CoreSolaris>);
+	unique_ptr <CoreBase> CoreDirect (new CoreSolaris);
 }

--- a/src/Driver/Fuse/FuseService.cpp
+++ b/src/Driver/Fuse/FuseService.cpp
@@ -592,5 +592,5 @@ namespace VeraCrypt
 	VolumeSlotNumber FuseService::SlotNumber;
 	uid_t FuseService::UserId;
 	gid_t FuseService::GroupId;
-	auto_ptr <Pipe> FuseService::SignalHandlerPipe;
+	unique_ptr <Pipe> FuseService::SignalHandlerPipe;
 }

--- a/src/Driver/Fuse/FuseService.h
+++ b/src/Driver/Fuse/FuseService.h
@@ -70,7 +70,7 @@ namespace VeraCrypt
 		static VolumeSlotNumber SlotNumber;
 		static uid_t UserId;
 		static gid_t GroupId;
-		static auto_ptr <Pipe> SignalHandlerPipe;
+		static unique_ptr <Pipe> SignalHandlerPipe;
 	};
 }
 

--- a/src/Main/CommandLineInterface.cpp
+++ b/src/Main/CommandLineInterface.cpp
@@ -828,5 +828,5 @@ namespace VeraCrypt
 			return shared_ptr<SecureBuffer>(new SecureBuffer ());
 	}
 
-	auto_ptr <CommandLineInterface> CmdLine;
+	unique_ptr <CommandLineInterface> CmdLine;
 }

--- a/src/Main/CommandLineInterface.h
+++ b/src/Main/CommandLineInterface.h
@@ -105,7 +105,7 @@ namespace VeraCrypt
 	shared_ptr<VolumePassword> ToUTF8Password (const wchar_t* str, size_t charCount, size_t maxUtf8Len);
 	shared_ptr<SecureBuffer> ToUTF8Buffer (const wchar_t* str, size_t charCount, size_t maxUtf8Len);
 
-	extern auto_ptr <CommandLineInterface> CmdLine;
+	extern unique_ptr <CommandLineInterface> CmdLine;
 }
 
 #endif // TC_HEADER_Main_CommandInterface

--- a/src/Main/Forms/MainFrame.cpp
+++ b/src/Main/Forms/MainFrame.cpp
@@ -509,7 +509,7 @@ namespace VeraCrypt
 
 			wxMenu *CreatePopupMenu ()
 			{
-				auto_ptr <wxMenu> popup (new wxMenu);
+				unique_ptr <wxMenu> popup (new wxMenu);
 
 				Gui->AppendToMenu (*popup, LangString[Gui->IsInBackgroundMode() ? "SHOW_TC" : "HIDE_TC"], this, wxCommandEventHandler (TaskBarIcon::OnShowHideMenuItemSelected));
 

--- a/src/Main/Forms/MainFrame.h
+++ b/src/Main/Forms/MainFrame.h
@@ -214,8 +214,8 @@ namespace VeraCrypt
 		map <int, FavoriteVolume> FavoriteVolumesMenuMap;
 		bool ListItemRightClickEventPending;
 		VolumeInfoList MountedVolumes;
-		auto_ptr <wxTaskBarIcon> mTaskBarIcon;
-		auto_ptr <wxTimer> mTimer;
+		unique_ptr <wxTaskBarIcon> mTaskBarIcon;
+		unique_ptr <wxTimer> mTimer;
 		long SelectedItemIndex;
 		VolumeSlotNumber SelectedSlotNumber;
 		int ShowRequestFifo;

--- a/src/Main/Forms/PreferencesDialog.h
+++ b/src/Main/Forms/PreferencesDialog.h
@@ -54,7 +54,7 @@ namespace VeraCrypt
 
 		KeyfilesPanel *DefaultKeyfilesPanel;
 		int LastVirtualKeyPressed;
-		auto_ptr <wxTimer> mTimer;
+		unique_ptr <wxTimer> mTimer;
 		UserPreferences Preferences;
 		bool RestoreValidatorBell;
 		HotkeyList UnregisteredHotkeys;

--- a/src/Main/Forms/ProgressWizardPage.h
+++ b/src/Main/Forms/ProgressWizardPage.h
@@ -36,7 +36,7 @@ namespace VeraCrypt
 		void OnAbortButtonClick (wxCommandEvent& event);
 		void OnTimer ();
 
-		auto_ptr <wxTimer> mTimer;
+		unique_ptr <wxTimer> mTimer;
 		int PreviousGaugeValue;
 		uint64 ProgressBarRange;
 		int RealProgressBarRange;

--- a/src/Main/Forms/VolumeCreationProgressWizardPage.h
+++ b/src/Main/Forms/VolumeCreationProgressWizardPage.h
@@ -48,7 +48,7 @@ namespace VeraCrypt
 
 		int PreviousGaugeValue;
 		uint64 ProgressBarRange;
-		auto_ptr <wxTimer> RandomPoolTimer;
+		unique_ptr <wxTimer> RandomPoolTimer;
 		int RealProgressBarRange;
 		wxLongLong StartTime;
 		bool VolumeCreatorRunning;

--- a/src/Main/Forms/VolumeCreationWizard.h
+++ b/src/Main/Forms/VolumeCreationWizard.h
@@ -67,8 +67,8 @@ namespace VeraCrypt
 		bool CrossPlatformSupport;
 		static bool DeviceWarningConfirmed;
 		bool DisplayKeyInfo;
-		auto_ptr <wxTimer> ProgressTimer;
-		auto_ptr <wxTimer> RandomPoolUpdateTimer;
+		unique_ptr <wxTimer> ProgressTimer;
+		unique_ptr <wxTimer> RandomPoolUpdateTimer;
 		shared_ptr <KeyfileList> Keyfiles;
 		bool LargeFilesSupport;
 		uint64 MaxHiddenVolumeSize;

--- a/src/Main/GraphicUserInterface.cpp
+++ b/src/Main/GraphicUserInterface.cpp
@@ -344,7 +344,7 @@ namespace VeraCrypt
 
 	void GraphicUserInterface::BeginInteractiveBusyState (wxWindow *window)
 	{
-		static auto_ptr <wxCursor> arrowWaitCursor;
+		static unique_ptr <wxCursor> arrowWaitCursor;
 
 		if (arrowWaitCursor.get() == nullptr)
 			arrowWaitCursor.reset (new wxCursor (wxCURSOR_ARROWWAIT));
@@ -409,7 +409,7 @@ namespace VeraCrypt
 
 	void GraphicUserInterface::EndInteractiveBusyState (wxWindow *window) const
 	{
-		static auto_ptr <wxCursor> arrowCursor;
+		static unique_ptr <wxCursor> arrowCursor;
 
 		if (arrowCursor.get() == nullptr)
 			arrowCursor.reset (new wxCursor (wxCURSOR_ARROW));
@@ -632,7 +632,7 @@ namespace VeraCrypt
 
 		try
 		{
-			SecurityToken::InitLibrary (Preferences.SecurityTokenModule, auto_ptr <GetPinFunctor> (new PinRequestHandler), auto_ptr <SendExceptionFunctor> (new WarningHandler));
+			SecurityToken::InitLibrary (Preferences.SecurityTokenModule, unique_ptr <GetPinFunctor> (new PinRequestHandler), unique_ptr <SendExceptionFunctor> (new WarningHandler));
 		}
 		catch (Exception &e)
 		{
@@ -965,8 +965,8 @@ namespace VeraCrypt
 					wxConnectionBase *OnMakeConnection () { return new Connection; }
 				};
 
-				auto_ptr <wxDDEClient> client (new Client);
-				auto_ptr <wxConnectionBase> connection (client->MakeConnection (L"localhost", serverName, L"raise"));
+				unique_ptr <wxDDEClient> client (new Client);
+				unique_ptr <wxConnectionBase> connection (client->MakeConnection (L"localhost", serverName, L"raise"));
 
 				if (connection.get() && connection->Execute (nullptr))
 				{

--- a/src/Main/GraphicUserInterface.h
+++ b/src/Main/GraphicUserInterface.h
@@ -129,10 +129,10 @@ namespace VeraCrypt
 		wxFrame *ActiveFrame;
 		bool BackgroundMode;
 #ifdef TC_WINDOWS
-		auto_ptr <wxDDEServer> DDEServer;
+		unique_ptr <wxDDEServer> DDEServer;
 #endif
 		wxFrame *mMainFrame;
-		auto_ptr <wxSingleInstanceChecker> SingleInstanceChecker;
+		unique_ptr <wxSingleInstanceChecker> SingleInstanceChecker;
 
 		mutable WaitDialog* mWaitDialog;
 public:	

--- a/src/Main/TextUserInterface.cpp
+++ b/src/Main/TextUserInterface.cpp
@@ -1156,7 +1156,7 @@ namespace VeraCrypt
 
 		try
 		{
-			SecurityToken::InitLibrary (Preferences.SecurityTokenModule, auto_ptr <GetPinFunctor> (new PinRequestHandler (this)), auto_ptr <SendExceptionFunctor> (new WarningHandler (this)));
+			SecurityToken::InitLibrary (Preferences.SecurityTokenModule, unique_ptr <GetPinFunctor> (new PinRequestHandler (this)), unique_ptr <SendExceptionFunctor> (new WarningHandler (this)));
 		}
 		catch (Exception &e)
 		{

--- a/src/Main/TextUserInterface.h
+++ b/src/Main/TextUserInterface.h
@@ -69,8 +69,8 @@ namespace VeraCrypt
 		virtual void ReadInputStreamLine (wxString &line) const;
 		virtual wxString ReadInputStreamLine () const;
 
-		auto_ptr <wxFFileInputStream> FInputStream;
-		auto_ptr <wxTextInputStream> TextInputStream;
+		unique_ptr <wxFFileInputStream> FInputStream;
+		unique_ptr <wxTextInputStream> TextInputStream;
 
 	private:
 		TextUserInterface (const TextUserInterface &);

--- a/src/Main/Xml.h
+++ b/src/Main/Xml.h
@@ -66,8 +66,8 @@ namespace VeraCrypt
 
 	protected:
 		int CurrentIndentLevel;
-		auto_ptr <wxMemoryOutputStream> MemOutStream;
-		auto_ptr <wxTextOutputStream> TextOutStream;
+		unique_ptr <wxMemoryOutputStream> MemOutStream;
+		unique_ptr <wxTextOutputStream> TextOutStream;
 		File OutFile;
 
 	private:

--- a/src/Platform/Unix/Process.cpp
+++ b/src/Platform/Unix/Process.cpp
@@ -170,7 +170,7 @@ namespace VeraCrypt
 
 		if (!exOutput.empty())
 		{
-			auto_ptr <Serializable> deserializedObject;
+			unique_ptr <Serializable> deserializedObject;
 			Exception *deserializedException = nullptr;
 
 			try

--- a/src/Volume/EncryptionThreadPool.cpp
+++ b/src/Volume/EncryptionThreadPool.cpp
@@ -125,9 +125,7 @@ namespace VeraCrypt
 
 		firstFragmentWorkItem->ItemCompletedEvent.Wait();
 
-		auto_ptr <Exception> itemException;
-		if (firstFragmentWorkItem->ItemException.get())
-			itemException = firstFragmentWorkItem->ItemException;
+		unique_ptr <Exception> itemException = std::move(firstFragmentWorkItem->ItemException);
 
 		firstFragmentWorkItem->State.Set (WorkItem::State::Free);
 		WorkItemCompletedEvent.Signal();

--- a/src/Volume/EncryptionThreadPool.h
+++ b/src/Volume/EncryptionThreadPool.h
@@ -44,7 +44,7 @@ namespace VeraCrypt
 			};
 
 			struct WorkItem *FirstFragment;
-			auto_ptr <Exception> ItemException;
+			unique_ptr <Exception> ItemException;
 			SyncEvent ItemCompletedEvent;
 			SharedVal <size_t> OutstandingFragmentCount;
 			SharedVal <State::Enum> State;


### PR DESCRIPTION
Hi!

`auto_ptr` is unsafe and was deprecated in C++11 in favor of `unique_ptr`.

My guess is that this upgrade has not been made to the code base due to wanting to maintain compatibility with ancient build environments. Is there any plan to drop support for these old environments?

Newer environments (~9 years old) do rightfully spam some warnings based on this while compiling.
```
Compiling StringFormatter.cpp
In file included from Main.h:18,
                 from StringFormatter.h:17,
                 from StringFormatter.cpp:14:
/home/chris/Code/VeraCrypt/src/Core/Core.h:20:9: warning: ‘template<class> class std::auto_ptr’ is deprecated [-Wdeprecated-declarations]
   20 |  extern auto_ptr <CoreBase> Core;
      |         ^~~~~~~~
In file included from /usr/include/c++/10.1.0/memory:83,
                 from /home/chris/Code/VeraCrypt/src/Platform/PlatformBase.h:19,
                 from /home/chris/Code/VeraCrypt/src/Platform/Platform.h:16,
                 from Main.h:17,
                 from StringFormatter.h:17,
                 from StringFormatter.cpp:14:
/usr/include/c++/10.1.0/bits/unique_ptr.h:56:28: note: declared here
   56 |   template<typename> class auto_ptr;
      |                            ^~~~~~~~
```
(Output is from GCC under Linux).

Feel free to close this with an answer. I did a pull request to also demonstrate the code changes required.

Thank you for maintaining this project!