### PR TITLE
Add support for OpenBSD

### DIFF
--- a/src/Build/Include/Makefile.inc
+++ b/src/Build/Include/Makefile.inc
@@ -51,7 +51,11 @@ endif
 
 
 # Embedded files
+ifeq "$(PLATFORM)" "OpenBSD"
+OD_BIN := ggod -v -t u1 -A n
+else
 OD_BIN := od -v -t u1 -A n
+endif
 TR_SED_BIN := tr '\n' ' ' | tr -s ' ' ',' | sed -e 's/^,//g' -e 's/,$$/n/' | tr 'n' '\n'
 
 %.xml.h: %.xml

--- a/src/Core/Unix/OpenBSD/CoreOpenBSD.cpp
+++ b/src/Core/Unix/OpenBSD/CoreOpenBSD.cpp
@@ -1,0 +1,166 @@
+/* $OpenBSD$ */
+/*
+ Based on FreeBSD/CoreFreeBSD.cpp
+
+ Derived from source code of TrueCrypt 7.1a, which is
+ Copyright (c) 2008-2012 TrueCrypt Developers Association and which is governed
+ by the TrueCrypt License 3.0.
+
+ Modifications and additions to the original source code (contained in this file)
+ and all other portions of this file are Copyright (c) 2013-2017 IDRIX
+ and are governed by the Apache License 2.0 the full text of which is
+ contained in the file License.txt included in VeraCrypt binary and source
+ code distribution packages.
+*/
+
+#include <fstream>
+#include <iostream>
+#include <stdio.h>
+#include <unistd.h>
+#include <sys/param.h>
+#include <sys/ucred.h>
+#include <sys/mount.h>
+#include <sys/wait.h>
+#include "CoreOpenBSD.h"
+#include "Core/Unix/CoreServiceProxy.h"
+
+namespace VeraCrypt
+{
+	CoreOpenBSD::CoreOpenBSD ()
+	{
+	}
+
+	CoreOpenBSD::~CoreOpenBSD ()
+	{
+	}
+
+	DevicePath CoreOpenBSD::AttachFileToLoopDevice (const FilePath &filePath, bool readOnly) const
+	{
+		list <string> args;
+
+		if (readOnly)
+		{
+			throw;
+		}
+
+		// find an available vnd
+		int freeVnd = -1;
+		for (int vnd = 0; vnd <= 3; vnd++)
+		{
+			stringstream devPath;
+			devPath << "/dev/vnd" << vnd << "c";
+
+			if (FilesystemPath (devPath.str()).IsBlockDevice() || FilesystemPath (devPath.str()).IsCharacterDevice())
+			{
+				make_shared_auto (HostDevice, device);
+				device->Path = devPath.str();
+				try
+				{
+					GetDeviceSize (device->Path);
+				}
+				catch (...)
+				{
+					freeVnd = vnd;
+					break;
+				}
+			}
+		}
+
+		if (freeVnd == -1)
+			throw "couldn't find free vnd";
+
+		args.push_back ("-c");
+
+		stringstream freePath;
+		freePath << "vnd" << freeVnd;
+		args.push_back (freePath.str());
+
+		args.push_back (filePath);
+
+		Process::Execute ("vnconfig", args);
+
+		return "/dev/" + freePath.str() + "c";
+	}
+
+	void CoreOpenBSD::DetachLoopDevice (const DevicePath &devicePath) const
+	{
+		list <string> args;
+		args.push_back ("-u");
+		args.push_back (devicePath);
+
+		for (int t = 0; true; t++)
+		{
+			try
+			{
+				Process::Execute ("vnconfig", args);
+				break;
+			}
+			catch (ExecutedProcessFailed&)
+			{
+				if (t > 5)
+					throw;
+				Thread::Sleep (200);
+			}
+		}
+	}
+
+	// not sure what this is used for
+	HostDeviceList CoreOpenBSD::GetHostDevices (bool pathListOnly) const
+	{
+		throw;
+	}
+
+	MountedFilesystemList CoreOpenBSD::GetMountedFilesystems (const DevicePath &devicePath, const DirectoryPath &mountPoint) const
+	{
+
+		static Mutex mutex;
+		ScopeLock sl (mutex);
+
+		struct statfs *sysMountList;
+		int count = getmntinfo (&sysMountList, MNT_NOWAIT);
+		throw_sys_if (count == 0);
+
+		MountedFilesystemList mountedFilesystems;
+
+		for (int i = 0; i < count; i++)
+		{
+			make_shared_auto (MountedFilesystem, mf);
+
+			if (sysMountList[i].f_mntfromname[0])
+				mf->Device = DevicePath (sysMountList[i].f_mntfromname);
+			else
+				continue;
+
+			if (sysMountList[i].f_mntonname[0])
+				mf->MountPoint = DirectoryPath (sysMountList[i].f_mntonname);
+
+			mf->Type = sysMountList[i].f_fstypename;
+
+			if ((devicePath.IsEmpty() || devicePath == mf->Device) && (mountPoint.IsEmpty() || mountPoint == mf->MountPoint))
+				mountedFilesystems.push_back (mf);
+		}
+
+		return mountedFilesystems;
+	}
+
+	void CoreOpenBSD::MountFilesystem (const DevicePath &devicePath, const DirectoryPath &mountPoint, const string &filesystemType, bool readOnly, const string &systemMountOptions) const
+	{
+		try
+		{
+			// Try to mount FAT by default as mount is unable to probe filesystem type on BSD
+			CoreUnix::MountFilesystem (devicePath, mountPoint, filesystemType.empty() ? "msdos" : filesystemType, readOnly, systemMountOptions);
+		}
+		catch (ExecutedProcessFailed&)
+		{
+			if (!filesystemType.empty())
+				throw;
+
+			CoreUnix::MountFilesystem (devicePath, mountPoint, filesystemType, readOnly, systemMountOptions);
+		}
+	}
+
+#ifdef TC_OPENBSD
+	unique_ptr <CoreBase> Core (new CoreServiceProxy <CoreOpenBSD>);
+	unique_ptr <CoreBase> CoreDirect (new CoreOpenBSD);
+#endif
+}

