### PR TITLE
Fix mount.veracrypt external helper

### DIFF
--- a/src/Setup/Linux/mount.veracrypt
+++ b/src/Setup/Linux/mount.veracrypt
@@ -13,11 +13,11 @@ for arg in $*; do
     fs=*)             VCOPTIONS=(${VCOPTIONS[*]} --filesystem=${arg#*=});;
     keyfiles=*)       VCOPTIONS=(${VCOPTIONS[*]} --keyfiles=${arg#*=});;
     password=*)       VCOPTIONS=(${VCOPTIONS[*]} --password=${arg#*=});;
-    pim=*)            VCOPTIONS=(${VCOPTIONS[*]} --pim==${arg#*=});;
+    pim=*)            VCOPTIONS=(${VCOPTIONS[*]} --pim=${arg#*=});;
     protect-hidden=*) VCOPTIONS=(${VCOPTIONS[*]} --protect-hidden=${arg#*=});;
     slot=*)           VCOPTIONS=(${VCOPTIONS[*]} --slot=${arg#*=});;
     *)                OPTIONS="${OPTIONS}${arg},";;
   esac
 done
 
-/usr/bin/veracrypt --non-interactive --text ${VCOPTIONS[*]} --fs-options="${OPTIONS%,*}" ${DEV} ${MNTPT}
+/usr/bin/veracrypt --text --non-interactive ${VCOPTIONS[*]} --fs-options="${OPTIONS%,*}" ${DEV} ${MNTPT}


### PR DESCRIPTION
`mount.veracrypt` is executed with the parameters from `/etc/fstab` when the fs-type is set to veracrypt. This allows one to mount a volume on boot without other tools such as cryptsetup.

This PR reverses order of --non-interactive and --text to actually make it run, also parse --pim correctly.

For testing, example usage in `/etc/fstab`:
`/home/user/volume.hc /media/veracrypt1 veracrypt password=mysecret,pim=0,nofail 0 0`

Though another way to pass in passwords and pim is preferred as these can be seen in process list (see ps(1)). Though when volume is mounted this way on boot, it is not recognized by Veracrypt which seems like a bug.
