### PR TITLE
Update Corsican translation on 2023-09 (2nd)

### DIFF
--- a/Translations/Language.co.xml
+++ b/Translations/Language.co.xml
@@ -9,7 +9,8 @@ Information about Corsican localization:
 
 	- Updated in 2023 by Patriccollu di Santa Maria è Sichè: May 29th (1.26), May 30th (1.26), June 1st (1.26),
 	          June 2nd (1.26), June 5th (1.26.2), June 21st (1.26.2), June 23rd (1.26.2), June 25th (1.26.2),
-	          June 29th (1.26.2), July 1st (1.26.3), July 30th (1.26.4), Aug. 14th (1.26.5), Sep. 8th (1.26.5)
+	          June 29th (1.26.2), July 1st (1.26.3), July 30th (1.26.4), Aug. 14th (1.26.5), Sep. 8th (1.26.5),
+	          Sep. 20th (1.26.5)
 	- Updated on March 23rd, 2022 for version 1.26 by Patriccollu di Santa Maria è Sichè
 	- Created on March 6th, 2022 for version 1.25.9 by Patriccollu di Santa Maria è Sichè
 
@@ -18,7 +19,7 @@ Information about Corsican localization:
 -->
 <VeraCrypt>
 	<localization prog-version="1.26.5">
-		<language langid="co" name="Corsu" en-name="Corsican" version="1.4.1" translators="Patriccollu di Santa Maria è Sichè"/>
+		<language langid="co" name="Corsu" en-name="Corsican" version="1.4.2" translators="Patriccollu di Santa Maria è Sichè"/>
 		<font lang="co" class="normal" size="11" face="default"/>
 		<font lang="co" class="bold" size="13" face="Arial"/>
 		<font lang="co" class="fixed" size="12" face="Lucida Console"/>
@@ -1650,6 +1651,7 @@ Information about Corsican localization:
 		<entry lang="co" key="EXPANDER_EXTENDING_FILESYSTEM">Estensione di u sistema di schedariu…\n</entry>
 		<entry lang="co" key="PARTIAL_SYSENC_MOUNT_READONLY">Avertimentu : A partizione di u sistema chì vo circate à muntà ùn hè stata micca cifrata sana. Da misura di sicurità, è per impedisce un alterazione pussibule, u vulume « %s » hè statu muntatu solu in lettura.</entry>
 		<entry lang="co" key="IDC_LINK_KEYFILES_EXTENSIONS_WARNING">Infurmazione impurtante nant’à l’impiegu d’estensioni di schedariu terze</entry>
+		<entry lang="co" key="IDC_DISABLE_MEMORY_PROTECTION">Disattivà a prutezzione di memoria in VeraCrypt</entry>
 	</localization>
 	<xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
 		<xs:element name="VeraCrypt">


### PR DESCRIPTION
Hello,

This is an update of **Corsican** (co) localization to take this commit into account:

 * https://github.com/veracrypt/VeraCrypt/commit/0f3ae268a4b0dfac7090f4fbf969601a1c35c86f Windows: Add setting in main UI and setup wizard to disable memory protection

Cheers,
Patriccollu.