### PR TITLE
Fix verbose message incorrectly saying "dismounting" when mounting on Linux

### DIFF
--- a/Translations/Language.ar.xml
+++ b/Translations/Language.ar.xml
@@ -1521,6 +1521,7 @@
     <entry lang="en" key="LINUX_NOT_SUPPORTED"> (not supported by components available on this platform).\n</entry>
     <entry lang="en" key="LINUX_KERNEL_OLD">Your system uses an old version of the Linux kernel.\n\nDue to a bug in the Linux kernel, your system may stop responding when writing data to a VeraCrypt volume. This problem can be solved by upgrading the kernel to version 2.6.24 or later.</entry>
     <entry lang="en" key="LINUX_VOL_DISMOUNTED">Volume {0} has been dismounted.</entry>
+    <entry lang="en" key="LINUX_VOL_MOUNTED">Volume {0} has been mounted.</entry>
     <entry lang="en" key="LINUX_OOM">Out of memory.</entry>
     <entry lang="en" key="LINUX_CANT_GET_ADMIN_PRIV">Failed to obtain administrator privileges</entry>
     <entry lang="en" key="LINUX_COMMAND_GET_ERROR">Command {0} returned error {1}.</entry>

--- a/Translations/Language.be.xml
+++ b/Translations/Language.be.xml
@@ -1521,6 +1521,7 @@
     <entry lang="en" key="LINUX_NOT_SUPPORTED"> (not supported by components available on this platform).\n</entry>
     <entry lang="en" key="LINUX_KERNEL_OLD">Your system uses an old version of the Linux kernel.\n\nDue to a bug in the Linux kernel, your system may stop responding when writing data to a VeraCrypt volume. This problem can be solved by upgrading the kernel to version 2.6.24 or later.</entry>
     <entry lang="en" key="LINUX_VOL_DISMOUNTED">Volume {0} has been dismounted.</entry>
+    <entry lang="en" key="LINUX_VOL_MOUNTED">Volume {0} has been mounted.</entry>
     <entry lang="en" key="LINUX_OOM">Out of memory.</entry>
     <entry lang="en" key="LINUX_CANT_GET_ADMIN_PRIV">Failed to obtain administrator privileges</entry>
     <entry lang="en" key="LINUX_COMMAND_GET_ERROR">Command {0} returned error {1}.</entry>

--- a/Translations/Language.bg.xml
+++ b/Translations/Language.bg.xml
@@ -1521,6 +1521,7 @@
     <entry lang="en" key="LINUX_NOT_SUPPORTED"> (not supported by components available on this platform).\n</entry>
     <entry lang="en" key="LINUX_KERNEL_OLD">Your system uses an old version of the Linux kernel.\n\nDue to a bug in the Linux kernel, your system may stop responding when writing data to a VeraCrypt volume. This problem can be solved by upgrading the kernel to version 2.6.24 or later.</entry>
     <entry lang="en" key="LINUX_VOL_DISMOUNTED">Volume {0} has been dismounted.</entry>
+    <entry lang="en" key="LINUX_VOL_MOUNTED">Volume {0} has been mounted.</entry>
     <entry lang="en" key="LINUX_OOM">Out of memory.</entry>
     <entry lang="en" key="LINUX_CANT_GET_ADMIN_PRIV">Failed to obtain administrator privileges</entry>
     <entry lang="en" key="LINUX_COMMAND_GET_ERROR">Command {0} returned error {1}.</entry>

--- a/Translations/Language.ca.xml
+++ b/Translations/Language.ca.xml
@@ -1521,6 +1521,7 @@
     <entry lang="en" key="LINUX_NOT_SUPPORTED"> (not supported by components available on this platform).\n</entry>
     <entry lang="en" key="LINUX_KERNEL_OLD">Your system uses an old version of the Linux kernel.\n\nDue to a bug in the Linux kernel, your system may stop responding when writing data to a VeraCrypt volume. This problem can be solved by upgrading the kernel to version 2.6.24 or later.</entry>
     <entry lang="en" key="LINUX_VOL_DISMOUNTED">Volume {0} has been dismounted.</entry>
+    <entry lang="en" key="LINUX_VOL_MOUNTED">Volume {0} has been mounted.</entry>
     <entry lang="en" key="LINUX_OOM">Out of memory.</entry>
     <entry lang="en" key="LINUX_CANT_GET_ADMIN_PRIV">Failed to obtain administrator privileges</entry>
     <entry lang="en" key="LINUX_COMMAND_GET_ERROR">Command {0} returned error {1}.</entry>

--- a/Translations/Language.co.xml
+++ b/Translations/Language.co.xml
@@ -1521,6 +1521,7 @@
     <entry lang="co" key="LINUX_NOT_SUPPORTED" > (micca accettatu da i cumpunenti dispunibule nant’à sta piattaforma).\n</entry>
     <entry lang="co" key="LINUX_KERNEL_OLD" >U vostru sistema impiegheghja una vechja versione di u nocciulu Linux.\n\nPer via d’un prublema in u nocciulu Linux, u vostru sistema puderia piantassi di risponde quandu si scrive i dati nant’à u vulume VeraCrypt. Stu prublema pò esse currettu mittendu à livellu u nocciulu à a versione 2.6.24 o più recente.</entry>
     <entry lang="co" key="LINUX_VOL_DISMOUNTED" >U vulume {0} hè statu smuntatu.</entry>
+    <entry lang="en" key="LINUX_VOL_MOUNTED">Volume {0} has been mounted.</entry>
     <entry lang="co" key="LINUX_OOM" >Mancanza di memoria.</entry>
     <entry lang="co" key="LINUX_CANT_GET_ADMIN_PRIV" >Impussibule d’ottene i privileghji d’amministratore</entry>
     <entry lang="co" key="LINUX_COMMAND_GET_ERROR" >A cumanda {0} hà restituitu u sbagliu {1}.</entry>

--- a/Translations/Language.cs.xml
+++ b/Translations/Language.cs.xml
@@ -1521,6 +1521,7 @@
     <entry lang="cs" key="LINUX_NOT_SUPPORTED"> (není podporováno komponentami dostupnými na této platformě).\n</entry>
     <entry lang="cs" key="LINUX_KERNEL_OLD">Váš systém používá starou verzi linuxového jádra.\n\nV důsledku chyby v linuxovém jádře může systém přestat reagovat při zápisu dat na svazek VeraCryptu. Tento problém lze vyřešit aktualizací jádra na verzi 2.6.24 nebo novější.</entry>
     <entry lang="cs" key="LINUX_VOL_DISMOUNTED">Svazek {0} byl odpojen.</entry>
