### PR TITLE
Allow cross compilation.

### DIFF
--- a/src/Driver/Fuse/Driver.make
+++ b/src/Driver/Fuse/Driver.make
@@ -15,6 +15,6 @@ NAME := Driver
 OBJS :=
 OBJS += FuseService.o
 
-CXXFLAGS += $(shell pkg-config fuse --cflags)
+CXXFLAGS += $(shell $(PKG_CONFIG) fuse --cflags)
 
 include $(BUILD_INC)/Makefile.inc

--- a/src/Main/Main.make
+++ b/src/Main/Main.make
@@ -102,7 +102,7 @@ endif
 
 #------ FUSE configuration ------
 
-FUSE_LIBS = $(shell pkg-config fuse --libs)
+FUSE_LIBS = $(shell $(PKG_CONFIG) fuse --libs)
 
 #------ Executable ------
 
@@ -159,7 +159,7 @@ endif
 
 $(APPNAME): $(LIBS) $(OBJS)
 	@echo Linking $@
-	$(CXX) -o $(APPNAME) $(OBJS) $(LIBS) $(FUSE_LIBS) $(WX_LIBS) $(LFLAGS)
+	$(CXX) -o $(APPNAME) $(OBJS) $(LIBS) $(AYATANA_LIBS) $(FUSE_LIBS) $(WX_LIBS) $(LFLAGS)
 
 ifeq "$(TC_BUILD_CONFIG)" "Release"
 ifndef NOSTRIP

--- a/src/Makefile
+++ b/src/Makefile
@@ -49,6 +49,7 @@ C_CXX_FLAGS := -MMD -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_LARGE_FILES -I
 export ASFLAGS := -D __GNUC__ -D __YASM__
 export LFLAGS :=
 
+export PKG_CONFIG ?= pkg-config
 export PKG_CONFIG_PATH ?= /usr/local/lib/pkgconfig
 
 export WX_CONFIG ?= wx-config
@@ -101,8 +102,8 @@ ifeq "$(origin INDICATOR)" "command line"
 	else
 		INDICATOR_LIBRARY=ayatana-appindicator-0.1
 	endif
-	export LIBS += $(shell pkg-config --libs $(INDICATOR_LIBRARY))
-	C_CXX_FLAGS += $(shell pkg-config --cflags $(INDICATOR_LIBRARY)) -DHAVE_INDICATORS
+	export AYATANA_LIBS += $(shell $(PKG_CONFIG) --libs $(INDICATOR_LIBRARY))
+	C_CXX_FLAGS += $(shell $(PKG_CONFIG) --cflags $(INDICATOR_LIBRARY)) -DHAVE_INDICATORS
 endif
 
 #------ Release configuration ------


### PR DESCRIPTION
This fixes up pkg-config such that cross compilation is successful.

Note: I only tested this on Linux, specifically Debian.