### PR TITLE
Call EnsureVisible() for OSX in OnActivate

### DIFF
--- a/src/Main/Forms/MainFrame.cpp
+++ b/src/Main/Forms/MainFrame.cpp
@@ -737,6 +737,7 @@ namespace VeraCrypt
 #ifdef TC_MACOSX
 		if (event.GetActive() && Gui->IsInBackgroundMode())
 			Gui->SetBackgroundMode (false);
+		EnsureVisible();
 #endif
 		event.Skip();
 	}


### PR DESCRIPTION
When using multiple monitors, the resolution can change in OSX, during plug-in/off off the display(s). To avoid window becoming non-usable, there is EnsureVisible, that is called in several places.

However, if you minimize VeraCrypt on the bigger screen, and restore it in the main screen of a MacBook, after unplugging, the window will become unusable (unless you know that clicking 'About' calls EnsureVisible :-)).

Call EnsureVisible OnActivate so MainFrame is always functional across screens, even when minimized.