--- a/src/Core/Unix/OpenBSD/CoreOpenBSD.h
+++ b/src/Core/Unix/OpenBSD/CoreOpenBSD.h
@@ -1,0 +1,44 @@
+/* $OpenBSD$ */
+/*
+ Based on FreeBSD/CoreFreeBSD.h
+
+ Derived from source code of TrueCrypt 7.1a, which is
+ Copyright (c) 2008-2012 TrueCrypt Developers Association and which is governed
+ by the TrueCrypt License 3.0.
+
+ Modifications and additions to the original source code (contained in this file)
+ and all other portions of this file are Copyright (c) 2013-2017 IDRIX
+ and are governed by the Apache License 2.0 the full text of which is
+ contained in the file License.txt included in VeraCrypt binary and source
+ code distribution packages.
+*/
+
+#ifndef TC_HEADER_Core_CoreOpenBSD
+#define TC_HEADER_Core_CoreOpenBSD
+
+#include "System.h"
+#include "Core/Unix/CoreUnix.h"
+
+namespace VeraCrypt
+{
+	class CoreOpenBSD : public CoreUnix
+	{
+	public:
+		CoreOpenBSD ();
+		virtual ~CoreOpenBSD ();
+
+		virtual HostDeviceList GetHostDevices (bool pathListOnly = false) const;
+
+	protected:
+		virtual DevicePath AttachFileToLoopDevice (const FilePath &filePath, bool readOnly) const;
+		virtual void DetachLoopDevice (const DevicePath &devicePath) const;
+		virtual MountedFilesystemList GetMountedFilesystems (const DevicePath &devicePath = DevicePath(), const DirectoryPath &mountPoint = DirectoryPath()) const;
+		virtual void MountFilesystem (const DevicePath &devicePath, const DirectoryPath &mountPoint, const string &filesystemType, bool readOnly, const string &systemMountOptions) const;
+
+	private:
+		CoreOpenBSD (const CoreOpenBSD &);
+		CoreOpenBSD &operator= (const CoreOpenBSD &);
+	};
+}
+
+#endif // TC_HEADER_Core_CoreOpenBSD

--- a/src/Core/Unix/OpenBSD/System.h
+++ b/src/Core/Unix/OpenBSD/System.h
@@ -1,0 +1,19 @@
+/* $OpenBSD$ */
+/*
+ Based on FreeBSD/System.h
+
+ Derived from source code of TrueCrypt 7.1a, which is
+ Copyright (c) 2008-2012 TrueCrypt Developers Association and which is governed
+ by the TrueCrypt License 3.0.
+
+ Modifications and additions to the original source code (contained in this file)
+ and all other portions of this file are Copyright (c) 2013-2017 IDRIX
+ and are governed by the Apache License 2.0 the full text of which is
+ contained in the file License.txt included in VeraCrypt binary and source
+ code distribution packages.
+*/
+
+#ifndef TC_HEADER_Platform_OpenBSD_System
+#define TC_HEADER_Platform_OpenBSD_System
+
+#endif // TC_HEADER_Platform_OpenBSD_System

--- a/src/Driver/Fuse/FuseService.cpp
+++ b/src/Driver/Fuse/FuseService.cpp
@@ -10,7 +10,12 @@
  code distribution packages.
 */
 
+#ifdef TC_OPENBSD
+#define FUSE_USE_VERSION  26
+#else
 #define FUSE_USE_VERSION  25
+#endif
+
 #include <errno.h>
 #include <fcntl.h>
 #include <fuse.h>
@@ -51,7 +56,11 @@ namespace VeraCrypt
 		return 0;
 	}
 
+#ifdef TC_OPENBSD
+	static void *fuse_service_init (struct fuse_conn_info *)
+#else
 	static void *fuse_service_init ()