+    <entry lang="en" key="LINUX_VOL_MOUNTED">Volume {0} has been mounted.</entry>
     <entry lang="cs" key="LINUX_OOM">Nedostatek paměti.</entry>
     <entry lang="cs" key="LINUX_CANT_GET_ADMIN_PRIV">Nepodařilo se získat oprávnění správce systému</entry>
     <entry lang="cs" key="LINUX_COMMAND_GET_ERROR">Příkaz {0} vrátil chybu {1}.</entry>

--- a/Translations/Language.da.xml
+++ b/Translations/Language.da.xml
@@ -1521,6 +1521,7 @@
     <entry lang="en" key="LINUX_NOT_SUPPORTED"> (not supported by components available on this platform).\n</entry>
     <entry lang="en" key="LINUX_KERNEL_OLD">Your system uses an old version of the Linux kernel.\n\nDue to a bug in the Linux kernel, your system may stop responding when writing data to a VeraCrypt volume. This problem can be solved by upgrading the kernel to version 2.6.24 or later.</entry>
     <entry lang="en" key="LINUX_VOL_DISMOUNTED">Volume {0} has been dismounted.</entry>
+    <entry lang="en" key="LINUX_VOL_MOUNTED">Volume {0} has been mounted.</entry>
     <entry lang="en" key="LINUX_OOM">Out of memory.</entry>
     <entry lang="en" key="LINUX_CANT_GET_ADMIN_PRIV">Failed to obtain administrator privileges</entry>
     <entry lang="en" key="LINUX_COMMAND_GET_ERROR">Command {0} returned error {1}.</entry>

--- a/Translations/Language.de.xml
+++ b/Translations/Language.de.xml
@@ -1524,6 +1524,7 @@
     <entry lang="de" key="LINUX_NOT_SUPPORTED">(wird von den vorhandenen Komponenten dieser Plattform nicht unterstützt).</entry>
     <entry lang="de" key="LINUX_KERNEL_OLD">Ihr System verwendet einen alten Linux-Kernel.\n\nWegen eines Fehlers im Linux-Kernel kann es passieren, dass Ihr System beim Schreiben auf ein VeraCrypt-Volume nicht mehr reagiert. Diese Problem kann durch einen Kernel in Version 2.6.24 oder neuer gelöst werden.</entry>
     <entry lang="de" key="LINUX_VOL_DISMOUNTED">Volume {0} ausgehängt.</entry>
+    <entry lang="en" key="LINUX_VOL_MOUNTED">Volume {0} has been mounted.</entry>
     <entry lang="de" key="LINUX_OOM">Zu wenig Speicher.</entry>
     <entry lang="de" key="LINUX_CANT_GET_ADMIN_PRIV">Erlangen der Administrator-Privilegien fehlgeschlagen</entry>
     <entry lang="de" key="LINUX_COMMAND_GET_ERROR">Kommando {0} lieferte Fehler: {1}.</entry>

--- a/Translations/Language.el.xml
+++ b/Translations/Language.el.xml
@@ -1520,6 +1520,7 @@
     <entry lang="en" key="LINUX_DOT_LF">.\n</entry>
     <entry lang="en" key="LINUX_NOT_SUPPORTED"> (not supported by components available on this platform).\n</entry>
     <entry lang="en" key="LINUX_KERNEL_OLD">Your system uses an old version of the Linux kernel.\n\nDue to a bug in the Linux kernel, your system may stop responding when writing data to a VeraCrypt volume. This problem can be solved by upgrading the kernel to version 2.6.24 or later.</entry>
+    <entry lang="en" key="LINUX_VOL_MOUNTED">Volume {0} has been mounted.</entry>
     <entry lang="en" key="LINUX_VOL_DISMOUNTED">Volume {0} has been dismounted.</entry>
     <entry lang="en" key="LINUX_OOM">Out of memory.</entry>
     <entry lang="en" key="LINUX_CANT_GET_ADMIN_PRIV">Failed to obtain administrator privileges</entry>

--- a/Translations/Language.es.xml
+++ b/Translations/Language.es.xml
@@ -1521,6 +1521,7 @@
     <entry lang="en" key="LINUX_NOT_SUPPORTED"> (not supported by components available on this platform).\n</entry>
     <entry lang="en" key="LINUX_KERNEL_OLD">Your system uses an old version of the Linux kernel.\n\nDue to a bug in the Linux kernel, your system may stop responding when writing data to a VeraCrypt volume. This problem can be solved by upgrading the kernel to version 2.6.24 or later.</entry>
     <entry lang="en" key="LINUX_VOL_DISMOUNTED">Volume {0} has been dismounted.</entry>
+    <entry lang="en" key="LINUX_VOL_MOUNTED">Volume {0} has been mounted.</entry>
     <entry lang="en" key="LINUX_OOM">Out of memory.</entry>
     <entry lang="en" key="LINUX_CANT_GET_ADMIN_PRIV">Failed to obtain administrator privileges</entry>
     <entry lang="en" key="LINUX_COMMAND_GET_ERROR">Command {0} returned error {1}.</entry>

--- a/Translations/Language.et.xml
+++ b/Translations/Language.et.xml
@@ -1521,6 +1521,7 @@
     <entry lang="en" key="LINUX_NOT_SUPPORTED"> (not supported by components available on this platform).\n</entry>
     <entry lang="en" key="LINUX_KERNEL_OLD">Your system uses an old version of the Linux kernel.\n\nDue to a bug in the Linux kernel, your system may stop responding when writing data to a VeraCrypt volume. This problem can be solved by upgrading the kernel to version 2.6.24 or later.</entry>
     <entry lang="en" key="LINUX_VOL_DISMOUNTED">Volume {0} has been dismounted.</entry>
+    <entry lang="en" key="LINUX_VOL_MOUNTED">Volume {0} has been mounted.</entry>
     <entry lang="en" key="LINUX_OOM">Out of memory.</entry>
     <entry lang="en" key="LINUX_CANT_GET_ADMIN_PRIV">Failed to obtain administrator privileges</entry>
     <entry lang="en" key="LINUX_COMMAND_GET_ERROR">Command {0} returned error {1}.</entry>

