### PR TITLE
Linux: Flush stdout explicitly when reading stdin

### DIFF
--- a/src/Main/TextUserInterface.cpp
+++ b/src/Main/TextUserInterface.cpp
@@ -1047,7 +1047,7 @@ namespace VeraCrypt
 
 	void TextUserInterface::DoShowString (const wxString &str) const
 	{
-		wcout << str.c_str();
+		wcout << str.c_str() << flush;
 	}
 
 	void TextUserInterface::DoShowWarning (const wxString &message) const


### PR DESCRIPTION
Rules of automatic flushing of stdout buffer is implementation-defined behaviour. In glibc this is automatically flushed, but we can't rely on it for other implementations such as musl. More info: https://stackoverflow.com/questions/39536212/what-are-the-rules-of-automatic-stdout-buffer-flushing-in-c/39536803#39536803



Fixes: https://github.com/veracrypt/VeraCrypt/issues/1171

