### PR TITLE
Make system devices work under FreeBSD

### DIFF
--- a/src/Platform/Unix/File.cpp
+++ b/src/Platform/Unix/File.cpp
@@ -32,6 +32,10 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 
+#ifdef TC_FREEBSD
+#include <sys/sysctl.h>
+#endif
+
 #include "Platform/File.h"
 #include "Platform/TextReader.h"
 
@@ -145,6 +149,31 @@ namespace VeraCrypt
 		uint64 offset;
 		throw_sys_sub_if (ioctl (FileHandle, DKIOCGETBASE, &offset) == -1, wstring (Path));
 		return offset;
+
+#elif defined (TC_FREEBSD)
+		// Get the kernel GEOM configuration
+		size_t sysctlDataLen, mibLen;
+		int mib[4];
+		mibLen = 4;
+		throw_sys_sub_if (sysctlnametomib ("kern.geom.conftxt", mib, &mibLen), wstring (Path));
+		throw_sys_sub_if (sysctl (mib, mibLen, NULL, &sysctlDataLen, NULL, 0), wstring (Path));
+		vector<char> conftxt(sysctlDataLen);
+		throw_sys_sub_if (sysctl (mib, mibLen, (void *)conftxt.data(), &sysctlDataLen, NULL, 0), wstring (Path));
+
+		// Find the slice/partition data
+		string conftxtStr (conftxt.begin(), conftxt.end());
+		size_t confLoc = conftxtStr.find (Path.ToBaseName());
+		throw_sys_sub_if (confLoc == string::npos, wstring (Path));
+
+		// Skip to the ninth column
+		for (int i = 0; i < 6;i++) {
+			confLoc = conftxtStr.find (" ", confLoc + 1);
+			throw_sys_sub_if (confLoc == string::npos, wstring (Path));
+		}
+		confLoc++;
+		size_t end = conftxtStr.find (" ", confLoc);
+		throw_sys_sub_if (end == string::npos, wstring (Path));
+		return StringConverter::ToUInt64 (conftxtStr.substr (confLoc, end - confLoc));
 
 #elif defined (TC_SOLARIS)
 

--- a/src/Platform/Unix/FilesystemPath.cpp
+++ b/src/Platform/Unix/FilesystemPath.cpp
@@ -107,8 +107,11 @@ namespace VeraCrypt
 
 		string pathStr = StringConverter::ToSingle (Path);
 		size_t p = pathStr.rfind ("s");
-		if (p == string::npos)
-			throw PartitionDeviceRequired (SRC_POS);
+		if (p == string::npos) {
+			p = pathStr.rfind ("p");
+			if (p == string::npos)
+				throw PartitionDeviceRequired (SRC_POS);
+		}
 		path = pathStr.substr (0, p);
 
 #elif defined (TC_SOLARIS)


### PR DESCRIPTION
We query the kern.geom.conftxt sysctl for the GEOM configuration to find
the partition offset. Technically speaking it would probably be better
to link against libgeom but this is less overall intrusive. Also
includes a small fix to find the parent device of an encrypted partition
when it is a GPT partition rather than a BSD slice.