+#endif
 	{
 		try
 		{
@@ -583,7 +592,11 @@ namespace VeraCrypt
 
 		SignalHandlerPipe->GetWriteFD();
 
+#ifdef TC_OPENBSD
+		_exit (fuse_main (argc, argv, &fuse_service_oper, NULL));
+#else
 		_exit (fuse_main (argc, argv, &fuse_service_oper));
+#endif
 	}
 
 	VolumeInfo FuseService::OpenVolumeInfo;

--- a/src/Main/FatalErrorHandler.cpp
+++ b/src/Main/FatalErrorHandler.cpp
@@ -25,7 +25,7 @@
 
 #ifdef TC_MACOSX
 #	include <sys/ucontext.h>
-#elif defined (TC_BSD)
+#elif defined (TC_BSD) && !defined (TC_OPENBSD)
 #	include <ucontext.h>
 #endif
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -363,6 +363,27 @@ ifeq "$(shell uname -s)" "FreeBSD"
 endif
 
 
+#------ OpenBSD configuration ------
+
+ifeq "$(shell uname -s)" "OpenBSD"
+
+	PLATFORM := OpenBSD
+	PLATFORM_UNSUPPORTED := 1
+	C_CXX_FLAGS += -DTC_UNIX -DTC_BSD -DTC_OPENBSD
+
+	CC := cc
+	CXX := c++
+
+	ifeq "$(TC_BUILD_CONFIG)" "Release"
+		C_CXX_FLAGS += -fdata-sections -ffunction-sections -fpie
+		LFLAGS += -Wl,--gc-sections -pie
+
+		WXCONFIG_CFLAGS += -fpie -fPIC
+		WXCONFIG_CXXFLAGS += -fpie -fPIC
+	endif
+endif
+
+
 #------ Solaris configuration ------
 
 ifeq "$(shell uname -s)" "SunOS"

--- a/src/Platform/Unix/File.cpp
+++ b/src/Platform/Unix/File.cpp
@@ -23,6 +23,12 @@
 #include <sys/disk.h>
 #endif
 
+#ifdef TC_OPENBSD
+#include <sys/ioctl.h>
+#include <sys/dkio.h>
+#include <sys/disklabel.h>
+#endif
+
 #ifdef TC_SOLARIS
 #include <stropts.h>
 #include <sys/dkio.h>
@@ -113,6 +119,11 @@ namespace VeraCrypt
 			throw_sys_sub_if (ioctl (FileHandle, DIOCGSECTORSIZE, &sectorSize) == -1, wstring (Path));
 			return (uint32) sectorSize;
 
+#elif defined (TC_OPENBSD)
+			struct disklabel dl;
+			throw_sys_sub_if (ioctl (FileHandle, DIOCGPDINFO, &dl) == -1, wstring (Path));
+			return (uint32) dl.d_secsize;
+
 #elif defined (TC_SOLARIS)
 			struct dk_minfo mediaInfo;
 			throw_sys_sub_if (ioctl (FileHandle, DKIOCGMEDIAINFO, &mediaInfo) == -1, wstring (Path));
@@ -171,6 +182,10 @@ namespace VeraCrypt
 			throw_sys_sub_if (ioctl (FileHandle, DKIOCGETBLOCKSIZE, &blockSize) == -1, wstring (Path));
 			throw_sys_sub_if (ioctl (FileHandle, DKIOCGETBLOCKCOUNT, &blockCount) == -1, wstring (Path));
 			return blockCount * blockSize;
+#	elif TC_OPENBSD
+			struct disklabel dl;
+			throw_sys_sub_if (ioctl (FileHandle, DIOCGPDINFO, &dl) == -1, wstring (Path));
+			return DL_GETDSIZE(&dl);
 #	else
 			uint64 mediaSize;
 			throw_sys_sub_if (ioctl (FileHandle, DIOCGMEDIASIZE, &mediaSize) == -1, wstring (Path));

--- a/src/Platform/Unix/FilesystemPath.cpp
+++ b/src/Platform/Unix/FilesystemPath.cpp
@@ -15,7 +15,7 @@
 #include "Platform/StringConverter.h"
 #include <stdio.h>
 #include <sys/stat.h>
-#if !defined(__FreeBSD__) && !defined(__APPLE__)
+#if !defined(__FreeBSD__) && !defined(__APPLE__) && !defined(__OpenBSD__)
 #include <sys/sysmacros.h>
 #endif
 

--- a/src/Platform/Unix/SystemInfo.cpp
+++ b/src/Platform/Unix/SystemInfo.cpp
@@ -24,6 +24,8 @@ namespace VeraCrypt
 		return L"Mac OS X";
 #elif defined (TC_FREEBSD)
 		return L"FreeBSD";
+#elif defined (TC_OPENBSD)
+		return L"OpenBSD";
 #elif defined (TC_SOLARIS)
 		return L"Solaris";
 #else


### PR DESCRIPTION
Hi, I've created patch based on jcs code (https://github.com/jcs/openbsd-ports/tree/master/security/veracrypt), with some minor changes / improvements and I'd like to make that code go upstream. Could somebody please review whether there is anything more needed? I've tested the code, it compiles without problems and the file based encryption (with FAT) works without any problem.