### PR TITLE
Fixed macFUSE support for macOS 11 (Big Sur)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@
 *.txt.h
 *.h.gch
 src/Main/veracrypt
+*.oo
+*.o.32
+*.o.64
 
 # wxWidgets Linux build artifacts
 src/wxrelease

--- a/src/Core/Unix/MacOSX/CoreMacOSX.cpp
+++ b/src/Core/Unix/MacOSX/CoreMacOSX.cpp
@@ -123,13 +123,17 @@ namespace VeraCrypt
 			fuseVersionStringLength = MAXHOSTNAMELEN;
 			if ((status = sysctlbyname ("vfs.generic.osxfuse.version.number", fuseVersionString, &fuseVersionStringLength, NULL, 0)) != 0)
 			{
-				throw HigherFuseVersionRequired (SRC_POS);
+				fuseVersionStringLength = MAXHOSTNAMELEN;
+				if ((status = sysctlbyname ("vfs.generic.macfuse.version.number", fuseVersionString, &fuseVersionStringLength, NULL, 0)) != 0)
+				{
+					throw HigherFuseVersionRequired (SRC_POS);
+				}
 			}
 		}
 
 		// look for OSXFuse dynamic library
 		struct stat sb;
-		if (0 != stat("/usr/local/lib/libosxfuse_i64.2.dylib", &sb))
+		if (0 != stat("/usr/local/lib/libosxfuse_i64.2.dylib", &sb) && 0 != stat("/usr/local/lib/libfuse.dylib", &sb))
 		{
 			throw HigherFuseVersionRequired (SRC_POS);
 		}

--- a/src/Main/Forms/MainFrame.h
+++ b/src/Main/Forms/MainFrame.h
@@ -170,7 +170,7 @@ namespace VeraCrypt
 
         void EnsureVisible(bool bOnlyHeadingBar = false)
         {
-        	wxDisplay display (this);
+		wxDisplay display;
         	wxRect displayRect = display.GetClientArea();
         	    
         	bool bMove = false;

--- a/src/Main/Main.make
+++ b/src/Main/Main.make
@@ -103,7 +103,7 @@ endif
 #------ FUSE configuration ------
 
 ifeq "$(PLATFORM)" "MacOSX"
-FUSE_LIBS = $(shell pkg-config osxfuse --libs)
+FUSE_LIBS = $(shell pkg-config $(if $(patsubst 10.%,,$(VC_OSX_TARGET)),fuse,osxfuse) --libs)
 else
 FUSE_LIBS = $(shell pkg-config fuse --libs)
 endif


### PR DESCRIPTION
Hi,

VeraCrypt no longer works on macOS 11 (Big Sur). See some reports here: https://sourceforge.net/p/veracrypt/discussion/general/thread/b7cd930cf7/

With macOS 11, osxFUSE v3.x no longer works because of changes in the kernel. With macOS 11, the name "OS X" no longer means anything and the FUSE port was renamed macFUSE. Version 4.0.2, currently in beta, works on macOS 11.

Since VeraCrypt explicitly checks the presence of osxFUSE, a few checks must be modified. Done in this PR.

This PR only modifies the code and one makefile. The packaging for macOS has not been modified. You may need some additional modifications here.