--- a/Translations/Language.eu.xml
+++ b/Translations/Language.eu.xml
@@ -1521,6 +1521,7 @@
     <entry lang="en" key="LINUX_NOT_SUPPORTED"> (not supported by components available on this platform).\n</entry>
     <entry lang="en" key="LINUX_KERNEL_OLD">Your system uses an old version of the Linux kernel.\n\nDue to a bug in the Linux kernel, your system may stop responding when writing data to a VeraCrypt volume. This problem can be solved by upgrading the kernel to version 2.6.24 or later.</entry>
     <entry lang="en" key="LINUX_VOL_DISMOUNTED">Volume {0} has been dismounted.</entry>
+    <entry lang="en" key="LINUX_VOL_MOUNTED">Volume {0} has been mounted.</entry>
     <entry lang="en" key="LINUX_OOM">Out of memory.</entry>
     <entry lang="en" key="LINUX_CANT_GET_ADMIN_PRIV">Failed to obtain administrator privileges</entry>
     <entry lang="en" key="LINUX_COMMAND_GET_ERROR">Command {0} returned error {1}.</entry>

--- a/Translations/Language.fa.xml
+++ b/Translations/Language.fa.xml
@@ -1521,6 +1521,7 @@
     <entry lang="en" key="LINUX_NOT_SUPPORTED"> (not supported by components available on this platform).\n</entry>
     <entry lang="en" key="LINUX_KERNEL_OLD">Your system uses an old version of the Linux kernel.\n\nDue to a bug in the Linux kernel, your system may stop responding when writing data to a VeraCrypt volume. This problem can be solved by upgrading the kernel to version 2.6.24 or later.</entry>
     <entry lang="en" key="LINUX_VOL_DISMOUNTED">Volume {0} has been dismounted.</entry>
+    <entry lang="en" key="LINUX_VOL_MOUNTED">Volume {0} has been mounted.</entry>
     <entry lang="en" key="LINUX_OOM">Out of memory.</entry>
     <entry lang="en" key="LINUX_CANT_GET_ADMIN_PRIV">Failed to obtain administrator privileges</entry>
     <entry lang="en" key="LINUX_COMMAND_GET_ERROR">Command {0} returned error {1}.</entry>

--- a/Translations/Language.fi.xml
+++ b/Translations/Language.fi.xml
@@ -1521,6 +1521,7 @@
     <entry lang="en" key="LINUX_NOT_SUPPORTED"> (not supported by components available on this platform).\n</entry>
     <entry lang="en" key="LINUX_KERNEL_OLD">Your system uses an old version of the Linux kernel.\n\nDue to a bug in the Linux kernel, your system may stop responding when writing data to a VeraCrypt volume. This problem can be solved by upgrading the kernel to version 2.6.24 or later.</entry>
     <entry lang="en" key="LINUX_VOL_DISMOUNTED">Volume {0} has been dismounted.</entry>
+    <entry lang="en" key="LINUX_VOL_MOUNTED">Volume {0} has been mounted.</entry>
     <entry lang="en" key="LINUX_OOM">Out of memory.</entry>
     <entry lang="en" key="LINUX_CANT_GET_ADMIN_PRIV">Failed to obtain administrator privileges</entry>
     <entry lang="en" key="LINUX_COMMAND_GET_ERROR">Command {0} returned error {1}.</entry>

--- a/Translations/Language.fr.xml
+++ b/Translations/Language.fr.xml
@@ -1521,6 +1521,7 @@
     <entry lang="en" key="LINUX_NOT_SUPPORTED"> (not supported by components available on this platform).\n</entry>
     <entry lang="en" key="LINUX_KERNEL_OLD">Your system uses an old version of the Linux kernel.\n\nDue to a bug in the Linux kernel, your system may stop responding when writing data to a VeraCrypt volume. This problem can be solved by upgrading the kernel to version 2.6.24 or later.</entry>
     <entry lang="en" key="LINUX_VOL_DISMOUNTED">Volume {0} has been dismounted.</entry>
+    <entry lang="en" key="LINUX_VOL_MOUNTED">Volume {0} has been mounted.</entry>
     <entry lang="en" key="LINUX_OOM">Out of memory.</entry>
     <entry lang="en" key="LINUX_CANT_GET_ADMIN_PRIV">Failed to obtain administrator privileges</entry>
     <entry lang="en" key="LINUX_COMMAND_GET_ERROR">Command {0} returned error {1}.</entry>

--- a/Translations/Language.he.xml
+++ b/Translations/Language.he.xml
@@ -1522,6 +1522,7 @@
     <entry lang="he" key="LINUX_NOT_SUPPORTED">(לא נתמך על ידי רכיבים הזמינים בפלטפורמה זו). \n</entry>
     <entry lang="he" key="LINUX_KERNEL_OLD">המערכת שלך משתמשת בגרסה ישנה של ליבת לינוקס. \n \n בשל באג בליבת הלינוקס, המערכת שלך עשויה להפסיק להגיב בעת כתיבת נתונים לאמצעי אחסון VeraCrypt.ניתן לפתור בעיה זו על ידי שדרוג הגרעין לגרסה 2.6.24 ואילך.</entry>
     <entry lang="he" key="LINUX_VOL_DISMOUNTED">אמצעי האחסון {0} הוסר.</entry>
+    <entry lang="en" key="LINUX_VOL_MOUNTED">Volume {0} has been mounted.</entry>
     <entry lang="he" key="LINUX_OOM">מתוך הזיכרון.</entry>
     <entry lang="he" key="LINUX_CANT_GET_ADMIN_PRIV">השגת הרשאות מנהל נכשלה</entry>
     <entry lang="he" key="LINUX_COMMAND_GET_ERROR">הפקודה {0} החזירה שגיאה {1}.</entry>

--- a/Translations/Language.hu.xml
+++ b/Translations/Language.hu.xml
@@ -1521,6 +1521,7 @@
     <entry lang="hu" key="LINUX_NOT_SUPPORTED"> (az aktuális platformon elérhető összetevők nem támogatják).\n</entry>
     <entry lang="hu" key="LINUX_KERNEL_OLD">Rendszere a Linux kernel régi verzióját használja.\n\nA Linux kernel hibája miatt előfordulhat, hogy rendszere nem válaszol, miközben adatokat ír egy VeraCrypt kötetre. Ez a probléma megoldható a kernel 2.6.24-es vagy újabb verziójára történő frissítésével.</entry>
     <entry lang="hu" key="LINUX_VOL_DISMOUNTED">A(z) {0} kötet le van választva.</entry>
