### PR TITLE
Linux: Overwriting file container allows you to use its previous space

### DIFF
--- a/src/Main/Forms/VolumeSizeWizardPage.cpp
+++ b/src/Main/Forms/VolumeSizeWizardPage.cpp
@@ -39,6 +39,12 @@ namespace VeraCrypt
 		}
 		else
 		{
+			if (!volumePath.IsDevice())
+			{
+				wxULongLong containerSizeUnsigned = wxFileName (wstring (volumePath)).GetSize();
+				if (containerSizeUnsigned != wxInvalidSize)
+					diskSpace += static_cast<wxLongLong_t>(containerSizeUnsigned.GetValue());
+			}
 			AvailableDiskSpace = (uint64) diskSpace.GetValue ();
 		}
 


### PR DESCRIPTION
When replacing a file container, we increase the `diskSpace` by the file container's size. This doesn't affect the hidden volume space logic, as in that case we use `MaxVolumeSize` when `MaxVolumeSizeValid` is true instead of `AvailableDiskSpace`.