### PR TITLE
Optimized the Makefile and added some useful documentation at the top of it.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -9,6 +9,16 @@
 # contained in the file License.txt included in VeraCrypt binary and source
 # code distribution packages.
 #
+# For best build performance, invoke Make using this command (using GNU Gold):
+#
+#    LD=ld.gold nice make -j`nproc` ...
+#
+# Or, simply (if you don't have the GNU Gold linker on your system):
+#
+#    nice make -j`nproc` ...
+#
+# The `nice` command gives the desktop environment some needed breathing room.
+# The `-j` option makes Make use all cores in the system concurrently.
 
 #------ Command line arguments ------
 # DEBUG:		Disable optimizations and enable debugging checks
@@ -455,4 +465,4 @@ endif
 	cd "$(WX_BUILD_DIR)" && "$(WX_ROOT)/configure" $(WX_CONFIGURE_FLAGS) >/dev/null
 
 	@echo Building wxWidgets library...
-	cd "$(WX_BUILD_DIR)" && $(MAKE) -j 4
+	cd "$(WX_BUILD_DIR)" && $(MAKE)


### PR DESCRIPTION
This tiny, minuscule *first* contribution to VeraCrypt basically speeds up the build on modern "many-core" Un*x machines.

Initially, the removal of the "-j 4" option in the Makefile, in the build target `wxbuild`, caused my Gnome desktop to crash and log me out.  However, after much experimentation, I realized that there must be some sort of bug in Gnome that kicks in when the CPU load is 100 percent without a nice value: Suddenly the memory load grows to insane heights (16 GB on my system), causing the Gnome desktop environment to crash and log me out, after having closed all my processes.

I have tested the modifications over and over, with clean boots and with and without the `ld.gold` linker.  It appears to work well.  I used `htop` to manually monitor the memory usage and it never went above 4.2 GB of RAM on my 16 GB system.

Feel free to disregard this pull request if unacceptable, I am only making it so that everyone may build VeraCrypt a tad faster.