+    <entry lang="en" key="LINUX_VOL_MOUNTED">Volume {0} has been mounted.</entry>
     <entry lang="hu" key="LINUX_OOM">Kevés a memória.</entry>
     <entry lang="hu" key="LINUX_CANT_GET_ADMIN_PRIV">Nem sikerült rendszergazdai jogosultságokat szerezni</entry>
     <entry lang="hu" key="LINUX_COMMAND_GET_ERROR">A(z) {0} parancs {1} hibával tért vissza.</entry>

--- a/Translations/Language.id.xml
+++ b/Translations/Language.id.xml
@@ -1521,6 +1521,7 @@
     <entry lang="id" key="LINUX_NOT_SUPPORTED"> (tidak didukung oleh komponen yang tersedia di platform ini).</entry>
     <entry lang="id" key="LINUX_KERNEL_OLD">Sistem Anda menggunakan versi lama dari kernel Linux. Masalah ini dapat diselesaikan dengan memutakhirkan kernel ke versi 2.6.24 atau yang lebih baru.</entry>
     <entry lang="id" key="LINUX_VOL_DISMOUNTED">Volume {0} telah turun.</entry>
+    <entry lang="en" key="LINUX_VOL_MOUNTED">Volume {0} has been mounted.</entry>
     <entry lang="id" key="LINUX_OOM">Kehabisan memori.</entry>
     <entry lang="id" key="LINUX_CANT_GET_ADMIN_PRIV">Gagal mendapatkan hak administrator</entry>
     <entry lang="id" key="LINUX_COMMAND_GET_ERROR">Perintah {0} mengembalikan kesalahan {1}.</entry>

--- a/Translations/Language.it.xml
+++ b/Translations/Language.it.xml
@@ -1521,6 +1521,7 @@
     <entry lang="it" key="LINUX_NOT_SUPPORTED">(non supportato dai componenti disponibili su questa piattaforma).\n</entry>
     <entry lang="it" key="LINUX_KERNEL_OLD">Il sistema usa una vecchia versione del kernel Linux.\n\nA causa di un bug nel kernel Linux, il sistema potrebbe smettere di rispondere quando scrivi dati su un volume VeraCrypt.\nQuesto problema può essere risolto aggiornando il kernel alla versione 2.6.24 o successiva.</entry>
     <entry lang="it" key="LINUX_VOL_DISMOUNTED">Il volume {0} è stato smontato.</entry>
+    <entry lang="en" key="LINUX_VOL_MOUNTED">Volume {0} has been mounted.</entry>
     <entry lang="it" key="LINUX_OOM">Memoria esaurita.</entry>
     <entry lang="it" key="LINUX_CANT_GET_ADMIN_PRIV">Impossibile ottenere i privilegi di amministratore</entry>
     <entry lang="it" key="LINUX_COMMAND_GET_ERROR">Il comando {0} ha restituito un errore {1}.</entry>

--- a/Translations/Language.ja.xml
+++ b/Translations/Language.ja.xml
@@ -1521,6 +1521,7 @@
     <entry lang="en" key="LINUX_NOT_SUPPORTED"> (not supported by components available on this platform).\n</entry>
     <entry lang="en" key="LINUX_KERNEL_OLD">Your system uses an old version of the Linux kernel.\n\nDue to a bug in the Linux kernel, your system may stop responding when writing data to a VeraCrypt volume. This problem can be solved by upgrading the kernel to version 2.6.24 or later.</entry>
     <entry lang="en" key="LINUX_VOL_DISMOUNTED">Volume {0} has been dismounted.</entry>
+    <entry lang="en" key="LINUX_VOL_MOUNTED">Volume {0} has been mounted.</entry>
     <entry lang="en" key="LINUX_OOM">Out of memory.</entry>
     <entry lang="en" key="LINUX_CANT_GET_ADMIN_PRIV">Failed to obtain administrator privileges</entry>
     <entry lang="en" key="LINUX_COMMAND_GET_ERROR">Command {0} returned error {1}.</entry>

--- a/Translations/Language.ka.xml
+++ b/Translations/Language.ka.xml
@@ -1521,6 +1521,7 @@
     <entry lang="en" key="LINUX_NOT_SUPPORTED"> (not supported by components available on this platform).\n</entry>
     <entry lang="en" key="LINUX_KERNEL_OLD">Your system uses an old version of the Linux kernel.\n\nDue to a bug in the Linux kernel, your system may stop responding when writing data to a VeraCrypt volume. This problem can be solved by upgrading the kernel to version 2.6.24 or later.</entry>
     <entry lang="en" key="LINUX_VOL_DISMOUNTED">Volume {0} has been dismounted.</entry>
+    <entry lang="en" key="LINUX_VOL_MOUNTED">Volume {0} has been mounted.</entry>
     <entry lang="en" key="LINUX_OOM">Out of memory.</entry>
     <entry lang="en" key="LINUX_CANT_GET_ADMIN_PRIV">Failed to obtain administrator privileges</entry>
     <entry lang="en" key="LINUX_COMMAND_GET_ERROR">Command {0} returned error {1}.</entry>

--- a/Translations/Language.ko.xml
+++ b/Translations/Language.ko.xml
@@ -1521,6 +1521,7 @@
     <entry lang="ko" key="LINUX_NOT_SUPPORTED"> (이 플랫폼의 구성요소로는 지원되지 않습니다).\n</entry>
     <entry lang="ko" key="LINUX_KERNEL_OLD">시스템이 오래된 Linux 커널을 사용하고 있습니다.\n\nLinux 커널의 버그로 인해, VeraCrypt 볼륨으로 데이터 작성 중에 시스템이 응답을 중단할 수도 있습니다. 이 문제는 커널을 2.6.24 혹은 더 높은 버전으로 업그레이드하면 해결됩니다.</entry>
     <entry lang="ko" key="LINUX_VOL_DISMOUNTED">{0} 볼륨이 마운트 해제되었습니다.</entry>
