### PR TITLE
Add note about Linux usage to docs

### DIFF
--- a/doc/html/Command Line Usage.html
+++ b/doc/html/Command Line Usage.html
@@ -239,7 +239,7 @@ It must be followed by a parameter indicating the PRF hash algorithm to use when
 <tr>
 <td>/encryption</td>
 <td>(Only with /create)<br>
-It must be followed by a parameter indicating the encryption algorithm to use. The default is AES if this switch is not specified. The parameter can have the following values (case insensitive):
+It must be followed by a parameter indicating the encryption algorithm to use. The default is AES if this switch is not specified. The parameter can have the following values (case insensitive). Note that on Linux AES(Twofish) becomes AES-Twofish:
 <ul>
 <li>AES </li><li>Serpent </li><li>Twofish </li><li>Camellia </li><li>Kuznyechik </li><li>AES(Twofish) </li><li>AES(Twofish(Serpent)) </li><li>Serpent(AES) </li><li>Serpent(Twofish(AES)) </li><li>Twofish(Serpent) </li>
 <li>Camellia(Kuznyechik) </li>


### PR DESCRIPTION
Docs specify cascading encryption should be specified as "AES(Twofish)" but on Linux it requires "AES-Twofish". This also is not documented by the --help flag but I was unable to find where to update that.