### PR TITLE
Update Corsican translation on 2023-06 (4th)

### DIFF
--- a/Translations/Language.co.xml
+++ b/Translations/Language.co.xml
@@ -7,11 +7,8 @@ Information about Corsican localization:
 
 2. History of Corsican translation for Notepad++:
 
-	- Updated on June 5th, 2023 for version 1.26.2 by Patriccollu di Santa Maria è Sichè
-	- Updated on June 2nd, 2023 for version 1.26 by Patriccollu di Santa Maria è Sichè
-	- Updated on June 1st, 2023 for version 1.26 by Patriccollu di Santa Maria è Sichè
-	- Updated on May 30th, 2023 for version 1.26 by Patriccollu di Santa Maria è Sichè
-	- Updated on May 29th, 2023 for version 1.26 by Patriccollu di Santa Maria è Sichè
+	- Updated in 2023 by Patriccollu di Santa Maria è Sichè: May 29th (1.26), May 30th (1.26), June 1st (1.26),
+	          June 2nd (1.26), June 5th (1.26.2), June 21st (1.26.2)
 	- Updated on March 23rd, 2022 for version 1.26 by Patriccollu di Santa Maria è Sichè
 	- Created on March 6th, 2022 for version 1.25.9 by Patriccollu di Santa Maria è Sichè
 
@@ -20,7 +17,7 @@ Information about Corsican localization:
 -->
 <VeraCrypt>
 	<localization prog-version="1.26.2">
-		<language langid="co" name="Corsu" en-name="Corsican" version="1.3.2" translators="Patriccollu di Santa Maria è Sichè"/>
+		<language langid="co" name="Corsu" en-name="Corsican" version="1.3.4" translators="Patriccollu di Santa Maria è Sichè"/>
 		<font lang="co" class="normal" size="11" face="default"/>
 		<font lang="co" class="bold" size="13" face="Arial"/>
 		<font lang="co" class="fixed" size="12" face="Lucida Console"/>
@@ -374,9 +371,9 @@ Information about Corsican localization:
 		<entry lang="co" key="IDT_KEYFILE_GENERATOR_NOTE">IMPURTANTE : Dispiazzate u vostru topu in sta finestra u più à l’azardu ch’ellu hè pussibule. Ancu megliu s’ella dura un pezzu. Què megliureghja cunsiderabilmente a forza crittografica di u schedariu chjave.</entry>
 		<entry lang="co" key="IDT_KEYFILE_WARNING">AVERTIMENTU : S’è vo pirdite un schedariu chjave o s’è un solu bit di i so 1024 primi chiloottetti cambia, serà impussibule di muntà i vulumi chì impieganu stu schedariu chjave !</entry>
 		<entry lang="co" key="IDT_KEY_UNIT">bits</entry>
-		<entry lang="co" key="IDT_NUMBER_KEYFILES">Numeru di sch. chjave :</entry>
-		<entry lang="co" key="IDT_KEYFILES_SIZE">Dimens. di i sch. chjave :</entry>
-		<entry lang="co" key="IDT_KEYFILES_BASE_NAME">Nome di basa di i sch. chjave :</entry>
+		<entry lang="co" key="IDT_NUMBER_KEYFILES">Numeru di schedarii chjave :</entry>
+		<entry lang="co" key="IDT_KEYFILES_SIZE">Dimensione di i schedarii chjave :</entry>
+		<entry lang="co" key="IDT_KEYFILES_BASE_NAME">Nome di basa di i schedarii chjave :</entry>
 		<entry lang="co" key="IDT_LANGPACK_AUTHORS">Traduttu da :</entry>
 		<entry lang="co" key="IDT_PLAINTEXT">Dimensione di u testu in chjaru :</entry>
 		<entry lang="co" key="IDT_PLAINTEXT_SIZE_UNIT">bits</entry>
@@ -957,7 +954,7 @@ Information about Corsican localization:
 		<entry lang="co" key="ENTER_HEADER_BACKUP_PASSWORD">Stampittate a parolla d’intesa per l°intestatura piazzata in u schedariu di salvaguardia</entry>
 		<entry lang="co" key="KEYFILE_CREATED">I schedarii chjave sò stati creati currettamente.</entry>
 		<entry lang="co" key="KEYFILE_INCORRECT_NUMBER">U numeru di schedarii chjave stampittatu hè inaccettevule.</entry>
-		<entry lang="en" key="KEYFILE_INCORRECT_SIZE">The keyfile size must be at least 64 bytes.</entry>
+		<entry lang="co" key="KEYFILE_INCORRECT_SIZE">A dimensione di u schedariu chjave deve esse più maiò chè 64 ottetti.</entry>
 		<entry lang="co" key="KEYFILE_EMPTY_BASE_NAME">Stampittate un nome per u(i) schedariu(i) chjave chì hà(anu) da esse ingeneratu(i)</entry>
 		<entry lang="co" key="KEYFILE_INVALID_BASE_NAME">U nome di basa di u(i) schedariu(i) chjave hè inaccettevule</entry>
 		<entry lang="co" key="KEYFILE_ALREADY_EXISTS">U schedariu chjave « %s » esiste dighjà.\nVulete rimpiazzallu ? U trattamentu di generazione serà piantatu s’è vò rispundite Nò.</entry>


### PR DESCRIPTION
Hello,

This is an update of **Corsican** (co) localization to take this commit into account:

 * https://github.com/veracrypt/VeraCrypt/commit/fbb1d180348f027974269dc22696a9d74a47f61d Windows: Allow selecting size unit (KB/MB/GB) for generated keyfiles

I also reduced the size of comment - regarding History of Corsican translation - at the beginning of file.

Cheers,
Patriccollu.