+    <entry lang="en" key="LINUX_VOL_MOUNTED">Volume {0} has been mounted.</entry>
     <entry lang="ko" key="LINUX_OOM">메모리 부족.</entry>
     <entry lang="ko" key="LINUX_CANT_GET_ADMIN_PRIV">관리자 권한을 취득하는데에 실패했습니다.</entry>
     <entry lang="ko" key="LINUX_COMMAND_GET_ERROR">{0} 명령어가 {1} 오류를 반환하였습니다.</entry>

--- a/Translations/Language.lv.xml
+++ b/Translations/Language.lv.xml
@@ -1521,6 +1521,7 @@
     <entry lang="en" key="LINUX_NOT_SUPPORTED"> (not supported by components available on this platform).\n</entry>
     <entry lang="en" key="LINUX_KERNEL_OLD">Your system uses an old version of the Linux kernel.\n\nDue to a bug in the Linux kernel, your system may stop responding when writing data to a VeraCrypt volume. This problem can be solved by upgrading the kernel to version 2.6.24 or later.</entry>
     <entry lang="en" key="LINUX_VOL_DISMOUNTED">Volume {0} has been dismounted.</entry>
+    <entry lang="en" key="LINUX_VOL_MOUNTED">Volume {0} has been mounted.</entry>
     <entry lang="en" key="LINUX_OOM">Out of memory.</entry>
     <entry lang="en" key="LINUX_CANT_GET_ADMIN_PRIV">Failed to obtain administrator privileges</entry>
     <entry lang="en" key="LINUX_COMMAND_GET_ERROR">Command {0} returned error {1}.</entry>

--- a/Translations/Language.my.xml
+++ b/Translations/Language.my.xml
@@ -1523,6 +1523,7 @@
     <entry lang="my" key="LINUX_NOT_SUPPORTED">(ဤပလက်ဖောင်းတွင် ရရှိနိုင်သော အစိတ်အပိုင်းများက မပံ့ပိုးပါ)။\n</entry>
     <entry lang="my" key="LINUX_KERNEL_OLD">သင့်စနစ်သည် Linux kernel ၏ ဗားရှင်းဟောင်းကို အသုံးပြုသည်။\n\nLinux kernel ရှိ ပြဿနာတစ်ခုကြောင့် VeraCrypt volume တစ်ခုသို့ ဒေတာရေးစဉ် သင့်စနစ် ရပ်သွားနိုင်သည်။ ဤပြဿနာကို ဖြေရှင်းရန် kernel ကို ဗားရှင်း ၂.၆.၂၄ သို့မဟုတ် နောက်ပိုင်းဗားရှင်းသို့ အဆင့်မြှင့်နိုင်သည်။</entry>
     <entry lang="my" key="LINUX_VOL_DISMOUNTED">Volume {0} ကို အဆုံးသတ်လိုက်ပါပြီ။</entry>
+    <entry lang="en" key="LINUX_VOL_MOUNTED">Volume {0} has been mounted.</entry>
     <entry lang="my" key="LINUX_OOM">မမ်မိုရီ မကျန်တော့ပါ။</entry>
     <entry lang="my" key="LINUX_CANT_GET_ADMIN_PRIV">စီမံအုပ်ချုပ်သူ အခွင့်ထူးများကို ရယူခြင်း မအောင်မြင်ပါ</entry>
     <entry lang="my" key="LINUX_COMMAND_GET_ERROR">ညွှန်ကြားချက် {0} က ပြဿနာ {1} ကို ပြန်ပို့ပေးသည်။</entry>

--- a/Translations/Language.nl.xml
+++ b/Translations/Language.nl.xml
@@ -1531,6 +1531,7 @@ Merk op dat VeraCrypt in dit geval niet de exacte maximaal toegestane grootte vo
     <entry lang="nl" key="LINUX_NOT_SUPPORTED"> (niet ondersteund door onderdelen beschikbaar op dit platform).\n</entry>
     <entry lang="nl" key="LINUX_KERNEL_OLD">Uw systeem gebruikt een oude versie van de Linux-kernel.\n\nDoor een bug in de Linux-kernel kan uw systeem stoppen met reageren bij het schrijven van gegevens naar een VeraCrypt-volume. Dit probleem kan worden opgelost door de kernel te upgraden naar versie 2.6.24 of later.</entry>
     <entry lang="nl" key="LINUX_VOL_DISMOUNTED">Volume {0} is ontkoppeld.</entry>
+    <entry lang="en" key="LINUX_VOL_MOUNTED">Volume {0} has been mounted.</entry>
     <entry lang="nl" key="LINUX_OOM">Onvoldoende geheugen.</entry>
     <entry lang="nl" key="LINUX_CANT_GET_ADMIN_PRIV">Geen beheerdersrechten verkregen</entry>
     <entry lang="nl" key="LINUX_COMMAND_GET_ERROR">Opdracht {0} gaf fout {1}.</entry>

--- a/Translations/Language.nn.xml
+++ b/Translations/Language.nn.xml
@@ -1521,6 +1521,7 @@
     <entry lang="en" key="LINUX_NOT_SUPPORTED"> (not supported by components available on this platform).\n</entry>
     <entry lang="en" key="LINUX_KERNEL_OLD">Your system uses an old version of the Linux kernel.\n\nDue to a bug in the Linux kernel, your system may stop responding when writing data to a VeraCrypt volume. This problem can be solved by upgrading the kernel to version 2.6.24 or later.</entry>
     <entry lang="en" key="LINUX_VOL_DISMOUNTED">Volume {0} has been dismounted.</entry>
+    <entry lang="en" key="LINUX_VOL_MOUNTED">Volume {0} has been mounted.</entry>
     <entry lang="en" key="LINUX_OOM">Out of memory.</entry>
     <entry lang="en" key="LINUX_CANT_GET_ADMIN_PRIV">Failed to obtain administrator privileges</entry>
     <entry lang="en" key="LINUX_COMMAND_GET_ERROR">Command {0} returned error {1}.</entry>

