### PR TITLE
Fix incorrect text color in dark mode

### DIFF
--- a/src/Main/Forms/VolumePasswordPanel.cpp
+++ b/src/Main/Forms/VolumePasswordPanel.cpp
@@ -472,9 +472,9 @@ namespace VeraCrypt
 			VolumePimHelpStaticText->SetLabel(LangString["PIM_CHANGE_WARNING"]);
 			guiUpdated = true;
 		}
-		if (!pimChanged && VolumePimHelpStaticText->GetForegroundColour() != *wxBLACK)
+		if (!pimChanged && VolumePimHelpStaticText->GetForegroundColour() != wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT))
 		{
-			VolumePimHelpStaticText->SetForegroundColour(*wxBLACK);
+			VolumePimHelpStaticText->SetForegroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
 			VolumePimHelpStaticText->SetLabel(LangString["IDC_PIM_HELP"]);
 			guiUpdated = true;
 		}

--- a/src/Main/Forms/VolumePimWizardPage.cpp
+++ b/src/Main/Forms/VolumePimWizardPage.cpp
@@ -82,7 +82,7 @@ namespace VeraCrypt
 		}
 		else
 		{
-			VolumePimHelpStaticText->SetForegroundColour(*wxBLACK);
+			VolumePimHelpStaticText->SetForegroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
 			VolumePimHelpStaticText->SetLabel(LangString["IDC_PIM_HELP"]);
 		}
 		Fit();


### PR DESCRIPTION
This uses `wxSystemSettings` to get the correct text color for help text about the PIM. Before, the color was hard coded as black, making it difficult to read in dark mode. Fixes #754.