### PR TITLE
Fix WXSTATIC building on latest wxWidgets stable 3.2.2.1

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -453,7 +453,7 @@ WX_CONFIGURE_FLAGS += --enable-unicode -disable-shared --disable-dependency-trac
 
 ifdef VC_WX_MINIMAL
 WX_CONFIGURE_FLAGS += --disable-protocol --disable-protocols --disable-url --disable-ipc --disable-sockets --disable-fs_inet --disable-ole --disable-docview --disable-clipboard \
-	--disable-help --disable-html --disable-mshtmlhelp --disable-htmlhelp --disable-mdi --disable-metafile --disable-webkit --disable-webview \
+	--disable-help --disable-html --disable-mshtmlhelp --disable-htmlhelp --disable-mdi --disable-metafile --disable-addremovectrl --disable-webview \
 	--disable-xrc --disable-aui --disable-postscript --disable-printarch \
 	--disable-arcstream --disable-fs_archive --disable-fs_zip --disable-tarstream --disable-zipstream \
 	--disable-animatectrl --disable-bmpcombobox --disable-calendar --disable-caret --disable-checklst --disable-collpane --disable-colourpicker --disable-comboctrl \


### PR DESCRIPTION
I was writing very elaborate Makefile parsing the wxWidgets version number from $(WX_ROOT)/include/wx/version.h to add/remove ./configure flags based on the version number, until I realized it would become quite crowded if we keep supporting the working VC_WX_MINIMAL flags for older wxWidget versions. I already have it mostly working, but I'm not sure if there is point to it. If we just care about the minimal build working on the latest stable, this MR fixes it.

Changes to be able to wxbuild with latest wxWidgets stable 3.2.2.1.

Removed in 3.1.5, needs to be removed.
--disable-webkit

Added in 3.1.0, needs to be added.
--disable-addremovectrl