--- a/Translations/Language.pl.xml
+++ b/Translations/Language.pl.xml
@@ -1521,6 +1521,7 @@
     <entry lang="pl" key="LINUX_NOT_SUPPORTED"> (nieobsługiwane przez komponenty dostępne na tej platformie).\n</entry>
     <entry lang="pl" key="LINUX_KERNEL_OLD">Twój system używa starej wersji jądra Linuksa.\n\nZ powodu błędu w jądrze Linuksa Twój system może przestać odpowiadać podczas zapisywania danych do wolumenu VeraCrypt. Ten problem można rozwiązać, aktualizując jądro do wersji 2.6.24 lub nowszej.</entry>
     <entry lang="pl" key="LINUX_VOL_DISMOUNTED">Wolumen {0} został odłączony.</entry>
+    <entry lang="en" key="LINUX_VOL_MOUNTED">Volume {0} has been mounted.</entry>
     <entry lang="pl" key="LINUX_OOM">Brak pamięci.</entry>
     <entry lang="pl" key="LINUX_CANT_GET_ADMIN_PRIV">Nie udało się uzyskać uprawnień administratora</entry>
     <entry lang="pl" key="LINUX_COMMAND_GET_ERROR">Polecenie {0} zwróciło błąd {1}.</entry>

--- a/Translations/Language.pt-br.xml
+++ b/Translations/Language.pt-br.xml
@@ -1521,6 +1521,7 @@
     <entry lang="en" key="LINUX_NOT_SUPPORTED"> (not supported by components available on this platform).\n</entry>
     <entry lang="en" key="LINUX_KERNEL_OLD">Your system uses an old version of the Linux kernel.\n\nDue to a bug in the Linux kernel, your system may stop responding when writing data to a VeraCrypt volume. This problem can be solved by upgrading the kernel to version 2.6.24 or later.</entry>
     <entry lang="en" key="LINUX_VOL_DISMOUNTED">Volume {0} has been dismounted.</entry>
+    <entry lang="en" key="LINUX_VOL_MOUNTED">Volume {0} has been mounted.</entry>
     <entry lang="en" key="LINUX_OOM">Out of memory.</entry>
     <entry lang="en" key="LINUX_CANT_GET_ADMIN_PRIV">Failed to obtain administrator privileges</entry>
     <entry lang="en" key="LINUX_COMMAND_GET_ERROR">Command {0} returned error {1}.</entry>

--- a/Translations/Language.ro.xml
+++ b/Translations/Language.ro.xml
@@ -1521,6 +1521,7 @@
     <entry lang="en" key="LINUX_NOT_SUPPORTED"> (not supported by components available on this platform).\n</entry>
     <entry lang="en" key="LINUX_KERNEL_OLD">Your system uses an old version of the Linux kernel.\n\nDue to a bug in the Linux kernel, your system may stop responding when writing data to a VeraCrypt volume. This problem can be solved by upgrading the kernel to version 2.6.24 or later.</entry>
     <entry lang="en" key="LINUX_VOL_DISMOUNTED">Volume {0} has been dismounted.</entry>
+    <entry lang="en" key="LINUX_VOL_MOUNTED">Volume {0} has been mounted.</entry>
     <entry lang="en" key="LINUX_OOM">Out of memory.</entry>
     <entry lang="en" key="LINUX_CANT_GET_ADMIN_PRIV">Failed to obtain administrator privileges</entry>
     <entry lang="en" key="LINUX_COMMAND_GET_ERROR">Command {0} returned error {1}.</entry>

--- a/Translations/Language.ru.xml
+++ b/Translations/Language.ru.xml
@@ -1521,6 +1521,7 @@
     <entry lang="ru" key="LINUX_NOT_SUPPORTED"> (не поддерживается компонентами, доступными на этой платформе).\n</entry>
     <entry lang="ru" key="LINUX_KERNEL_OLD">Ваша система использует старую версию ядра Linux.\n\nИз-за ошибки в ядре Linux система может перестать отвечать на запросы при записи данных на том VeraCrypt. Эта проблема решается обновлением ядра до версии 2.6.24 или более новой.</entry>
     <entry lang="ru" key="LINUX_VOL_DISMOUNTED">Том {0} размонтирован.</entry>
+    <entry lang="en" key="LINUX_VOL_MOUNTED">Volume {0} has been mounted.</entry>
     <entry lang="ru" key="LINUX_OOM">Недостаточно памяти.</entry>
     <entry lang="ru" key="LINUX_CANT_GET_ADMIN_PRIV">Не удалось получить права администратора</entry>
     <entry lang="ru" key="LINUX_COMMAND_GET_ERROR">Команда {0} возвратила ошибку {1}.</entry>

--- a/Translations/Language.sk.xml
+++ b/Translations/Language.sk.xml
@@ -1521,6 +1521,7 @@
     <entry lang="en" key="LINUX_NOT_SUPPORTED"> (not supported by components available on this platform).\n</entry>
     <entry lang="en" key="LINUX_KERNEL_OLD">Your system uses an old version of the Linux kernel.\n\nDue to a bug in the Linux kernel, your system may stop responding when writing data to a VeraCrypt volume. This problem can be solved by upgrading the kernel to version 2.6.24 or later.</entry>
     <entry lang="en" key="LINUX_VOL_DISMOUNTED">Volume {0} has been dismounted.</entry>
+    <entry lang="en" key="LINUX_VOL_MOUNTED">Volume {0} has been mounted.</entry>
     <entry lang="en" key="LINUX_OOM">Out of memory.</entry>
     <entry lang="en" key="LINUX_CANT_GET_ADMIN_PRIV">Failed to obtain administrator privileges</entry>
     <entry lang="en" key="LINUX_COMMAND_GET_ERROR">Command {0} returned error {1}.</entry>

--- a/Translations/Language.sl.xml
+++ b/Translations/Language.sl.xml
@@ -1521,6 +1521,7 @@
     <entry lang="en" key="LINUX_NOT_SUPPORTED"> (not supported by components available on this platform).\n</entry>
     <entry lang="en" key="LINUX_KERNEL_OLD">Your system uses an old version of the Linux kernel.\n\nDue to a bug in the Linux kernel, your system may stop responding when writing data to a VeraCrypt volume. This problem can be solved by upgrading the kernel to version 2.6.24 or later.</entry>
     <entry lang="en" key="LINUX_VOL_DISMOUNTED">Volume {0} has been dismounted.</entry>
