### PR TITLE
Add toggleable support for application indicators, off by default.

### DIFF
--- a/src/Main/Forms/MainFrame.cpp
+++ b/src/Main/Forms/MainFrame.cpp
@@ -46,6 +46,9 @@ namespace VeraCrypt
 	DEFINE_EVENT_TYPE(wxEVT_COMMAND_SHOW_WARNING)
 
 	MainFrame::MainFrame (wxWindow* parent) : MainFrameBase (parent),
+#ifdef HAVE_INDICATORS
+		indicator (NULL),
+#endif
 		ListItemRightClickEventPending (false),
 		SelectedItemIndex (-1),
 		SelectedSlotNumber (0),
@@ -1558,6 +1561,32 @@ namespace VeraCrypt
 		}
 	}
 
+#ifdef HAVE_INDICATORS
+	void MainFrame::SetBusy (bool busy)
+	{
+		gtk_widget_set_sensitive(indicator_item_mountfavorites, !busy);
+		gtk_widget_set_sensitive(indicator_item_dismountall, !busy);
+		gtk_widget_set_sensitive(indicator_item_prefs, !busy);
+		gtk_widget_set_sensitive(indicator_item_exit, !busy /*&& CanExit()*/);
+	}
+
+	static void IndicatorOnShowHideMenuItemSelected (GtkWidget *widget, MainFrame *self) { Gui->SetBackgroundMode (!Gui->IsInBackgroundMode()); }
+	static void IndicatorOnMountAllFavoritesMenuItemSelected (GtkWidget *widget, MainFrame *self) { self->SetBusy(true); self->MountAllFavorites (); self->SetBusy(false); }
+	static void IndicatorOnDismountAllMenuItemSelected (GtkWidget *widget, MainFrame *self) { self->SetBusy(true); Gui->DismountAllVolumes(); self->SetBusy(false); }
+	static void IndicatorOnPreferencesMenuItemSelected (GtkWidget *widget, MainFrame *self) {
+		self->SetBusy(true);
+		PreferencesDialog dialog (self);
+		dialog.ShowModal();
+		self->SetBusy(false);
+	}
+	static void IndicatorOnExitMenuItemSelected (GtkWidget *widget, MainFrame *self) {
+		self->SetBusy(true);
+		if (Core->GetMountedVolumes().empty() || Gui->AskYesNo (LangString ["CONFIRM_EXIT"], false, true))
+			self->Close (true);
+		self->SetBusy(false);
+	}
+
+#endif
 	void MainFrame::ShowTaskBarIcon (bool show)
 	{
 		if (!show && mTaskBarIcon->IsIconInstalled())
@@ -1567,7 +1596,46 @@ namespace VeraCrypt
 		else if (show && !mTaskBarIcon->IsIconInstalled())
 		{
 #ifndef TC_MACOSX
+#ifndef HAVE_INDICATORS
 			mTaskBarIcon->SetIcon (Resources::GetVeraCryptIcon(), L"VeraCrypt");
+#endif
+#endif
+#ifdef HAVE_INDICATORS
+			if (indicator == NULL) {
+				indicator = app_indicator_new ("veracrypt", "veracrypt", APP_INDICATOR_CATEGORY_APPLICATION_STATUS);
+				app_indicator_set_status (indicator, APP_INDICATOR_STATUS_ACTIVE);
+
+				GtkWidget *menu = gtk_menu_new();
+
+				indicator_item_showhide = gtk_menu_item_new_with_label (LangString[Gui->IsInBackgroundMode() ? "SHOW_TC" : "HIDE_TC"].mb_str());
+				gtk_menu_shell_append (GTK_MENU_SHELL (menu), indicator_item_showhide);
+				g_signal_connect (indicator_item_showhide, "activate", G_CALLBACK (IndicatorOnShowHideMenuItemSelected), this);
+
+				gtk_menu_shell_append (GTK_MENU_SHELL (menu), gtk_separator_menu_item_new());
+
+				indicator_item_mountfavorites = gtk_menu_item_new_with_label (LangString["IDM_MOUNT_FAVORITE_VOLUMES"]);
+				gtk_menu_shell_append (GTK_MENU_SHELL (menu), indicator_item_mountfavorites);
+				g_signal_connect (indicator_item_mountfavorites, "activate", G_CALLBACK (IndicatorOnMountAllFavoritesMenuItemSelected), this);
+
+				indicator_item_dismountall = gtk_menu_item_new_with_label (LangString["HK_DISMOUNT_ALL"]);
+				gtk_menu_shell_append (GTK_MENU_SHELL (menu), indicator_item_dismountall);
+				g_signal_connect (indicator_item_dismountall, "activate", G_CALLBACK (IndicatorOnDismountAllMenuItemSelected), this);
+
+				gtk_menu_shell_append (GTK_MENU_SHELL (menu), gtk_separator_menu_item_new());
+
+				indicator_item_prefs = gtk_menu_item_new_with_label (LangString["IDM_PREFERENCES"]);
+				gtk_menu_shell_append (GTK_MENU_SHELL (menu), indicator_item_prefs);
+				g_signal_connect (indicator_item_prefs, "activate", G_CALLBACK (IndicatorOnPreferencesMenuItemSelected), this);
+
+				gtk_menu_shell_append (GTK_MENU_SHELL (menu), gtk_separator_menu_item_new());
+
+				indicator_item_exit = gtk_menu_item_new_with_label (LangString["EXIT"]);
+				gtk_menu_shell_append (GTK_MENU_SHELL (menu), indicator_item_exit);
+				g_signal_connect (indicator_item_exit, "activate", G_CALLBACK (IndicatorOnExitMenuItemSelected), this);
+
+				gtk_widget_show_all (menu);
+				app_indicator_set_menu (indicator, GTK_MENU (menu));
+			}
 #endif
 		}
 	}

