### PR TITLE
adding a sponsor button to repository

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: "https://www.veracrypt.fr/en/Donation.html"


### PR DESCRIPTION
this commit will add a sponsor button to the repository,
pointing to the donation page of the veracrypt website.

more information on github documentation under https://git.io/JL9e6