+    <entry lang="en" key="LINUX_VOL_MOUNTED">Volume {0} has been mounted.</entry>
     <entry lang="en" key="LINUX_OOM">Out of memory.</entry>
     <entry lang="en" key="LINUX_CANT_GET_ADMIN_PRIV">Failed to obtain administrator privileges</entry>
     <entry lang="en" key="LINUX_COMMAND_GET_ERROR">Command {0} returned error {1}.</entry>

--- a/Translations/Language.sv.xml
+++ b/Translations/Language.sv.xml
@@ -1521,6 +1521,7 @@
     <entry lang="en" key="LINUX_NOT_SUPPORTED"> (not supported by components available on this platform).\n</entry>
     <entry lang="en" key="LINUX_KERNEL_OLD">Your system uses an old version of the Linux kernel.\n\nDue to a bug in the Linux kernel, your system may stop responding when writing data to a VeraCrypt volume. This problem can be solved by upgrading the kernel to version 2.6.24 or later.</entry>
     <entry lang="en" key="LINUX_VOL_DISMOUNTED">Volume {0} has been dismounted.</entry>
+    <entry lang="en" key="LINUX_VOL_MOUNTED">Volume {0} has been mounted.</entry>
     <entry lang="en" key="LINUX_OOM">Out of memory.</entry>
     <entry lang="en" key="LINUX_CANT_GET_ADMIN_PRIV">Failed to obtain administrator privileges</entry>
     <entry lang="en" key="LINUX_COMMAND_GET_ERROR">Command {0} returned error {1}.</entry>

--- a/Translations/Language.th.xml
+++ b/Translations/Language.th.xml
@@ -1522,6 +1522,7 @@
     <entry lang="en" key="LINUX_NOT_SUPPORTED"> (not supported by components available on this platform).\n</entry>
     <entry lang="en" key="LINUX_KERNEL_OLD">Your system uses an old version of the Linux kernel.\n\nDue to a bug in the Linux kernel, your system may stop responding when writing data to a VeraCrypt volume. This problem can be solved by upgrading the kernel to version 2.6.24 or later.</entry>
     <entry lang="en" key="LINUX_VOL_DISMOUNTED">Volume {0} has been dismounted.</entry>
+    <entry lang="en" key="LINUX_VOL_MOUNTED">Volume {0} has been mounted.</entry>
     <entry lang="en" key="LINUX_OOM">Out of memory.</entry>
     <entry lang="en" key="LINUX_CANT_GET_ADMIN_PRIV">Failed to obtain administrator privileges</entry>
     <entry lang="en" key="LINUX_COMMAND_GET_ERROR">Command {0} returned error {1}.</entry>

--- a/Translations/Language.tr.xml
+++ b/Translations/Language.tr.xml
@@ -1521,6 +1521,7 @@
     <entry lang="tr" key="LINUX_NOT_SUPPORTED"> (Bu platformda bulunan bileşenler tarafından desteklenmez).\n</entry>
     <entry lang="tr" key="LINUX_KERNEL_OLD">Sisteminiz Linux çekirdeğinin eski bir sürümünü kullanıyor.\n\nLinux çekirdeğindeki bir hata nedeniyle, sisteminiz bir VeraCrypt birimine veri yazarken yanıt vermeyebilir. Bu sorun, çekirdeği 2.6.24 veya sonraki bir sürüme yükselterek çözülebilir..</entry>
     <entry lang="tr" key="LINUX_VOL_DISMOUNTED">{0} birimi kaldırıldı.</entry>
+    <entry lang="en" key="LINUX_VOL_MOUNTED">Volume {0} has been mounted.</entry>
     <entry lang="tr" key="LINUX_OOM">Bellek yetersiz.</entry>
     <entry lang="tr" key="LINUX_CANT_GET_ADMIN_PRIV">Yönetici ayrıcalıkları alınamadı</entry>
     <entry lang="tr" key="LINUX_COMMAND_GET_ERROR">{0} komutu {1} hatası verdi.</entry>

--- a/Translations/Language.uk.xml
+++ b/Translations/Language.uk.xml
@@ -1521,6 +1521,7 @@
     <entry lang="en" key="LINUX_NOT_SUPPORTED"> (not supported by components available on this platform).\n</entry>
     <entry lang="en" key="LINUX_KERNEL_OLD">Your system uses an old version of the Linux kernel.\n\nDue to a bug in the Linux kernel, your system may stop responding when writing data to a VeraCrypt volume. This problem can be solved by upgrading the kernel to version 2.6.24 or later.</entry>
     <entry lang="en" key="LINUX_VOL_DISMOUNTED">Volume {0} has been dismounted.</entry>
+    <entry lang="en" key="LINUX_VOL_MOUNTED">Volume {0} has been mounted.</entry>
     <entry lang="en" key="LINUX_OOM">Out of memory.</entry>
     <entry lang="en" key="LINUX_CANT_GET_ADMIN_PRIV">Failed to obtain administrator privileges</entry>
     <entry lang="en" key="LINUX_COMMAND_GET_ERROR">Command {0} returned error {1}.</entry>

--- a/Translations/Language.uz.xml
+++ b/Translations/Language.uz.xml
@@ -1521,6 +1521,7 @@
     <entry lang="en" key="LINUX_NOT_SUPPORTED"> (not supported by components available on this platform).\n</entry>
     <entry lang="en" key="LINUX_KERNEL_OLD">Your system uses an old version of the Linux kernel.\n\nDue to a bug in the Linux kernel, your system may stop responding when writing data to a VeraCrypt volume. This problem can be solved by upgrading the kernel to version 2.6.24 or later.</entry>
     <entry lang="en" key="LINUX_VOL_DISMOUNTED">Volume {0} has been dismounted.</entry>
+    <entry lang="en" key="LINUX_VOL_MOUNTED">Volume {0} has been mounted.</entry>
     <entry lang="en" key="LINUX_OOM">Out of memory.</entry>
     <entry lang="en" key="LINUX_CANT_GET_ADMIN_PRIV">Failed to obtain administrator privileges</entry>
     <entry lang="en" key="LINUX_COMMAND_GET_ERROR">Command {0} returned error {1}.</entry>

