### PR TITLE
Keep PIM secret and re-ask when user entered a wrong value

### DIFF
--- a/src/Main/TextUserInterface.cpp
+++ b/src/Main/TextUserInterface.cpp
@@ -175,9 +175,13 @@ namespace VeraCrypt
 		wxString msg = _("Enter new PIM: ");
 		if (!message.empty())
 			msg = message + L": ";
+		SetTerminalEcho (false);
+		finally_do ({ TextUserInterface::SetTerminalEcho (true); });
 		while (pim < 0)
 		{
 			wstring pimStr = AskString (msg);
+			ShowString (L"\n");
+
 			if (pimStr.empty())
 				pim = 0;
 			else
@@ -1290,7 +1294,7 @@ namespace VeraCrypt
 				options.Password = AskPassword (StringFormatter (_("Enter password for {0}"), wstring (*options.Path)));
 			}
 
-			if (!options.TrueCryptMode && (options.Pim < 0))
+			if (!options.TrueCryptMode /*&& (options.Pim < 0) re-ask in case of wrong value entered*/)
 			{
 				options.Pim = AskPim (StringFormatter (_("Enter PIM for {0}"), wstring (*options.Path)));
 			}


### PR DESCRIPTION
Since PIM is a part of the user's secret (the key is derived from it), as it is written:

> The PIM is treated like a secret value that must be entered by the user each time alongside the password.

(https://veracrypt.fr/en/Personal%20Iterations%20Multiplier%20(PIM).html?), it should also be hidden from view and not echoed to the terminal.

This patch addresses this issue.

Apart from this, PIM should be allowed to be re-entered, just like the password is, in case decryption fails. Otherwise, if the user enters the correct password and an incorrect PIM, he/she doesn't have a chance to fix the mistake - the process must be re-started.

This issue is also addressed.