### PR TITLE
OpenBSD vnconfig no longer accepts -c option

### DIFF
--- a/src/Core/Unix/OpenBSD/CoreOpenBSD.cpp
+++ b/src/Core/Unix/OpenBSD/CoreOpenBSD.cpp
@@ -69,8 +69,6 @@ namespace VeraCrypt
 		if (freeVnd == -1)
 			throw "couldn't find free vnd";
 
-		args.push_back ("-c");
-
 		stringstream freePath;
 		freePath << "vnd" << freeVnd;
 		args.push_back (freePath.str());


### PR DESCRIPTION
vnconfig used to accept a `-c` option for configuring virtual disk node, but this option is not required as configuring virtual disk node is always the default operation. Since OpenBSD 5.6, this option is no longer accepted and will result in an error, preventing veracrypt from mounting any volume.

This change removes the `-c` option when invoking vnconfig.

Tested on OpenBSD 7.2, same patch also tested in https://github.com/veracrypt/VeraCrypt/issues/968