### PR TITLE
Update .gitignore with .idea/ and blake2s build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # For those using Visual Studio Code for development
 .vscode/
 
+# CLion
+.idea/
+
 # VC Linux build artifacts
 *.o
 *.o0
@@ -11,6 +14,8 @@
 *.txt.h
 *.h.gch
 src/Main/veracrypt
+*.osse41
+*.ossse3
 
 # VC macOS build artifacts
 src/Main/VeraCrypt


### PR DESCRIPTION
Ignores src/Crypto/blake2s_SSE41.osse41 and src/Crypto/blake2s_SSSE3.ossse3 build artifacts and CLion specific project folder.