--- a/src/Main/Forms/MainFrame.h
+++ b/src/Main/Forms/MainFrame.h
@@ -13,6 +13,12 @@
 #ifndef TC_HEADER_Main_Forms_MainFrame
 #define TC_HEADER_Main_Forms_MainFrame
 
+#ifdef HAVE_INDICATORS
+#define GSocket GlibGSocket
+#include <libayatana-appindicator/app-indicator.h>
+#undef GSocket
+#endif
+
 #include "Forms.h"
 #include "ChangePasswordDialog.h"
 #ifdef TC_MACOSX
@@ -38,6 +44,18 @@ namespace VeraCrypt
 		static FilePath GetShowRequestFifoPath () { return Application::GetConfigFilePath (L".show-request-queue", true); }
 #endif
 
+		void MountAllFavorites ();
+
+#ifdef HAVE_INDICATORS
+		AppIndicator *indicator;
+		GtkWidget *indicator_item_showhide;
+		GtkWidget *indicator_item_mountfavorites;
+		GtkWidget *indicator_item_dismountall;
+		GtkWidget *indicator_item_prefs;
+		GtkWidget *indicator_item_exit;
+		void SetBusy (bool busy);
+
+#endif
 	protected:
 		enum
 		{
@@ -71,7 +89,6 @@ namespace VeraCrypt
 		void LoadFavoriteVolumes ();
 		void LoadPreferences ();
 		void MountAllDevices ();
-		void MountAllFavorites ();
 		void MountVolume ();
 		void OnAboutMenuItemSelected (wxCommandEvent& event);
 		void OnQuit(wxCommandEvent& event) { Close(true); }

--- a/src/Main/GraphicUserInterface.cpp
+++ b/src/Main/GraphicUserInterface.cpp
@@ -1754,6 +1754,10 @@ namespace VeraCrypt
 		}
 
 		BackgroundMode = state;
+
+#ifdef HAVE_INDICATORS
+		gtk_menu_item_set_label ((GtkMenuItem*) ((MainFrame*) mMainFrame)->indicator_item_showhide, LangString[Gui->IsInBackgroundMode() ? "SHOW_TC" : "HIDE_TC"].mb_str());
+#endif
 	}
 
 	void GraphicUserInterface::SetListCtrlColumnWidths (wxListCtrl *listCtrl, list <int> columnWidthPermilles, bool hasVerticalScrollbar) const

--- a/src/Makefile
+++ b/src/Makefile
@@ -95,6 +95,15 @@ ifeq "$(origin WXSTATIC)" "command line"
 	endif
 endif
 
+ifeq "$(origin INDICATOR)" "command line"
+	ifneq (,$(findstring gtk3,$(shell $(WX_CONFIG) --selected-config)))
+		INDICATOR_LIBRARY=ayatana-appindicator3-0.1
+	else
+		INDICATOR_LIBRARY=ayatana-appindicator-0.1
+	endif
+	export LIBS += $(shell pkg-config --libs $(INDICATOR_LIBRARY))
+	C_CXX_FLAGS += $(shell pkg-config --cflags $(INDICATOR_LIBRARY)) -DHAVE_INDICATORS
+endif
 
 #------ Release configuration ------
 


### PR DESCRIPTION
I have no idea if this is actually something you want to optionally support upstream, but I guess just close this out if not.

This tries to figure out, via wx-config, if you're using GTK2 or GTK3 and uses the associated Ayatana library.

This just adds support, off by default, for building against the Ayatana libraries for indicator support.  As I understand it, for GNOME this is somewhat required to have a tray icon as they don't support the xembed ones at all.  This of course works in Xfce too and in places that don't have indicator support, it should fall back to tray icon.  Like for tint2.

I have been led to believe tray icons aren't exactly going to work out in a wayland world at all, but as I use Xfce I mainly ignore wayland at this stage.