### PR TITLE
Fix error when checking for free space

### DIFF
--- a/src/Main/TextUserInterface.cpp
+++ b/src/Main/TextUserInterface.cpp
@@ -648,7 +648,8 @@ namespace VeraCrypt
 		{
 			uint64 AvailableDiskSpace = 0;
 			wxLongLong diskSpace = 0;
-			if (wxGetDiskSpace (wxFileName (wstring (options->Path)).GetPath(), nullptr, &diskSpace))
+			if (!wxFileName (wstring (options->Path)).GetPath().IsEmpty() &&
+				wxGetDiskSpace (wxFileName (wstring (options->Path)).GetPath(), nullptr, &diskSpace))
 			{
 				AvailableDiskSpace = (uint64) diskSpace.GetValue ();
 				if (maxVolumeSize > AvailableDiskSpace)


### PR DESCRIPTION
When creating a totally new volume on the command line (Linux), VeraCrypt displays an error:
```
Error: Failed to get file system statistics (error 2: No such file or directory)
```
This is caused by passing an empty path to `wxGetDiskSpace`.
My fix is a simple workaround for this - if the path is empty, just don't call `wxGetDiskSpace`.

Perhaps a better solution would be to pass something like the basedir of the path if the file doesn't exist, but this is what I can do with my knowledge.