--- a/Translations/Language.vi.xml
+++ b/Translations/Language.vi.xml
@@ -1521,6 +1521,7 @@
     <entry lang="en" key="LINUX_NOT_SUPPORTED"> (not supported by components available on this platform).\n</entry>
     <entry lang="en" key="LINUX_KERNEL_OLD">Your system uses an old version of the Linux kernel.\n\nDue to a bug in the Linux kernel, your system may stop responding when writing data to a VeraCrypt volume. This problem can be solved by upgrading the kernel to version 2.6.24 or later.</entry>
     <entry lang="en" key="LINUX_VOL_DISMOUNTED">Volume {0} has been dismounted.</entry>
+    <entry lang="en" key="LINUX_VOL_MOUNTED">Volume {0} has been mounted.</entry>
     <entry lang="en" key="LINUX_OOM">Out of memory.</entry>
     <entry lang="en" key="LINUX_CANT_GET_ADMIN_PRIV">Failed to obtain administrator privileges</entry>
     <entry lang="en" key="LINUX_COMMAND_GET_ERROR">Command {0} returned error {1}.</entry>

--- a/Translations/Language.zh-cn.xml
+++ b/Translations/Language.zh-cn.xml
@@ -1521,6 +1521,7 @@
     <entry lang="zh-cn" key="LINUX_NOT_SUPPORTED"> (此平台上可用的组件不支持).\n</entry>
     <entry lang="zh-cn" key="LINUX_KERNEL_OLD">您的系统使用的是旧版本Linux内核。\n\n由于Linux内核中的错误，在将数据写入VeraCrypt卷时，系统可能会停止响应。这个问题可以通过将内核升级到2.6.24或更高版本来解决。</entry>
     <entry lang="zh-cn" key="LINUX_VOL_DISMOUNTED">卷{0}已卸载。</entry>
+    <entry lang="en" key="LINUX_VOL_MOUNTED">Volume {0} has been mounted.</entry>
     <entry lang="zh-cn" key="LINUX_OOM">内存不足。</entry>
     <entry lang="zh-cn" key="LINUX_CANT_GET_ADMIN_PRIV">获取管理员权限失败</entry>
     <entry lang="zh-cn" key="LINUX_COMMAND_GET_ERROR">命令{0}返回错误{1}.</entry>

--- a/Translations/Language.zh-hk.xml
+++ b/Translations/Language.zh-hk.xml
@@ -1521,6 +1521,7 @@
     <entry lang="en" key="LINUX_NOT_SUPPORTED"> (not supported by components available on this platform).\n</entry>
     <entry lang="en" key="LINUX_KERNEL_OLD">Your system uses an old version of the Linux kernel.\n\nDue to a bug in the Linux kernel, your system may stop responding when writing data to a VeraCrypt volume. This problem can be solved by upgrading the kernel to version 2.6.24 or later.</entry>
     <entry lang="en" key="LINUX_VOL_DISMOUNTED">Volume {0} has been dismounted.</entry>
+    <entry lang="en" key="LINUX_VOL_MOUNTED">Volume {0} has been mounted.</entry>
     <entry lang="en" key="LINUX_OOM">Out of memory.</entry>
     <entry lang="en" key="LINUX_CANT_GET_ADMIN_PRIV">Failed to obtain administrator privileges</entry>
     <entry lang="en" key="LINUX_COMMAND_GET_ERROR">Command {0} returned error {1}.</entry>

--- a/Translations/Language.zh-tw.xml
+++ b/Translations/Language.zh-tw.xml
@@ -1521,6 +1521,7 @@
     <entry lang="en" key="LINUX_NOT_SUPPORTED"> (not supported by components available on this platform).\n</entry>
     <entry lang="en" key="LINUX_KERNEL_OLD">Your system uses an old version of the Linux kernel.\n\nDue to a bug in the Linux kernel, your system may stop responding when writing data to a VeraCrypt volume. This problem can be solved by upgrading the kernel to version 2.6.24 or later.</entry>
     <entry lang="en" key="LINUX_VOL_DISMOUNTED">Volume {0} has been dismounted.</entry>
+    <entry lang="en" key="LINUX_VOL_MOUNTED">Volume {0} has been mounted.</entry>
     <entry lang="en" key="LINUX_OOM">Out of memory.</entry>
     <entry lang="en" key="LINUX_CANT_GET_ADMIN_PRIV">Failed to obtain administrator privileges</entry>
     <entry lang="en" key="LINUX_COMMAND_GET_ERROR">Command {0} returned error {1}.</entry>

--- a/src/Common/Language.xml
+++ b/src/Common/Language.xml
@@ -1521,6 +1521,7 @@
     <entry lang="en" key="LINUX_NOT_SUPPORTED"> (not supported by components available on this platform).\n</entry>
     <entry lang="en" key="LINUX_KERNEL_OLD">Your system uses an old version of the Linux kernel.\n\nDue to a bug in the Linux kernel, your system may stop responding when writing data to a VeraCrypt volume. This problem can be solved by upgrading the kernel to version 2.6.24 or later.</entry>
     <entry lang="en" key="LINUX_VOL_DISMOUNTED">Volume {0} has been dismounted.</entry>
+    <entry lang="en" key="LINUX_VOL_MOUNTED">Volume {0} has been mounted.</entry>
     <entry lang="en" key="LINUX_OOM">Out of memory.</entry>
     <entry lang="en" key="LINUX_CANT_GET_ADMIN_PRIV">Failed to obtain administrator privileges</entry>
     <entry lang="en" key="LINUX_COMMAND_GET_ERROR">Command {0} returned error {1}.</entry>

--- a/src/Main/UserInterface.cpp
+++ b/src/Main/UserInterface.cpp
@@ -1008,7 +1008,7 @@ namespace VeraCrypt
 					{
 						if (!message.IsEmpty())
 							message += L'\n';
-						message += StringFormatter (LangString["LINUX_VOL_DISMOUNTED"], wstring (volume.Path));
+						message += StringFormatter (LangString["LINUX_VOL_MOUNTED"], wstring (volume.Path));
 					}
 					ShowInfo (message);
 				}


### PR DESCRIPTION
Currently on Linux when mounting a volume with -v verbose flag on, regardless of mounting or -d dismounting, you'll get the message of `Volume {0} has been dismounted.`. If I understood this correctly, in `UserInterface.cpp` -> `UserInterface::ProcessCommandLine` incorrectly uses `LINUX_VOL_DISMOUNTED` LangString when mounting with verbosity on.

I couldn't find a fitting existing LangString that conveyed the "has been mounted", so I created a new one called `LINUX_VOL_MOUNTED`.