### PR TITLE
wolfCrypt as crypto backend for VeraCrypt

### DIFF
--- a/src/Common/BootEncryption.cpp
+++ b/src/Common/BootEncryption.cpp
@@ -1687,23 +1687,26 @@ namespace VeraCrypt
 
 				if (_stricmp (request.BootEncryptionAlgorithmName, "AES") == 0)
 					ea = AES;
-				else if (_stricmp (request.BootEncryptionAlgorithmName, "Serpent") == 0)
+                        #ifndef WOLFCRYPT_BACKEND
+				else if (_stricmp (request.BootEncryptionAlgorithmName, "Camellia") == 0)
+					ea = CAMELLIA;	
+                                else if (_stricmp (request.BootEncryptionAlgorithmName, "Serpent") == 0)
 					ea = SERPENT;
 				else if (_stricmp (request.BootEncryptionAlgorithmName, "Twofish") == 0)
 					ea = TWOFISH;
-				else if (_stricmp (request.BootEncryptionAlgorithmName, "Camellia") == 0)
-					ea = CAMELLIA;
-
+                        #endif
 				if (_stricmp(request.BootPrfAlgorithmName, "SHA-256") == 0)
 					pkcs5_prf = SHA256;
-				else if (_stricmp(request.BootPrfAlgorithmName, "BLAKE2s-256") == 0)
-					pkcs5_prf = BLAKE2S;
-				else if (_stricmp(request.BootPrfAlgorithmName, "SHA-512") == 0)
+                              else if (_stricmp(request.BootPrfAlgorithmName, "SHA-512") == 0)
 					pkcs5_prf = SHA512;
+                        #ifndef WOLFCRYPT_BACKEND
+				else if (_stricmp(request.BootPrfAlgorithmName, "BLAKE2s-256") == 0)
+					pkcs5_prf = BLAKE2S;	
 				else if (_stricmp(request.BootPrfAlgorithmName, "Whirlpool") == 0)
 					pkcs5_prf = WHIRLPOOL;
 				else if (_stricmp(request.BootPrfAlgorithmName, "Streebog") == 0)
 					pkcs5_prf = STREEBOG;
+                        #endif
 				else if (strlen(request.BootPrfAlgorithmName) == 0) // case of version < 1.0f
 					pkcs5_prf = BLAKE2S;
 			}

--- a/src/Common/Crypto.c
+++ b/src/Common/Crypto.c
@@ -57,14 +57,18 @@ static Cipher Ciphers[] =
 //	  ID		Name			(Bytes)		(Bytes)		(Bytes)
 #ifdef TC_WINDOWS_BOOT
 	{ AES,		"AES",			16,			32,			AES_KS				},
-	{ SERPENT,	"Serpent",		16,			32,			140*4				},
+#ifndef WOLFCRYPT_BACKEND
+        { SERPENT,	"Serpent",		16,			32,			140*4				},
 	{ TWOFISH,	"Twofish",		16,			32,			TWOFISH_KS			},
+#endif
 #else
 	{ AES,		L"AES",			16,			32,			AES_KS				},
+#ifndef WOLFCRYPT_BACKEND
 	{ SERPENT,	L"Serpent",		16,			32,			140*4				},
 	{ TWOFISH,	L"Twofish",		16,			32,			TWOFISH_KS			},
 	{ CAMELLIA,	L"Camellia",	16,			32,			CAMELLIA_KS			},
 	{ KUZNYECHIK,	L"Kuznyechik",16,		32,			KUZNYECHIK_KS },
+#endif
 #endif
 	{ 0,		0,				0,			0,			0					}
 };
@@ -79,6 +83,7 @@ static EncryptionAlgorithm EncryptionAlgorithms[] =
 
 	{ { 0,							0 }, { 0, 0},		0, 0 },	// Must be all-zero
 	{ { AES,							0 }, { XTS, 0 },	1, 1 },
+#ifndef WOLFCRYPT_BACKEND
 	{ { SERPENT,					0 }, { XTS, 0 },	1, 1 },
 	{ { TWOFISH,					0 }, { XTS, 0 },	1, 1 },
 	{ { CAMELLIA,					0 }, { XTS, 0 },	1, 1 },
@@ -93,6 +98,7 @@ static EncryptionAlgorithm EncryptionAlgorithms[] =
 	{ { SERPENT, CAMELLIA,		0 }, { XTS, 0 },	0, 1 },
 	{ { AES, KUZNYECHIK,		0 }, { XTS, 0 },	0, 1 },
 	{ { CAMELLIA, SERPENT, KUZNYECHIK,	0 }, { XTS, 0 },	0, 1 },
+#endif
 	{ { 0,							0 }, { 0,    0},	0, 0 }		// Must be all-zero
 
 #else // TC_WINDOWS_BOOT
@@ -100,6 +106,7 @@ static EncryptionAlgorithm EncryptionAlgorithms[] =
 	// Encryption algorithms available for boot drive encryption
 	{ { 0,						0 }, { 0, 0 },		0 },	// Must be all-zero
 	{ { AES,					0 }, { XTS, 0 },	1 },
+#ifndef WOLFCRYPT_BACKEND
 	{ { SERPENT,				0 }, { XTS, 0 },	1 },
 	{ { TWOFISH,				0 }, { XTS, 0 },	1 },
 	{ { TWOFISH, AES,			0 }, { XTS, 0 },	1 },
@@ -107,6 +114,7 @@ static EncryptionAlgorithm EncryptionAlgorithms[] =
 	{ { AES, SERPENT,			0 }, { XTS, 0 },	1 },
 	{ { AES, TWOFISH, SERPENT,	0 }, { XTS, 0 },	1 },
 	{ { SERPENT, TWOFISH,		0 }, { XTS, 0 },	1 },
+#endif
 	{ { 0,						0 }, { 0, 0 },		0 },	// Must be all-zero
 
 #endif
@@ -119,11 +127,13 @@ static EncryptionAlgorithm EncryptionAlgorithms[] =
 static Hash Hashes[] =
 {	// ID				Name					Deprecated	System Encryption
 	{ SHA512,		L"SHA-512",				FALSE,	FALSE },
-	{ WHIRLPOOL,	L"Whirlpool",			FALSE,	FALSE },
-	{ BLAKE2S,		L"BLAKE2s-256",				FALSE,	TRUE },
 	{ SHA256,		L"SHA-256",				FALSE,	TRUE },
+    #ifndef WOLFCRYPT_BACKEND
+        { BLAKE2S,		L"BLAKE2s-256",				FALSE,	TRUE },
+        { WHIRLPOOL,	L"Whirlpool",			FALSE,	FALSE },
 	{ STREEBOG,		L"Streebog",	FALSE,	FALSE },
-	{ 0, 0, 0 }
+    #endif
+        { 0, 0, 0 }
 };
 #endif
 
@@ -147,6 +157,7 @@ int CipherInit (int cipher, unsigned char *key, unsigned __int8 *ks)
 #endif
 		break;
 
+#ifndef WOLFCRYPT_BACKEND	
 	case SERPENT:
 		serpent_set_key (key, ks);
 		break;
@@ -167,6 +178,7 @@ int CipherInit (int cipher, unsigned char *key, unsigned __int8 *ks)
 		break;
 #endif // !defined(TC_WINDOWS_BOOT)
 
+#endif
 	default:
 		// Unknown/wrong cipher ID
 		return ERR_CIPHER_INIT_FAILURE;
@@ -189,6 +201,7 @@ void EncipherBlock(int cipher, void *data, void *ks)
 			aes_encrypt (data, data, ks);
 		break;
 
+#ifndef WOLFCRYPT_BACKEND
 	case TWOFISH:		twofish_encrypt (ks, data, data); break;
 	case SERPENT:		serpent_encrypt (data, data, ks); break;
 #if !defined (TC_WINDOWS_BOOT) || defined (TC_WINDOWS_BOOT_CAMELLIA)
@@ -197,6 +210,7 @@ void EncipherBlock(int cipher, void *data, void *ks)
 #if !defined(TC_WINDOWS_BOOT)
 	case KUZNYECHIK:		kuznyechik_encrypt_block(data, data, ks); break;
 #endif // !defined(TC_WINDOWS_BOOT) 
+#endif
 	default:			TC_THROW_FATAL_EXCEPTION;	// Unknown/wrong ID
 	}
 }
@@ -230,6 +244,7 @@ void EncipherBlocks (int cipher, void *dataPtr, void *ks, size_t blockCount)
 		KeRestoreFloatingPointState (&floatingPointState);
 #endif
 	}
+#ifndef WOLFCRYPT_BACKEND	
 #if CRYPTOPP_BOOL_SSE2_INTRINSICS_AVAILABLE && !defined (_UEFI)
 	else if (cipher == SERPENT
 			&& (blockCount >= 4)
@@ -267,6 +282,7 @@ void EncipherBlocks (int cipher, void *dataPtr, void *ks, size_t blockCount)
 #endif
 	}
 #endif
+#endif
 	else
 	{
 		size_t blockSize = CipherGetBlockSize (cipher);
@@ -284,6 +300,7 @@ void DecipherBlock(int cipher, void *data, void *ks)
 {
 	switch (cipher)
 	{
+#ifndef WOLFCRYPT_BACKEND	
 	case SERPENT:	serpent_decrypt (data, data, ks); break;
 	case TWOFISH:	twofish_decrypt (ks, data, data); break;
 #if !defined (TC_WINDOWS_BOOT) || defined (TC_WINDOWS_BOOT_CAMELLIA)
@@ -292,6 +309,7 @@ void DecipherBlock(int cipher, void *data, void *ks)
 #if !defined(TC_WINDOWS_BOOT)
 	case KUZNYECHIK:	kuznyechik_decrypt_block(data, data, ks); break;
 #endif // !defined(TC_WINDOWS_BOOT)
+#endif
 
 
 #ifndef TC_WINDOWS_BOOT
@@ -341,6 +359,7 @@ void DecipherBlocks (int cipher, void *dataPtr, void *ks, size_t blockCount)
 		KeRestoreFloatingPointState (&floatingPointState);
 #endif
 	}
+#ifndef WOLFCRYPT_BACKEND	
 #if CRYPTOPP_BOOL_SSE2_INTRINSICS_AVAILABLE && !defined (_UEFI)
 	else if (cipher == SERPENT
 			&& (blockCount >= 4)
@@ -377,6 +396,7 @@ void DecipherBlocks (int cipher, void *dataPtr, void *ks, size_t blockCount)
 		KeRestoreFloatingPointState (&floatingPointState);
 #endif
 	}
+#endif
 #endif
 	else
 	{
@@ -523,8 +543,16 @@ BOOL EAInitMode (PCRYPTO_INFO ci, unsigned char* key2)
 		// Secondary key schedule
 		if (EAInit (ci->ea, key2, ci->ks2) != ERR_SUCCESS)
 			return FALSE;
+                
+            #ifdef WOLFCRYPT_BACKEND
+                if (xts_encrypt_key256 (key2, (aes_encrypt_ctx *) ci->ks) != EXIT_SUCCESS)
+			return ERR_CIPHER_INIT_FAILURE;
 
-		/* Note: XTS mode could potentially be initialized with a weak key causing all blocks in one data unit
+		if (xts_decrypt_key256 (key2, (aes_decrypt_ctx *) (ci->ks + sizeof(aes_encrypt_ctx))) != EXIT_SUCCESS)
+			return ERR_CIPHER_INIT_FAILURE;
+            #endif
+
+                /* Note: XTS mode could potentially be initialized with a weak key causing all blocks in one data unit
 		on the volume to be tweaked with zero tweaks (i.e. 512 bytes of the volume would be encrypted in ECB
 		mode). However, to create a TrueCrypt volume with such a weak key, each human being on Earth would have
 		to create approximately 11,378,125,361,078,862 (about eleven quadrillion) TrueCrypt volumes (provided 
@@ -1093,11 +1121,11 @@ void EncipherBlock(int cipher, void *data, void *ks)
 		aes_hw_cpu_encrypt ((byte *) ks, data);
 	else
 		aes_encrypt (data, data, ks); 
-#elif defined (TC_WINDOWS_BOOT_SERPENT)
+#elif defined (TC_WINDOWS_BOOT_SERPENT) && !defined (WOLFCRYPT_BACKEND)
 	serpent_encrypt (data, data, ks);
-#elif defined (TC_WINDOWS_BOOT_TWOFISH)
+#elif defined (TC_WINDOWS_BOOT_TWOFISH) && !defined (WOLFCRYPT_BACKEND)
 	twofish_encrypt (ks, data, data);
-#elif defined (TC_WINDOWS_BOOT_CAMELLIA)
+#elif defined (TC_WINDOWS_BOOT_CAMELLIA) && !defined (WOLFCRYPT_BACKEND)
 	camellia_encrypt (data, data, ks);
 #endif
 }
@@ -1109,11 +1137,11 @@ void DecipherBlock(int cipher, void *data, void *ks)
 		aes_hw_cpu_decrypt ((byte *) ks + sizeof (aes_encrypt_ctx) + 14 * 16, data);
 	else
 		aes_decrypt (data, data, (aes_decrypt_ctx *) ((byte *) ks + sizeof(aes_encrypt_ctx))); 
-#elif defined (TC_WINDOWS_BOOT_SERPENT)
+#elif defined (TC_WINDOWS_BOOT_SERPENT) && !defined (WOLFCRYPT_BACKEND)
 	serpent_decrypt (data, data, ks);
-#elif defined (TC_WINDOWS_BOOT_TWOFISH)
+#elif defined (TC_WINDOWS_BOOT_TWOFISH) && !defined (WOLFCRYPT_BACKEND)
 	twofish_decrypt (ks, data, data);
-#elif defined (TC_WINDOWS_BOOT_CAMELLIA)
+#elif defined (TC_WINDOWS_BOOT_CAMELLIA) && !defined (WOLFCRYPT_BACKEND)
 	camellia_decrypt (data, data, ks);
 #endif
 }

--- a/src/Common/Dlgcode.c
+++ b/src/Common/Dlgcode.c
@@ -6143,11 +6143,13 @@ static BOOL PerformBenchmark(HWND hBenchDlg, HWND hwndDlg)
 		*/
 		{
 			BYTE digest [MAX_DIGESTSIZE];
-			WHIRLPOOL_CTX	wctx;
-			blake2s_state   bctx;
+		#ifndef WOLFCRYPT_BACKEND	
+                        WHIRLPOOL_CTX	wctx;
+			STREEBOG_CTX		stctx;
+                        blake2s_state   bctx;
+               #endif
 			sha512_ctx		s2ctx;
 			sha256_ctx		s256ctx;
-			STREEBOG_CTX		stctx;
 
 			int hid, i;
 
@@ -6172,7 +6174,7 @@ static BOOL PerformBenchmark(HWND hBenchDlg, HWND hwndDlg)
 						sha256_hash (lpTestBuffer, benchmarkBufferSize, &s256ctx);
 						sha256_end ((unsigned char *) digest, &s256ctx);
 						break;
-
+                              #ifndef WOLFCRYPT_BACKEND
 					case BLAKE2S:
 						blake2s_init(&bctx);
 						blake2s_update(&bctx, lpTestBuffer, benchmarkBufferSize);
@@ -6192,7 +6194,8 @@ static BOOL PerformBenchmark(HWND hBenchDlg, HWND hwndDlg)
 						break;
 
 					}
-				}
+			        #endif	
+                                }
 
 				if (QueryPerformanceCounter (&performanceCountEnd) == 0)
 					goto counter_error;
@@ -6240,7 +6243,7 @@ static BOOL PerformBenchmark(HWND hBenchDlg, HWND hwndDlg)
 					/* PKCS-5 test with HMAC-SHA-256 used as the PRF */
 					derive_key_sha256 ("passphrase-1234567890", 21, tmp_salt, 64, get_pkcs5_iteration_count(thid, benchmarkPim, benchmarkPreBoot), dk, MASTER_KEYDATA_SIZE);
 					break;
-
+                          #ifndef WOLFCRYPT_BACKEND
 				case BLAKE2S:
 					/* PKCS-5 test with HMAC-BLAKE2s used as the PRF */
 					derive_key_blake2s ("passphrase-1234567890", 21, tmp_salt, 64, get_pkcs5_iteration_count(thid, benchmarkPim, benchmarkPreBoot), dk, MASTER_KEYDATA_SIZE);
@@ -6256,7 +6259,8 @@ static BOOL PerformBenchmark(HWND hBenchDlg, HWND hwndDlg)
 					derive_key_streebog("passphrase-1234567890", 21, tmp_salt, 64, get_pkcs5_iteration_count(thid, benchmarkPim, benchmarkPreBoot), dk, MASTER_KEYDATA_SIZE);
 					break;
 				}
-			}
+	                   #endif	
+                        }
 
 			if (QueryPerformanceCounter (&performanceCountEnd) == 0)
 				goto counter_error;

--- a/src/Common/Random.c
+++ b/src/Common/Random.c
@@ -262,19 +262,17 @@ BOOL Randmix ()
 	if (bRandmixEnabled)
 	{
 		unsigned char hashOutputBuffer [MAX_DIGESTSIZE];
-		WHIRLPOOL_CTX	wctx;
-		blake2s_state   bctx;
+        #ifndef WOLFCRYPT_BACKEND		
+                WHIRLPOOL_CTX	wctx;
+                blake2s_state   bctx;
+		STREEBOG_CTX	stctx;
+        #endif
 		sha512_ctx		sctx;
 		sha256_ctx		s256ctx;
-		STREEBOG_CTX	stctx;
 		int poolIndex, digestIndex, digestSize;
 
 		switch (HashFunction)
 		{
-		case BLAKE2S:
-			digestSize = BLAKE2S_DIGESTSIZE;
-			break;
-
 		case SHA512:
 			digestSize = SHA512_DIGESTSIZE;
 			break;
@@ -283,6 +281,11 @@ BOOL Randmix ()
 			digestSize = SHA256_DIGESTSIZE;
 			break;
 
+        #ifndef WOLFCRYPT_BACKEND	
+               case BLAKE2S:
+			digestSize = BLAKE2S_DIGESTSIZE;
+			break;
+	
 		case WHIRLPOOL:
 			digestSize = WHIRLPOOL_DIGESTSIZE;
 			break;
@@ -290,7 +293,7 @@ BOOL Randmix ()
 		case STREEBOG:
 			digestSize = STREEBOG_DIGESTSIZE;
 			break;
-
+        #endif
 		default:
 			TC_THROW_FATAL_EXCEPTION;
 		}
@@ -303,12 +306,6 @@ BOOL Randmix ()
 			/* Compute the message digest of the entire pool using the selected hash function. */
 			switch (HashFunction)
 			{
-			case BLAKE2S:
-				blake2s_init(&bctx);
-				blake2s_update(&bctx, pRandPool, RNG_POOL_SIZE);
-				blake2s_final(&bctx, hashOutputBuffer);
-				break;
-
 			case SHA512:
 				sha512_begin (&sctx);
 				sha512_hash (pRandPool, RNG_POOL_SIZE, &sctx);
@@ -319,6 +316,13 @@ BOOL Randmix ()
 				sha256_begin (&s256ctx);
 				sha256_hash (pRandPool, RNG_POOL_SIZE, &s256ctx);
 				sha256_end (hashOutputBuffer, &s256ctx);
+				break;
+
+                #ifndef WOLFCRYPT_BACKEND
+                      case BLAKE2S:
+				blake2s_init(&bctx);
+				blake2s_update(&bctx, pRandPool, RNG_POOL_SIZE);
+				blake2s_final(&bctx, hashOutputBuffer);
 				break;
 
 			case WHIRLPOOL:
@@ -332,7 +336,7 @@ BOOL Randmix ()
 				STREEBOG_add (&stctx, pRandPool, RNG_POOL_SIZE);
 				STREEBOG_finalize (&stctx, hashOutputBuffer);
 				break;
-
+                #endif
 			default:
 				// Unknown/wrong ID
 				TC_THROW_FATAL_EXCEPTION;
@@ -349,16 +353,17 @@ BOOL Randmix ()
 		burn (hashOutputBuffer, MAX_DIGESTSIZE);
 		switch (HashFunction)
 		{
-		case BLAKE2S:
-			burn (&bctx, sizeof(bctx));
-			break;
-
 		case SHA512:
 			burn (&sctx, sizeof(sctx));
 			break;
 
 		case SHA256:
 			burn (&s256ctx, sizeof(s256ctx));
+			break;
+
+        #ifndef WOLFCRYPT_BACKEND
+               case BLAKE2S:
+			burn (&bctx, sizeof(bctx));
 			break;
 
 		case WHIRLPOOL:
@@ -368,7 +373,7 @@ BOOL Randmix ()
 		case STREEBOG:
 			burn (&stctx, sizeof(sctx));
 			break;
-
+        #endif
 		default:
 			// Unknown/wrong ID
 			TC_THROW_FATAL_EXCEPTION;

--- a/src/Common/Tests.c
+++ b/src/Common/Tests.c
@@ -311,6 +311,9 @@ AES_TEST aes_ecb_vectors[AES_TEST_COUNT] = {
 0x8e,0xa2,0xb7,0xca,0x51,0x67,0x45,0xbf,0xea,0xfc,0x49,0x90,0x4b,0x49,0x60,0x89
 };
 
+
+#ifndef WOLFCRYPT_BACKEND
+
 // Serpent ECB test vectors
 
 #define SERPENT_TEST_COUNT 1
@@ -419,6 +422,7 @@ KUZNYECHIK_TEST kuznyechik_vectors[KUZNYECHIK_TEST_COUNT] = {
 }
 };
 
+#endif
 
 /* Test vectors from FIPS 198a, RFC 4231, RFC 2104, RFC 2202, and other sources. */
 
@@ -784,6 +788,7 @@ BOOL TestSectorBufEncryption (PCRYPTO_INFO ci)
 					break;
 				}
 			}
+               #ifndef WOLFCRYPT_BACKEND
 			else if (wcscmp (name, L"Serpent") == 0)
 			{
 				switch (testCase)
@@ -1148,7 +1153,7 @@ BOOL TestSectorBufEncryption (PCRYPTO_INFO ci)
 					break;
 				}
 			}
-
+                #endif
 			if (crc == 0x9f5edd58)
 				return FALSE;
 
@@ -1200,6 +1205,7 @@ BOOL TestSectorBufEncryption (PCRYPTO_INFO ci)
 				return FALSE;
 			nTestsPerformed++;
 		}
+        #ifndef WOLFCRYPT_BACKEND
 		else if (wcscmp (name, L"Serpent") == 0)
 		{
 			if (crc != 0x3494d480)
@@ -1284,7 +1290,7 @@ BOOL TestSectorBufEncryption (PCRYPTO_INFO ci)
 				return FALSE;
 			nTestsPerformed++;
 		}
-
+        #endif
 		if (crc == 0x9f5edd58)
 			return FALSE;
 
@@ -1357,6 +1363,7 @@ static BOOL DoAutoTestAlgorithms (void)
 			bFailed = TRUE;
 	}
 
+    #ifndef WOLFCRYPT_BACKEND
 	/* Serpent */
 
 	for (i = 0; i < SERPENT_TEST_COUNT; i++)
@@ -1437,6 +1444,7 @@ static BOOL DoAutoTestAlgorithms (void)
 	}
 	if (i != KUZNYECHIK_TEST_COUNT)
 		bFailed = TRUE;
+    #endif
 
 	/* PKCS #5 and HMACs */
 	if (!test_pkcs5 ())
@@ -1565,6 +1573,7 @@ BOOL test_hmac_sha512 ()
 	return (nTestsPerformed == 6);
 }
 
+#ifndef WOLFCRYPT_BACKEND
 BOOL test_hmac_blake2s ()
 {
 	unsigned int i;
@@ -1609,6 +1618,7 @@ BOOL test_hmac_whirlpool ()
 
 	return TRUE;
 }
+#endif
 
 /* http://www.tc26.ru/methods/recommendation/%D0%A2%D0%9A26%D0%90%D0%9B%D0%93.pdf */
 /* https://tools.ietf.org/html/draft-smyshlyaev-gost-usage-00 */
@@ -1633,6 +1643,7 @@ static const unsigned char gost3411_2012_hmac_r1[] = {
 };
 
 
+#ifndef WOLFCRYPT_BACKEND
 BOOL test_hmac_streebog ()
 {
 	CRYPTOPP_ALIGN_DATA(16) char digest[64]; /* large enough to hold digets and test vector inputs */
@@ -1653,6 +1664,7 @@ int __cdecl StreebogHash (unsigned char* input, unsigned long inputLen, unsigned
 	STREEBOG_finalize (&ctx, output);
 	return STREEBOG_DIGESTSIZE;
 }
+#endif
 
 BOOL test_pkcs5 ()
 {
@@ -1666,6 +1678,7 @@ BOOL test_pkcs5 ()
 	if (!test_hmac_sha512())
 		return FALSE;
 
+#ifndef WOLFCRYPT_BACKEND
 	/* HMAC-BLAKE2s tests */
 	if (test_hmac_blake2s() == FALSE)
 		return FALSE;
@@ -1685,7 +1698,7 @@ BOOL test_pkcs5 ()
 	/* STREEBOG hash tests */
 	if (RunHashTest (StreebogHash, Streebog512TestVectors, (HasSSE2() || HasSSE41())? TRUE : FALSE) == FALSE)
 		return FALSE;
-
+#endif
 	/* PKCS-5 test 1 with HMAC-SHA-256 used as the PRF (https://tools.ietf.org/html/draft-josefsson-scrypt-kdf-00) */
 	derive_key_sha256 ("passwd", 6, "\x73\x61\x6C\x74", 4, 1, dk, 64);
 	if (memcmp (dk, "\x55\xac\x04\x6e\x56\xe3\x08\x9f\xec\x16\x91\xc2\x25\x44\xb6\x05\xf9\x41\x85\x21\x6d\xde\x04\x65\xe6\x8b\x9d\x57\xc2\x0d\xac\xbc\x49\xca\x9c\xcc\xf1\x79\xb6\x45\x99\x16\x64\xb3\x9d\x77\xef\x31\x7c\x71\xb8\x45\xb1\xe3\x0b\xd5\x09\x11\x20\x41\xd3\xa1\x97\x83", 64) != 0)
@@ -1717,6 +1730,7 @@ BOOL test_pkcs5 ()
 	if (memcmp (dk, "\x13\x64\xae\xf8\x0d\xf5\x57\x6c\x30\xd5\x71\x4c\xa7\x75\x3f\xfd\x00\xe5\x25\x8b\x39\xc7\x44\x7f\xce\x23\x3d\x08\x75\xe0\x2f\x48\xd6\x30\xd7\x00\xb6\x24\xdb\xe0\x5a\xd7\x47\xef\x52\xca\xa6\x34\x83\x47\xe5\xcb\xe9\x87\xf1\x20\x59\x6a\xe6\xa9\xcf\x51\x78\xc6\xb6\x23\xa6\x74\x0d\xe8\x91\xbe\x1a\xd0\x28\xcc\xce\x16\x98\x9a\xbe\xfb\xdc\x78\xc9\xe1\x7d\x72\x67\xce\xe1\x61\x56\x5f\x96\x68\xe6\xe1\xdd\xf4\xbf\x1b\x80\xe0\x19\x1c\xf4\xc4\xd3\xdd\xd5\xd5\x57\x2d\x83\xc7\xa3\x37\x87\xf4\x4e\xe0\xf6\xd8\x6d\x65\xdc\xa0\x52\xa3\x13\xbe\x81\xfc\x30\xbe\x7d\x69\x58\x34\xb6\xdd\x41\xc6", 144) != 0)
 		return FALSE;
 
+#ifndef WOLFCRYPT_BACKEND
 	/* PKCS-5 test 1 with HMAC-BLAKE2s used as the PRF */
 	derive_key_blake2s ("password", 8, "\x12\x34\x56\x78", 4, 5, dk, 4);
 	if (memcmp (dk, "\x8d\x51\xfa\x31", 4) != 0)
@@ -1746,6 +1760,6 @@ BOOL test_pkcs5 ()
 	derive_key_streebog ("password", 8, "\x12\x34\x56\x78", 4, 5, dk, 96);
 	if (memcmp (dk, "\xd0\x53\xa2\x30\x6f\x45\x81\xeb\xbc\x06\x81\xc5\xe7\x53\xa8\x5d\xc7\xf1\x23\x33\x1e\xbe\x64\x2c\x3b\x0f\x26\xd7\x00\xe1\x95\xc9\x65\x26\xb1\x85\xbe\x1e\xe2\xf4\x9b\xfc\x6b\x14\x84\xda\x24\x61\xa0\x1b\x9e\x79\x5c\xee\x69\x6e\xf9\x25\xb1\x1d\xca\xa0\x31\xba\x02\x6f\x9e\x99\x0f\xdb\x25\x01\x5b\xf1\xc7\x10\x19\x53\x3b\x29\x3f\x18\x00\xd6\xfc\x85\x03\xdc\xf2\xe5\xe9\x5a\xb1\x1e\x61\xde", 96) != 0)
 		return FALSE;
-
+#endif
 	return TRUE;
 }

--- a/src/Common/Xts.c
+++ b/src/Common/Xts.c
@@ -54,10 +54,14 @@ void EncryptBufferXTS (unsigned __int8 *buffer,
 					   unsigned __int8 *ks2,
 					   int cipher)
 {
-	if (CipherSupportsIntraDataUnitParallelization (cipher))
+    #ifndef WOLFCRYPT_BACKEND
+        if (CipherSupportsIntraDataUnitParallelization (cipher))
 		EncryptBufferXTSParallel (buffer, length, startDataUnitNo, startCipherBlockNo, ks, ks2, cipher);
 	else
 		EncryptBufferXTSNonParallel (buffer, length, startDataUnitNo, startCipherBlockNo, ks, ks2, cipher);
+    #else
+        xts_encrypt(buffer, buffer, length, startDataUnitNo, ks);
+    #endif
 }
 
 #if (CRYPTOPP_BOOL_SSE2_INTRINSICS_AVAILABLE && CRYPTOPP_BOOL_X64)
@@ -380,10 +384,14 @@ void DecryptBufferXTS (unsigned __int8 *buffer,
 					   unsigned __int8 *ks2,
 					   int cipher)
 {
+    #ifndef WOLFCRYPT_BACKEND
 	if (CipherSupportsIntraDataUnitParallelization (cipher))
 		DecryptBufferXTSParallel (buffer, length, startDataUnitNo, startCipherBlockNo, ks, ks2, cipher);
 	else
 		DecryptBufferXTSNonParallel (buffer, length, startDataUnitNo, startCipherBlockNo, ks, ks2, cipher);
+    #else
+        xts_decrypt(buffer, buffer, length, startDataUnitNo, ks);
+    #endif
 }
 
 

--- a/src/Core/RandomNumberGenerator.cpp
+++ b/src/Core/RandomNumberGenerator.cpp
@@ -257,7 +257,11 @@ namespace VeraCrypt
 	void RandomNumberGenerator::Test ()
 	{
 		shared_ptr <Hash> origPoolHash = PoolHash;
-		PoolHash.reset (new Blake2s());
+	    #ifndef WOLFCRYPT_BACKEND
+                PoolHash.reset (new Blake2s());
+            #else
+                PoolHash.reset (new Sha256());
+            #endif
 
 		Pool.Zero();
 		Buffer buffer (1);
@@ -267,15 +271,23 @@ namespace VeraCrypt
 			AddToPool (buffer);
 		}
 
+	    #ifndef WOLFCRYPT_BACKEND
  		if (Crc32::ProcessBuffer (Pool) != 0x9c743238)
-			throw TestFailed (SRC_POS);
+            #else
+                if (Crc32::ProcessBuffer (Pool) != 0xac95ac1a)
+            #endif
+		        throw TestFailed (SRC_POS);
 
 		buffer.Allocate (PoolSize);
 		buffer.CopyFrom (PeekPool());
 		AddToPool (buffer);
 
- 		if (Crc32::ProcessBuffer (Pool) != 0xd2d09c8d)
-			throw TestFailed (SRC_POS);
+	    #ifndef WOLFCRYPT_BACKEND
+                if (Crc32::ProcessBuffer (Pool) != 0xd2d09c8d)
+            #else
+                if (Crc32::ProcessBuffer (Pool) != 0xb79f3c12)
+            #endif
+		        throw TestFailed (SRC_POS);
 
 		PoolHash = origPoolHash;
 	}

--- a/src/Core/Unix/Linux/CoreLinux.cpp
+++ b/src/Core/Unix/Linux/CoreLinux.cpp
@@ -22,6 +22,9 @@
 #include "Platform/SystemInfo.h"
 #include "Platform/TextReader.h"
 #include "Volume/EncryptionModeXTS.h"
+#ifdef WOLFCRYPT_BACKEND
+#include "Volume/EncryptionModeWolfCryptXTS.h"
+#endif
 #include "Driver/Fuse/FuseService.h"
 #include "Core/Unix/CoreServiceProxy.h"
 
@@ -302,8 +305,13 @@ namespace VeraCrypt
 
 	void CoreLinux::MountVolumeNative (shared_ptr <Volume> volume, MountOptions &options, const DirectoryPath &auxMountPoint) const
 	{
-		bool xts = (typeid (*volume->GetEncryptionMode()) == typeid (EncryptionModeXTS));
-		bool algoNotSupported = (typeid (*volume->GetEncryptionAlgorithm()) == typeid (Kuznyechik))
+		bool xts = (typeid (*volume->GetEncryptionMode()) == 
+            #ifdef WOLFCRYPT_BACKEND
+                        typeid (EncryptionModeWolfCryptXTS));
+            #else
+                        typeid (EncryptionModeXTS));
+            #endif 
+                bool algoNotSupported = (typeid (*volume->GetEncryptionAlgorithm()) == typeid (Kuznyechik))
 			|| (typeid (*volume->GetEncryptionAlgorithm()) == typeid (CamelliaKuznyechik))
 			|| (typeid (*volume->GetEncryptionAlgorithm()) == typeid (KuznyechikTwofish))
 			|| (typeid (*volume->GetEncryptionAlgorithm()) == typeid (KuznyechikAES))

--- a/src/Core/VolumeCreator.cpp
+++ b/src/Core/VolumeCreator.cpp
@@ -12,6 +12,9 @@
 
 #include "Volume/EncryptionTest.h"
 #include "Volume/EncryptionModeXTS.h"
+#ifdef WOLFCRYPT_BACKEND
+#include "Volume/EncryptionModeWolfCryptXTS.h"
+#endif
 #include "Core.h"
 
 #ifdef TC_UNIX
@@ -360,8 +363,13 @@ namespace VeraCrypt
 
 			// Data area keys
 			options->EA->SetKey (MasterKey.GetRange (0, options->EA->GetKeySize()));
-			shared_ptr <EncryptionMode> mode (new EncryptionModeXTS ());
-			mode->SetKey (MasterKey.GetRange (options->EA->GetKeySize(), options->EA->GetKeySize()));
+                    #ifdef WOLFCRYPT_BACKEND
+                        shared_ptr <EncryptionMode> mode (new EncryptionModeWolfCryptXTS ());
+                        options->EA->SetKeyXTS (MasterKey.GetRange (options->EA->GetKeySize(), options->EA->GetKeySize()));
+                    #else
+                        shared_ptr <EncryptionMode> mode (new EncryptionModeXTS ());
+                    #endif
+                        mode->SetKey (MasterKey.GetRange (options->EA->GetKeySize(), options->EA->GetKeySize()));
 			options->EA->SetMode (mode);
 
 			Options = options;

--- a/src/Crypto/Aes.h
+++ b/src/Crypto/Aes.h
@@ -35,6 +35,11 @@
 
 #include "Common/Tcdefs.h"
 
+#ifdef WOLFCRYPT_BACKEND
+    #include <wolfssl/options.h>
+    #include <wolfssl/wolfcrypt/aes.h>
+#endif
+
 #ifndef EXIT_SUCCESS
 #define EXIT_SUCCESS    0
 #define EXIT_FAILURE    1
@@ -93,11 +98,19 @@ typedef union
 typedef struct
 {   uint_32t ks[KS_LENGTH];
     aes_inf inf;
+#ifdef WOLFCRYPT_BACKEND
+    XtsAes  wc_enc_xts;
+    Aes     wc_enc_aes;
+#endif
 } aes_encrypt_ctx;
 
 typedef struct
 {   uint_32t ks[KS_LENGTH];
     aes_inf inf;
+#ifdef WOLFCRYPT_BACKEND
+    XtsAes  wc_dec_xts;
+    Aes     wc_dec_aes;
+#endif
 } aes_decrypt_ctx;
 
 /* This routine must be called before first use if non-static       */
@@ -150,6 +163,13 @@ AES_RETURN aes_decrypt_key(const unsigned char *key, int key_len, aes_decrypt_ct
 
 AES_RETURN aes_decrypt(const unsigned char *in, unsigned char *out, const aes_decrypt_ctx cx[1]);
 
+#endif
+
+#ifdef WOLFCRYPT_BACKEND
+AES_RETURN xts_encrypt_key256(const unsigned char *key, aes_encrypt_ctx cx[1]);
+AES_RETURN xts_decrypt_key256(const unsigned char *key, aes_decrypt_ctx cx[1]);
+AES_RETURN xts_encrypt(const unsigned char *in, unsigned char *out, word64 length, word64 sector, const aes_encrypt_ctx cx[1]);
+AES_RETURN xts_decrypt(const unsigned char *in, unsigned char *out, word64 length, word64 sector, const aes_decrypt_ctx cx[1]);
 #endif
 
 #if defined(AES_MODES)

--- a/src/Crypto/Sha2.h
+++ b/src/Crypto/Sha2.h
@@ -12,6 +12,13 @@
 #include "Common/Endian.h"
 #include "Crypto/config.h"
 
+#ifdef WOLFCRYPT_BACKEND
+    #include <wolfssl/options.h>
+    #include <wolfssl/wolfcrypt/sha256.h>
+    #include <wolfssl/wolfcrypt/sha512.h>
+    #include <wolfssl/wolfcrypt/hash.h>
+#endif
+
 #if defined(__cplusplus)
 extern "C" {
 #endif
@@ -32,12 +39,18 @@ typedef struct
 {   uint_64t count[2];
     SHA2_ALIGN uint_64t hash[8];
     SHA2_ALIGN uint_64t wbuf[16];
+#ifdef WOLFCRYPT_BACKEND
+    wc_Sha512 wc_sha512;
+#endif
 } sha512_ctx;
 
 typedef struct
 {   uint_32t count[2];
     SHA2_ALIGN uint_32t hash[8];
     SHA2_ALIGN uint_32t wbuf[16];
+#ifdef WOLFCRYPT_BACKEND
+    wc_Sha256 wc_sha256;
+#endif
 } sha256_ctx;
 
 

--- a/src/Crypto/Sha2.h
+++ b/src/Crypto/Sha2.h
@@ -35,23 +35,22 @@ extern "C" {
 #define SHA2_ALIGN	CRYPTOPP_ALIGN_DATA(16)
 #endif
 
+#ifdef WOLFCRYPT_BACKEND
+typedef struct wc_Sha512 sha512_ctx;
+typedef struct wc_Sha256 sha256_ctx;
+#else
 typedef struct
 {   uint_64t count[2];
     SHA2_ALIGN uint_64t hash[8];
     SHA2_ALIGN uint_64t wbuf[16];
-#ifdef WOLFCRYPT_BACKEND
-    wc_Sha512 wc_sha512;
-#endif
 } sha512_ctx;
 
 typedef struct
 {   uint_32t count[2];
     SHA2_ALIGN uint_32t hash[8];
     SHA2_ALIGN uint_32t wbuf[16];
-#ifdef WOLFCRYPT_BACKEND
-    wc_Sha256 wc_sha256;
-#endif
 } sha256_ctx;
+#endif
 
 
 void sha512_begin(sha512_ctx* ctx);

--- a/src/Crypto/cpu.h
+++ b/src/Crypto/cpu.h
@@ -214,7 +214,7 @@ extern "C" {
 #endif
 
 #define CRYPTOPP_CPUID_AVAILABLE
-#ifndef CRYPTOPP_DISABLE_AESNI
+#if !defined(CRYPTOPP_DISABLE_AESNI) && !defined(WOLFCRYPT_BACKEND)
 #define TC_AES_HW_CPU
 #endif
 

--- a/src/Crypto/wolfCrypt.c
+++ b/src/Crypto/wolfCrypt.c
@@ -186,19 +186,17 @@ AES_RETURN xts_decrypt(const unsigned char *in, unsigned char *out, word64 lengt
 
 void sha256_begin(sha256_ctx* ctx)
 {
-    wc_Sha256 sha;
-    wc_InitSha256(&sha);
-    ctx->wc_sha256 = sha;
+    wc_InitSha256(ctx);
 }
 
 void sha256_hash(const unsigned char * source, uint_32t sourceLen, sha256_ctx *ctx)
 {
-    wc_Sha256Update(&ctx->wc_sha256, source, sourceLen);
+    wc_Sha256Update(ctx, source, sourceLen);
 }
 
 void sha256_end(unsigned char * result, sha256_ctx* ctx)
 {
-    wc_Sha256Final(&ctx->wc_sha256, result);
+    wc_Sha256Final(ctx, result);
 }
 
 void sha256(unsigned char * result, const unsigned char* source, uint_32t sourceLen)
@@ -212,19 +210,17 @@ void sha256(unsigned char * result, const unsigned char* source, uint_32t source
 
 void sha512_begin(sha512_ctx* ctx)
 {
-    wc_Sha512 sha;
-    wc_InitSha512(&sha);
-    ctx->wc_sha512 = sha;
+    wc_InitSha512(ctx);
 }
 
 void sha512_hash(const unsigned char * source, uint_64t sourceLen, sha512_ctx *ctx)
 {
-    wc_Sha512Update(&ctx->wc_sha512, source, sourceLen);
+    wc_Sha512Update(ctx, source, sourceLen);
 }
 
 void sha512_end(unsigned char * result, sha512_ctx* ctx)
 {
-    wc_Sha512Final(&ctx->wc_sha512, result);
+    wc_Sha512Final(ctx, result);
 }
 
 void sha512(unsigned char * result, const unsigned char* source, uint_64t sourceLen)

--- a/src/Crypto/wolfCrypt.c
+++ b/src/Crypto/wolfCrypt.c
@@ -1,0 +1,247 @@
+/* See src/Crypto/wolfCrypt.md */
+
+#include "Aes.h"
+#include "Sha2.h"
+#include "../Common/Crypto.h"
+#include <wolfssl/wolfcrypt/hmac.h>
+
+
+AES_RETURN aes_init()
+{
+#if defined( AES_ERR_CHK )
+    return EXIT_SUCCESS;
+#else
+    return;
+#endif
+}
+
+AES_RETURN aes_encrypt_key(const unsigned char *key, int key_len, aes_encrypt_ctx cx[1])
+{
+    int ret = 0;
+
+    ret = wc_AesInit(&cx->wc_enc_aes, NULL, INVALID_DEVID);
+
+    if (key_len == 128 || key_len == 192 || key_len == 256)
+        key_len = key_len/8;
+
+    if (ret == 0) {
+        ret = wc_AesSetKey(&cx->wc_enc_aes, key, key_len, NULL, AES_ENCRYPTION);
+    }
+
+#if defined( AES_ERR_CHK )
+    return ret ? EXIT_FAILURE : EXIT_SUCCESS;
+#else
+    return;
+#endif
+}
+
+AES_RETURN aes_decrypt_key(const unsigned char *key, int key_len, aes_decrypt_ctx cx[1])
+{
+    int ret = 0;
+
+    ret = wc_AesInit(&cx->wc_dec_aes, NULL, INVALID_DEVID);
+
+    if (key_len == 128 || key_len == 192 || key_len == 256)
+        key_len = key_len/8;
+
+    if (ret == 0) {
+        ret = wc_AesSetKey(&cx->wc_dec_aes, key, key_len, NULL, AES_DECRYPTION);
+    }
+
+#if defined( AES_ERR_CHK )
+    return ret ? EXIT_FAILURE : EXIT_SUCCESS;
+#else
+    return;
+#endif
+}
+
+AES_RETURN aes_encrypt_key128(const unsigned char *key, aes_encrypt_ctx cx[1])
+{
+    return aes_encrypt_key(key, 128, cx);
+}
+
+AES_RETURN aes_encrypt_key192(const unsigned char *key, aes_encrypt_ctx cx[1])
+{
+    return aes_encrypt_key(key, 192, cx);
+}
+
+AES_RETURN aes_encrypt_key256(const unsigned char *key, aes_encrypt_ctx cx[1])
+{
+    return aes_encrypt_key(key, 256, cx);
+}
+
+AES_RETURN aes_decrypt_key128(const unsigned char *key, aes_decrypt_ctx cx[1])
+{
+    return aes_decrypt_key(key, 128, cx);
+}
+
+AES_RETURN aes_decrypt_key192(const unsigned char *key, aes_decrypt_ctx cx[1])
+{
+    return aes_decrypt_key(key, 192, cx);
+}
+
+AES_RETURN aes_decrypt_key256(const unsigned char *key, aes_decrypt_ctx cx[1])
+{
+    return aes_decrypt_key(key, 256, cx);
+}
+
+AES_RETURN aes_encrypt(const unsigned char *in, unsigned char *out, const aes_encrypt_ctx cx[1])
+{
+    int ret = wc_AesEncryptDirect(&cx->wc_enc_aes, out, in);
+#if defined( AES_ERR_CHK )
+    return ret ? EXIT_FAILURE : EXIT_SUCCESS;
+#else
+    return;
+#endif
+
+}
+
+AES_RETURN aes_decrypt(const unsigned char *in, unsigned char *out, const aes_decrypt_ctx cx[1])
+{
+    int ret = wc_AesDecryptDirect(&cx->wc_dec_aes, out, in);
+#if defined( AES_ERR_CHK )
+    return ret ? EXIT_FAILURE : EXIT_SUCCESS;
+#else
+    return;
+#endif
+
+}
+
+AES_RETURN xts_encrypt_key(const unsigned char *key, int key_len, aes_encrypt_ctx cx[1])
+{
+    int ret = 0;
+
+    cx->wc_enc_xts.aes = cx->wc_enc_aes;
+
+    ret = wc_AesInit(&cx->wc_enc_xts.tweak, NULL, INVALID_DEVID);
+
+    if (key_len == 128 || key_len == 192 || key_len == 256)
+        key_len = key_len/8;
+
+    if (ret == 0) {
+        ret = wc_AesSetKey(&cx->wc_enc_xts.tweak, key, key_len, NULL, AES_ENCRYPTION);
+    }
+#if defined( AES_ERR_CHK )
+    return ret ? EXIT_FAILURE : EXIT_SUCCESS;
+#else
+    return;
+#endif
+}
+
+AES_RETURN xts_decrypt_key(const unsigned char *key, int key_len, aes_decrypt_ctx cx[1])
+{
+    int ret = 0;
+
+    cx->wc_dec_xts.aes = cx->wc_dec_aes;
+
+    ret = wc_AesInit(&cx->wc_dec_xts.tweak, NULL, INVALID_DEVID);
+
+    if (key_len == 128 || key_len == 192 || key_len == 256)
+        key_len = key_len/8;
+
+    if (ret == 0) {
+        ret = wc_AesSetKey(&cx->wc_dec_xts.tweak, key, key_len, NULL, AES_ENCRYPTION);
+    }
+
+#if defined( AES_ERR_CHK )
+    return ret ? EXIT_FAILURE : EXIT_SUCCESS;
+#else
+    return;
+#endif
+}
+
+AES_RETURN xts_encrypt_key256(const unsigned char *key, aes_encrypt_ctx cx[1])
+{
+    return xts_encrypt_key(key, 256, cx);
+}
+
+AES_RETURN xts_decrypt_key256(const unsigned char *key, aes_decrypt_ctx cx[1])
+{
+    return xts_decrypt_key(key, 256, cx);
+}
+
+AES_RETURN xts_encrypt(const unsigned char *in, unsigned char *out, word64 length, word64 sector, const aes_encrypt_ctx cx[1])
+{
+    int ret = wc_AesXtsEncryptConsecutiveSectors(&cx->wc_enc_xts, out, in, length, sector, ENCRYPTION_DATA_UNIT_SIZE);
+
+#if defined( AES_ERR_CHK )
+    return ret ? EXIT_FAILURE : EXIT_SUCCESS;
+#else
+    return;
+#endif
+
+}
+
+AES_RETURN xts_decrypt(const unsigned char *in, unsigned char *out, word64 length, word64 sector, const aes_decrypt_ctx cx[1])
+{
+    int ret = wc_AesXtsDecryptConsecutiveSectors(&cx->wc_dec_xts, out, in, length, sector, ENCRYPTION_DATA_UNIT_SIZE);
+
+#if defined( AES_ERR_CHK )
+    return ret ? EXIT_FAILURE : EXIT_SUCCESS;
+#else
+    return;
+#endif
+}
+
+
+void sha256_begin(sha256_ctx* ctx)
+{
+    wc_Sha256 sha;
+    wc_InitSha256(&sha);
+    ctx->wc_sha256 = sha;
+}
+
+void sha256_hash(const unsigned char * source, uint_32t sourceLen, sha256_ctx *ctx)
+{
+    wc_Sha256Update(&ctx->wc_sha256, source, sourceLen);
+}
+
+void sha256_end(unsigned char * result, sha256_ctx* ctx)
+{
+    wc_Sha256Final(&ctx->wc_sha256, result);
+}
+
+void sha256(unsigned char * result, const unsigned char* source, uint_32t sourceLen)
+{
+    wc_Sha256 sha256;
+    wc_InitSha256(&sha256);
+    wc_Sha256Update(&sha256, source, sourceLen);
+    wc_Sha256Final(&sha256, result);
+    wc_Sha256Free(&sha256);
+}
+
+void sha512_begin(sha512_ctx* ctx)
+{
+    wc_Sha512 sha;
+    wc_InitSha512(&sha);
+    ctx->wc_sha512 = sha;
+}
+
+void sha512_hash(const unsigned char * source, uint_64t sourceLen, sha512_ctx *ctx)
+{
+    wc_Sha512Update(&ctx->wc_sha512, source, sourceLen);
+}
+
+void sha512_end(unsigned char * result, sha512_ctx* ctx)
+{
+    wc_Sha512Final(&ctx->wc_sha512, result);
+}
+
+void sha512(unsigned char * result, const unsigned char* source, uint_64t sourceLen)
+{
+    wc_Sha512 sha512;
+    wc_InitSha512(&sha512);
+    wc_Sha512Update(&sha512, source, sourceLen);
+    wc_Sha512Final(&sha512, result);
+    wc_Sha512Free(&sha512);
+}
+
+void derive_key_sha512 (char *pwd, int pwd_len, char *salt, int salt_len, uint32 iterations, char *dk, int dklen) {
+    (void) iterations;
+    wc_HKDF(WC_SHA512, (byte*)pwd, (word32)pwd_len, (byte*)salt, (word32)salt_len, NULL, 0, (byte*)dk, (word32)dklen);
+}
+
+void derive_key_sha256 (char *pwd, int pwd_len, char *salt, int salt_len, uint32 iterations, char *dk, int dklen) {
+    (void) iterations;
+    wc_HKDF(WC_SHA256, (byte*)pwd, (word32)pwd_len, (byte*)salt, (word32)salt_len, NULL, 0, (byte*)dk, (word32)dklen);
+}

--- a/src/Crypto/wolfCrypt.md
+++ b/src/Crypto/wolfCrypt.md
@@ -1,0 +1,25 @@
+# wolfSSL as crypto provider for VeraCrypt
+
+[wolfCrypt](https://www.wolfssl.com/products/wolfcrypt/) is wolfSSL's cutting edge crypto engine and a 
+potential FIPS solution for users of VeraCrypt. Follow the steps below to setup VeraCrypt with wolfCrypt. 
+
+## Building wolfSSL
+
+Clone wolfSSL and build it as shown below.
+
+```
+git clone https://github.com/wolfssl/wolfssl && cd wolfssl
+./autogen.sh
+./configure --enable-xts CFLAGS="-DNO_OLD_WC_NAMES"
+make
+sudo make install
+```
+
+## Building VeraCrypt with wolfSSL
+
+Build VeraCrypt with the `WOLFCRYPT` command line option.
+
+```
+make WXSTATIC=1 wxbuild && make WXSTATIC=1 clean && make WXSTATIC=1 WOLFCRYPT=1 && make WXSTATIC=1 WOLFCRYPT=1 package
+```
+

--- a/src/Format/Tcformat.c
+++ b/src/Format/Tcformat.c
@@ -4475,9 +4475,11 @@ BOOL CALLBACK PageDialogProc (HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lPa
 				}
 
 				SetFocus (GetDlgItem (hwndDlg, IDC_PIM));
-
+                            #ifndef WOLFCRYPT_BACKEND
 				SetWindowTextW (GetDlgItem (hwndDlg, IDC_BOX_HELP), GetString (SysEncInEffect () && hash_algo != SHA512 && hash_algo != WHIRLPOOL? "PIM_SYSENC_HELP" : "PIM_HELP"));
-
+                            #else
+				SetWindowTextW (GetDlgItem (hwndDlg, IDC_BOX_HELP), GetString (SysEncInEffect () && hash_algo != SHA512? "PIM_SYSENC_HELP" : "PIM_HELP"));
+                            #endif
 				ToHyperlink (hwndDlg, IDC_LINK_PIM_INFO);
 
 				if (CreatingHiddenSysVol())

--- a/src/Main/Forms/BenchmarkDialog.cpp
+++ b/src/Main/Forms/BenchmarkDialog.cpp
@@ -12,6 +12,9 @@
 
 #include "System.h"
 #include "Volume/EncryptionModeXTS.h"
+#ifdef WOLFCRYPT_BACKEND
+#include "Volume/EncryptionModeWolfCryptXTS.h"
+#endif
 #include "Main/GraphicUserInterface.h"
 #include "BenchmarkDialog.h"
 
@@ -209,9 +212,13 @@ namespace VeraCrypt
 
 						Buffer key (ea->GetKeySize());
 						ea->SetKey (key);
-
+                                            #ifdef WOLFCRYPT_BACKEND
+						shared_ptr <EncryptionMode> xts (new EncryptionModeWolfCryptXTS);
+						ea->SetKeyXTS (key);
+                                            #else
 						shared_ptr <EncryptionMode> xts (new EncryptionModeXTS);
-						xts->SetKey (key);
+                                            #endif
+                                                xts->SetKey (key);
 						ea->SetMode (xts);
 
 						wxLongLong startTime = wxGetLocalTimeMillis();

--- a/src/Main/Forms/EncryptionTestDialog.cpp
+++ b/src/Main/Forms/EncryptionTestDialog.cpp
@@ -12,6 +12,9 @@
 
 #include "System.h"
 #include "Volume/EncryptionModeXTS.h"
+#ifdef WOLFCRYPT_BACKEND
+#include "Volume/EncryptionModeWolfCryptXTS.h"
+#endif
 #include "Volume/EncryptionTest.h"
 #include "Main/GraphicUserInterface.h"
 #include "EncryptionTestDialog.h"
@@ -94,8 +97,13 @@ namespace VeraCrypt
 					throw StringConversionFailed (SRC_POS);
 				}
 
+                            #ifdef WOLFCRYPT_BACKEND
+				shared_ptr <EncryptionMode> xts (new EncryptionModeWolfCryptXTS);
+				ea->SetKeyXTS (secondaryKey);
+                            #else
 				shared_ptr <EncryptionMode> xts (new EncryptionModeXTS);
-				xts->SetKey (secondaryKey);
+                            #endif
+                                xts->SetKey (secondaryKey);
 				ea->SetMode (xts);
 
 				Buffer sector (ENCRYPTION_DATA_UNIT_SIZE);

--- a/src/Main/Forms/WaitDialog.cpp
+++ b/src/Main/Forms/WaitDialog.cpp
@@ -8,6 +8,9 @@
 
 #include "System.h"
 #include "Volume/EncryptionModeXTS.h"
+#ifdef WOLFCRYPT_BACKEND
+#include "Volume/EncryptionModeWolfCryptXTS.h"
+#endif
 #include "Main/GraphicUserInterface.h"
 #include "Common/PCSCException.h"
 #include "Common/SecurityToken.h"

--- a/src/Makefile
+++ b/src/Makefile
@@ -24,6 +24,7 @@
 # SSE41:		Enable SSE4.1 support in compiler
 # NOSSE2:		Disable SEE2 support in compiler
 # WITHGTK3:		Build wxWidgets against GTK3
+# WOLFCRYPT:		Build with wolfCrypt as crypto provider (see Crypto/wolfCrypt.md)
 
 #------ Targets ------
 # all
@@ -145,6 +146,7 @@ export PLATFORM_UNSUPPORTED := 0
 export CPU_ARCH ?= unknown
 export SIMD_SUPPORTED := 0
 export DISABLE_AESNI ?= 0
+export ENABLE_WOLFCRYPT ?= 0
 
 export GCC_GTEQ_440 := 0
 export GCC_GTEQ_430 := 0
@@ -183,6 +185,13 @@ endif
 
 ifeq "$(origin NOAESNI)" "command line"
 	DISABLE_AESNI := 1
+endif
+
+ifeq "$(origin WOLFCRYPT)" "command line"
+	ENABLE_WOLFCRYPT := 1
+        C_CXX_FLAGS += -DWOLFCRYPT_BACKEND
+        export LIBS += -lwolfssl
+	export LD_LIBRARY_PATH=/usr/local/lib
 endif
 
 #------ Linux configuration ------

--- a/src/Volume/EncryptionAlgorithm.cpp
+++ b/src/Volume/EncryptionAlgorithm.cpp
@@ -62,6 +62,7 @@ namespace VeraCrypt
 		EncryptionAlgorithmList l;
 
 		l.push_back (shared_ptr <EncryptionAlgorithm> (new AES ()));
+        #ifndef WOLFCRYPT_BACKEND
 		l.push_back (shared_ptr <EncryptionAlgorithm> (new Serpent ()));
 		l.push_back (shared_ptr <EncryptionAlgorithm> (new Twofish ()));
 		l.push_back (shared_ptr <EncryptionAlgorithm> (new Camellia ()));
@@ -76,7 +77,7 @@ namespace VeraCrypt
 		l.push_back (shared_ptr <EncryptionAlgorithm> (new SerpentAES ()));
 		l.push_back (shared_ptr <EncryptionAlgorithm> (new SerpentTwofishAES ()));
 		l.push_back (shared_ptr <EncryptionAlgorithm> (new TwofishSerpent ()));
-
+        #endif
 		return l;
 	}
 
@@ -229,6 +230,7 @@ namespace VeraCrypt
 		SupportedModes.push_back (shared_ptr <EncryptionMode> (new EncryptionModeXTS ()));
 	}
 
+#ifndef WOLFCRYPT_BACKEND
 	// AES-Twofish
 	AESTwofish::AESTwofish ()
 	{
@@ -353,4 +355,5 @@ namespace VeraCrypt
 
 		SupportedModes.push_back (shared_ptr <EncryptionMode> (new EncryptionModeXTS ()));
 	}
+#endif
 }

--- a/src/Volume/EncryptionAlgorithm.cpp
+++ b/src/Volume/EncryptionAlgorithm.cpp
@@ -12,6 +12,9 @@
 
 #include "EncryptionAlgorithm.h"
 #include "EncryptionModeXTS.h"
+#ifdef WOLFCRYPT_BACKEND
+#include "EncryptionModeWolfCryptXTS.h"
+#endif
 
 namespace VeraCrypt
 {
@@ -216,7 +219,25 @@ namespace VeraCrypt
 		}
 	}
 
-	void EncryptionAlgorithm::ValidateState () const
+    #ifdef WOLFCRYPT_BACKEND
+        void EncryptionAlgorithm::SetKeyXTS (const ConstBufferPtr &key)
+	{
+		if (Ciphers.size() < 1)
+			throw NotInitialized (SRC_POS);
+
+		if (GetKeySize() != key.Size())
+			throw ParameterIncorrect (SRC_POS);
+
+		size_t keyOffset = 0;
+		foreach_ref (Cipher &c, Ciphers)
+		{
+			c.SetKeyXTS (key.GetRange (keyOffset, c.GetKeySize()));
+			keyOffset += c.GetKeySize();
+		}
+	}
+    #endif
+
+        void EncryptionAlgorithm::ValidateState () const
 	{
 		if (Ciphers.size() < 1 || Mode.get() == nullptr)
 			throw NotInitialized (SRC_POS);
@@ -227,8 +248,12 @@ namespace VeraCrypt
 	{
 		Ciphers.push_back (shared_ptr <Cipher> (new CipherAES()));
 
+            #ifdef WOLFCRYPT_BACKEND
+                SupportedModes.push_back (shared_ptr <EncryptionMode> (new EncryptionModeWolfCryptXTS ()));
+            #else
 		SupportedModes.push_back (shared_ptr <EncryptionMode> (new EncryptionModeXTS ()));
-	}
+            #endif
+        }
 
 #ifndef WOLFCRYPT_BACKEND
 	// AES-Twofish

--- a/src/Volume/EncryptionAlgorithm.h
+++ b/src/Volume/EncryptionAlgorithm.h
@@ -46,7 +46,10 @@ namespace VeraCrypt
 		virtual bool IsModeSupported (const EncryptionMode &mode) const;
 		virtual bool IsModeSupported (const shared_ptr <EncryptionMode> mode) const;
 		virtual void SetKey (const ConstBufferPtr &key);
-		virtual void SetMode (shared_ptr <EncryptionMode> mode);
+            #ifdef WOLFCRYPT_BACKEND
+		virtual void SetKeyXTS (const ConstBufferPtr &key);
+            #endif
+                virtual void SetMode (shared_ptr <EncryptionMode> mode);
 
 	protected:
 		EncryptionAlgorithm ();

--- a/src/Volume/EncryptionMode.cpp
+++ b/src/Volume/EncryptionMode.cpp
@@ -12,6 +12,9 @@
 
 #include "EncryptionMode.h"
 #include "EncryptionModeXTS.h"
+#ifdef WOLFCRYPT_BACKEND
+#include "EncryptionModeWolfCryptXTS.h"
+#endif
 #include "EncryptionThreadPool.h"
 
 namespace VeraCrypt
@@ -38,7 +41,11 @@ namespace VeraCrypt
 	{
 		EncryptionModeList l;
 
+            #ifdef WOLFCRYPT_BACKEND
+		l.push_back (shared_ptr <EncryptionMode> (new EncryptionModeWolfCryptXTS ()));
+            #else
 		l.push_back (shared_ptr <EncryptionMode> (new EncryptionModeXTS ()));
+            #endif
 
 		return l;
 	}

--- a/src/Volume/EncryptionModeWolfCryptXTS.cpp
+++ b/src/Volume/EncryptionModeWolfCryptXTS.cpp
@@ -1,0 +1,119 @@
+
+#include "Crypto/cpu.h"
+#include "Crypto/misc.h"
+#include "EncryptionModeWolfCryptXTS.h"
+#include "Common/Crypto.h"
+
+namespace VeraCrypt
+{
+	void EncryptionModeWolfCryptXTS::Encrypt (byte *data, uint64 length) const
+	{
+		EncryptBuffer (data, length, 0);
+	}
+
+	void EncryptionModeWolfCryptXTS::EncryptBuffer (byte *data, uint64 length, uint64 startDataUnitNo) const
+	{
+		if_debug (ValidateState());
+
+		CipherList::const_iterator iSecondaryCipher = SecondaryCiphers.begin();
+
+		for (CipherList::const_iterator iCipher = Ciphers.begin(); iCipher != Ciphers.end(); ++iCipher)
+		{
+			EncryptBufferXTS (**iCipher, **iSecondaryCipher, data, length, startDataUnitNo, 0);
+			++iSecondaryCipher;
+		}
+
+		assert (iSecondaryCipher == SecondaryCiphers.end());
+	}
+
+	void EncryptionModeWolfCryptXTS::EncryptBufferXTS (Cipher &cipher, const Cipher &secondaryCipher, byte *buffer, uint64 length, uint64 startDataUnitNo, unsigned int startCipherBlockNo) const
+	{
+                cipher.EncryptBlockXTS(buffer, length, startDataUnitNo);
+	}
+
+	void EncryptionModeWolfCryptXTS::EncryptSectorsCurrentThread (byte *data, uint64 sectorIndex, uint64 sectorCount, size_t sectorSize) const
+	{
+		EncryptBuffer (data, sectorCount * sectorSize, sectorIndex * sectorSize / ENCRYPTION_DATA_UNIT_SIZE);
+	}
+
+	size_t EncryptionModeWolfCryptXTS::GetKeySize () const
+	{
+		if (Ciphers.empty())
+			throw NotInitialized (SRC_POS);
+
+		size_t keySize = 0;
+		foreach_ref (const Cipher &cipher, SecondaryCiphers)
+		{
+			keySize += cipher.GetKeySize();
+		}
+
+		return keySize;
+	}
+
+	void EncryptionModeWolfCryptXTS::Decrypt (byte *data, uint64 length) const
+	{
+		DecryptBuffer (data, length, 0);
+	}
+
+	void EncryptionModeWolfCryptXTS::DecryptBuffer (byte *data, uint64 length, uint64 startDataUnitNo) const
+	{
+		if_debug (ValidateState());
+
+		CipherList::const_iterator iSecondaryCipher = SecondaryCiphers.end();
+
+		for (CipherList::const_reverse_iterator iCipher = Ciphers.rbegin(); iCipher != Ciphers.rend(); ++iCipher)
+		{
+			--iSecondaryCipher;
+			DecryptBufferXTS (**iCipher, **iSecondaryCipher, data, length, startDataUnitNo, 0);
+		}
+
+		assert (iSecondaryCipher == SecondaryCiphers.begin());
+	}
+
+	void EncryptionModeWolfCryptXTS::DecryptBufferXTS (Cipher &cipher, const Cipher &secondaryCipher, byte *buffer, uint64 length, uint64 startDataUnitNo, unsigned int startCipherBlockNo) const
+	{
+                cipher.DecryptBlockXTS(buffer, length, startDataUnitNo);
+        }
+
+	void EncryptionModeWolfCryptXTS::DecryptSectorsCurrentThread (byte *data, uint64 sectorIndex, uint64 sectorCount, size_t sectorSize) const
+	{
+		DecryptBuffer (data, sectorCount * sectorSize, sectorIndex * sectorSize / ENCRYPTION_DATA_UNIT_SIZE);
+	}
+
+	void EncryptionModeWolfCryptXTS::SetCiphers (const CipherList &ciphers)
+	{
+		EncryptionMode::SetCiphers (ciphers);
+
+		SecondaryCiphers.clear();
+
+		foreach_ref (const Cipher &cipher, ciphers)
+		{
+			SecondaryCiphers.push_back (cipher.GetNew());
+		}
+
+		if (SecondaryKey.Size() > 0)
+			SetSecondaryCipherKeys();
+	}
+
+	void EncryptionModeWolfCryptXTS::SetKey (const ConstBufferPtr &key)
+	{
+		SecondaryKey.Allocate (key.Size());
+		SecondaryKey.CopyFrom (key);
+
+		if (!SecondaryCiphers.empty())
+			SetSecondaryCipherKeys();
+
+        }
+
+	void EncryptionModeWolfCryptXTS::SetSecondaryCipherKeys ()
+	{
+		size_t keyOffset = 0;
+		foreach_ref (Cipher &cipher, SecondaryCiphers)
+		{
+                        cipher.SetKeyXTS (SecondaryKey.GetRange (keyOffset, cipher.GetKeySize()));
+                        keyOffset += cipher.GetKeySize();
+		}
+
+		KeySet = true;
+	}
+}

--- a/src/Volume/EncryptionModeWolfCryptXTS.h
+++ b/src/Volume/EncryptionModeWolfCryptXTS.h
@@ -10,19 +10,19 @@
  code distribution packages.
 */
 
-#ifndef TC_HEADER_Volume_EncryptionModeXTS
-#define TC_HEADER_Volume_EncryptionModeXTS
+#ifndef TC_HEADER_Volume_EncryptionModeWolfCryptXTS
+#define TC_HEADER_Volume_EncryptionModeWolfCryptXTS
 
 #include "Platform/Platform.h"
 #include "EncryptionMode.h"
 
 namespace VeraCrypt
 {
-	class EncryptionModeXTS : public EncryptionMode
+	class EncryptionModeWolfCryptXTS : public EncryptionMode
 	{
 	public:
-		EncryptionModeXTS () { }
-		virtual ~EncryptionModeXTS () { }
+		EncryptionModeWolfCryptXTS () { }
+		virtual ~EncryptionModeWolfCryptXTS () { }
 
 		virtual void Decrypt (byte *data, uint64 length) const;
 		virtual void DecryptSectorsCurrentThread (byte *data, uint64 sectorIndex, uint64 sectorCount, size_t sectorSize) const;
@@ -31,24 +31,24 @@ namespace VeraCrypt
 		virtual const SecureBuffer &GetKey () const { return SecondaryKey; }
 		virtual size_t GetKeySize () const;
 		virtual wstring GetName () const { return L"XTS"; };
-		virtual shared_ptr <EncryptionMode> GetNew () const { return shared_ptr <EncryptionMode> (new EncryptionModeXTS); }
+		virtual shared_ptr <EncryptionMode> GetNew () const { return shared_ptr <EncryptionMode> (new EncryptionModeWolfCryptXTS); }
 		virtual void SetCiphers (const CipherList &ciphers);
-		virtual void SetKey (const ConstBufferPtr &key);
+	        virtual void SetKey (const ConstBufferPtr &key);
 
 	protected:
 		void DecryptBuffer (byte *data, uint64 length, uint64 startDataUnitNo) const;
-		void DecryptBufferXTS (const Cipher &cipher, const Cipher &secondaryCipher, byte *buffer, uint64 length, uint64 startDataUnitNo, unsigned int startCipherBlockNo) const;
+		void DecryptBufferXTS (Cipher &cipher, const Cipher &secondaryCipher, byte *buffer, uint64 length, uint64 startDataUnitNo, unsigned int startCipherBlockNo) const;
 		void EncryptBuffer (byte *data, uint64 length, uint64 startDataUnitNo) const;
-		void EncryptBufferXTS (const Cipher &cipher, const Cipher &secondaryCipher, byte *buffer, uint64 length, uint64 startDataUnitNo, unsigned int startCipherBlockNo) const;
+		void EncryptBufferXTS (Cipher &cipher, const Cipher &secondaryCipher, byte *buffer, uint64 length, uint64 startDataUnitNo, unsigned int startCipherBlockNo) const;
 		void SetSecondaryCipherKeys ();
 
 		SecureBuffer SecondaryKey;
 		CipherList SecondaryCiphers;
 
 	private:
-		EncryptionModeXTS (const EncryptionModeXTS &);
-		EncryptionModeXTS &operator= (const EncryptionModeXTS &);
+		EncryptionModeWolfCryptXTS (const EncryptionModeWolfCryptXTS &);
+		EncryptionModeWolfCryptXTS &operator= (const EncryptionModeWolfCryptXTS &);
 	};
 }
 
-#endif // TC_HEADER_Volume_EncryptionModeXTS
+#endif // TC_HEADER_Volume_EncryptionModeWolfCryptXTS

--- a/src/Volume/EncryptionModeXTS.cpp
+++ b/src/Volume/EncryptionModeXTS.cpp
@@ -67,9 +67,8 @@ namespace VeraCrypt
 		assert (iSecondaryCipher == SecondaryCiphers.end());
 	}
 
-	void EncryptionModeXTS::EncryptBufferXTS (Cipher &cipher, const Cipher &secondaryCipher, byte *buffer, uint64 length, uint64 startDataUnitNo, unsigned int startCipherBlockNo) const
+	void EncryptionModeXTS::EncryptBufferXTS (const Cipher &cipher, const Cipher &secondaryCipher, byte *buffer, uint64 length, uint64 startDataUnitNo, unsigned int startCipherBlockNo) const
 	{
-    #ifndef WOLFCRYPT_BACKEND
                 byte finalCarry;
 		byte whiteningValues [ENCRYPTION_DATA_UNIT_SIZE];
 		byte whiteningValue [BYTES_PER_XTS_BLOCK];
@@ -206,10 +205,6 @@ namespace VeraCrypt
 
 		FAST_ERASE64 (whiteningValue, sizeof (whiteningValue));
 		FAST_ERASE64 (whiteningValues, sizeof (whiteningValues));
-        #else
-                cipher.SetKeyXTS (SecondaryKey.GetRange (0, cipher.GetKeySize()));
-                cipher.EncryptBlockXTS(buffer, length, startDataUnitNo);
-        #endif
 	}
 
 	void EncryptionModeXTS::EncryptSectorsCurrentThread (byte *data, uint64 sectorIndex, uint64 sectorCount, size_t sectorSize) const
@@ -251,9 +246,8 @@ namespace VeraCrypt
 		assert (iSecondaryCipher == SecondaryCiphers.begin());
 	}
 
-	void EncryptionModeXTS::DecryptBufferXTS (Cipher &cipher, const Cipher &secondaryCipher, byte *buffer, uint64 length, uint64 startDataUnitNo, unsigned int startCipherBlockNo) const
+	void EncryptionModeXTS::DecryptBufferXTS (const Cipher &cipher, const Cipher &secondaryCipher, byte *buffer, uint64 length, uint64 startDataUnitNo, unsigned int startCipherBlockNo) const
 	{
-    #ifndef WOLFCRYPT_BACKEND
 		byte finalCarry;
 		byte whiteningValues [ENCRYPTION_DATA_UNIT_SIZE];
 		byte whiteningValue [BYTES_PER_XTS_BLOCK];
@@ -380,10 +374,6 @@ namespace VeraCrypt
 
 		FAST_ERASE64 (whiteningValue, sizeof (whiteningValue));
 		FAST_ERASE64 (whiteningValues, sizeof (whiteningValues));
-	#else
-                cipher.SetKeyXTS (SecondaryKey.GetRange (0, cipher.GetKeySize()));
-                cipher.DecryptBlockXTS(buffer, length, startDataUnitNo);
-        #endif
         }
 
 	void EncryptionModeXTS::DecryptSectorsCurrentThread (byte *data, uint64 sectorIndex, uint64 sectorCount, size_t sectorSize) const
@@ -420,11 +410,7 @@ namespace VeraCrypt
 		size_t keyOffset = 0;
 		foreach_ref (Cipher &cipher, SecondaryCiphers)
 		{
-            #ifndef WOLFCRYPT_BACKEND
 			cipher.SetKey (SecondaryKey.GetRange (keyOffset, cipher.GetKeySize()));
-            #else
-                        cipher.SetKeyXTS (SecondaryKey.GetRange (keyOffset, cipher.GetKeySize()));
-	    #endif
                         keyOffset += cipher.GetKeySize();
 		}
 

--- a/src/Volume/EncryptionModeXTS.h
+++ b/src/Volume/EncryptionModeXTS.h
@@ -37,9 +37,9 @@ namespace VeraCrypt
 
 	protected:
 		void DecryptBuffer (byte *data, uint64 length, uint64 startDataUnitNo) const;
-		void DecryptBufferXTS (const Cipher &cipher, const Cipher &secondaryCipher, byte *buffer, uint64 length, uint64 startDataUnitNo, unsigned int startCipherBlockNo) const;
+		void DecryptBufferXTS (Cipher &cipher, const Cipher &secondaryCipher, byte *buffer, uint64 length, uint64 startDataUnitNo, unsigned int startCipherBlockNo) const;
 		void EncryptBuffer (byte *data, uint64 length, uint64 startDataUnitNo) const;
-		void EncryptBufferXTS (const Cipher &cipher, const Cipher &secondaryCipher, byte *buffer, uint64 length, uint64 startDataUnitNo, unsigned int startCipherBlockNo) const;
+		void EncryptBufferXTS (Cipher &cipher, const Cipher &secondaryCipher, byte *buffer, uint64 length, uint64 startDataUnitNo, unsigned int startCipherBlockNo) const;
 		void SetSecondaryCipherKeys ();
 
 		SecureBuffer SecondaryKey;

--- a/src/Volume/EncryptionTest.cpp
+++ b/src/Volume/EncryptionTest.cpp
@@ -64,6 +64,7 @@ namespace VeraCrypt
 		}
 	};
 
+    #ifndef WOLFCRYPT_BACKEND
 	static const CipherTestVector SerpentTestVectors[] =
 	{
 		{
@@ -151,6 +152,7 @@ namespace VeraCrypt
 			}
 		}
 	};
+    #endif
 
 	static void TestCipher (Cipher &cipher, const CipherTestVector *testVector, size_t testVectorCount)
 	{
@@ -190,6 +192,7 @@ namespace VeraCrypt
 			if (origCrc != Crc32::ProcessBuffer (testData))
 				throw TestFailed (SRC_POS);
 
+        #ifndef WOLFCRYPT_BACKEND
 			CipherSerpent serpent;
 			TestCipher (serpent, SerpentTestVectors, array_capacity (SerpentTestVectors));
 
@@ -201,6 +204,7 @@ namespace VeraCrypt
 			
 			CipherKuznyechik kuznyechik;
 			TestCipher (kuznyechik, KuznyechikTestVectors, array_capacity (KuznyechikTestVectors));
+        #endif
 	}
 
 	const EncryptionTest::XtsTestVector EncryptionTest::XtsTestVectors[] =
@@ -556,6 +560,7 @@ namespace VeraCrypt
 						break;
 					}
 				}
+                        #ifndef WOLFCRYPT_BACKEND
 				else if (typeid (ea) == typeid (Serpent))
 				{
 					switch (testCase)
@@ -920,7 +925,7 @@ namespace VeraCrypt
 						break;
 					}
 				}
-
+                        #endif
 				if (crc == 0x9f5edd58)
 					throw TestFailed (SRC_POS);
 
@@ -974,6 +979,7 @@ namespace VeraCrypt
 					throw TestFailed (SRC_POS);
 				nTestsPerformed++;
 			}
+                #ifndef WOLFCRYPT_BACKEND
 			else if (typeid (ea) == typeid (Serpent))
 			{
 				if (crc != 0x3494d480)
@@ -1058,6 +1064,7 @@ namespace VeraCrypt
 					throw TestFailed (SRC_POS);
 				nTestsPerformed++;
 			}
+                #endif
 
 			if (crc == 0x9f5edd58)
 				throw TestFailed (SRC_POS);
@@ -1069,8 +1076,11 @@ namespace VeraCrypt
 
 			nTestsPerformed++;
 		}
-
+            #ifndef WOLFCRYPT_BACKEND
 		if (nTestsPerformed != 150)
+            #else
+               if (nTestsPerformed != 10)
+            #endif
 			throw TestFailed (SRC_POS);
 	}
 
@@ -1081,6 +1091,7 @@ namespace VeraCrypt
 		ConstBufferPtr salt (saltData, sizeof (saltData));
 		Buffer derivedKey (4);
 
+         #ifndef WOLFCRYPT_BACKEND
 		Pkcs5HmacBlake2s pkcs5HmacBlake2s;
 		pkcs5HmacBlake2s.DeriveKey (derivedKey, password, salt, 5);
 		if (memcmp (derivedKey.Ptr(), "\x8d\x51\xfa\x31", 4) != 0)
@@ -1105,5 +1116,16 @@ namespace VeraCrypt
 		pkcs5HmacStreebog.DeriveKey (derivedKey, password, salt, 5);
 		if (memcmp (derivedKey.Ptr(), "\xd0\x53\xa2\x30", 4) != 0)
 			throw TestFailed (SRC_POS);
-	}
+         #else
+               Pkcs5HmacSha256 pkcs5HmacSha256;
+		pkcs5HmacSha256.DeriveKey (derivedKey, password, salt, 5);
+		if (memcmp (derivedKey.Ptr(), "\x64\xf3\xa5\xa3", 4) != 0)
+			throw TestFailed (SRC_POS);
+
+		Pkcs5HmacSha512 pkcs5HmacSha512;	
+                pkcs5HmacSha512.DeriveKey (derivedKey, password, salt, 5);
+		if (memcmp (derivedKey.Ptr(), "\x55\xa1\x76\xbb", 4) != 0)
+			throw TestFailed (SRC_POS);
+        #endif	
+        }
 }

--- a/src/Volume/Hash.cpp
+++ b/src/Volume/Hash.cpp
@@ -24,11 +24,12 @@ namespace VeraCrypt
 		HashList l;
 
 		l.push_back (shared_ptr <Hash> (new Sha512 ()));
-		l.push_back (shared_ptr <Hash> (new Whirlpool ()));
-		l.push_back (shared_ptr <Hash> (new Blake2s ()));
 		l.push_back (shared_ptr <Hash> (new Sha256 ()));
+        #ifndef WOLFCRYPT_BACKEND
+		l.push_back (shared_ptr <Hash> (new Blake2s ()));
+                l.push_back (shared_ptr <Hash> (new Whirlpool ()));
 		l.push_back (shared_ptr <Hash> (new Streebog ()));
-
+        #endif
 		return l;
 	}
 
@@ -44,6 +45,7 @@ namespace VeraCrypt
 			throw ParameterIncorrect (SRC_POS);
 	}
 
+    #ifndef WOLFCRYPT_BACKEND
 	// RIPEMD-160
 	Blake2s::Blake2s ()
 	{
@@ -67,6 +69,7 @@ namespace VeraCrypt
 		if_debug (ValidateDataParameters (data));
 		blake2s_update ((blake2s_state *) Context.Ptr(), data.Get(), data.Size());
 	}
+    #endif
 
 	// SHA-256
 	Sha256::Sha256 ()
@@ -116,6 +119,7 @@ namespace VeraCrypt
 		sha512_hash (data.Get(), (int) data.Size(), (sha512_ctx *) Context.Ptr());
 	}
 
+    #ifndef WOLFCRYPT_BACKEND
 	// Whirlpool
 	Whirlpool::Whirlpool ()
 	{
@@ -163,4 +167,5 @@ namespace VeraCrypt
 		if_debug (ValidateDataParameters (data));
 		STREEBOG_add ((STREEBOG_CTX *) Context.Ptr(), data.Get(), (int) data.Size());
 	}
+    #endif
 }

--- a/src/Volume/Hash.h
+++ b/src/Volume/Hash.h
@@ -48,6 +48,7 @@ namespace VeraCrypt
 		Hash &operator= (const Hash &);
 	};
 
+    #ifndef WOLFCRYPT_BACKEND
 	// Blake2s
 	class Blake2s : public Hash
 	{
@@ -70,6 +71,7 @@ namespace VeraCrypt
 		Blake2s (const Blake2s &);
 		Blake2s &operator= (const Blake2s &);
 	};
+    #endif
 
 	// SHA-256
 	class Sha256 : public Hash
@@ -117,6 +119,7 @@ namespace VeraCrypt
 		Sha512 &operator= (const Sha512 &);
 	};
 
+    #ifndef WOLFCRYPT_BACKEND
 	// Whirlpool
 	class Whirlpool : public Hash
 	{
@@ -162,6 +165,7 @@ namespace VeraCrypt
 		Streebog (const Streebog &);
 		Streebog &operator= (const Streebog &);
 	};
+    #endif
 }
 
 #endif // TC_HEADER_Encryption_Hash

--- a/src/Volume/Pkcs5Kdf.cpp
+++ b/src/Volume/Pkcs5Kdf.cpp
@@ -56,10 +56,11 @@ namespace VeraCrypt
 
 		l.push_back (shared_ptr <Pkcs5Kdf> (new Pkcs5HmacSha512 ()));
 		l.push_back (shared_ptr <Pkcs5Kdf> (new Pkcs5HmacSha256 ()));
+        #ifndef WOLFCRYPT_BACKEND
 		l.push_back (shared_ptr <Pkcs5Kdf> (new Pkcs5HmacBlake2s ()));
-		l.push_back (shared_ptr <Pkcs5Kdf> (new Pkcs5HmacWhirlpool ()));
+                l.push_back (shared_ptr <Pkcs5Kdf> (new Pkcs5HmacWhirlpool ()));
 		l.push_back (shared_ptr <Pkcs5Kdf> (new Pkcs5HmacStreebog ()));
-
+        #endif
 		return l;
 	}
 
@@ -69,6 +70,7 @@ namespace VeraCrypt
 			throw ParameterIncorrect (SRC_POS);
 	}
 
+    #ifndef WOLFCRYPT_BACKEND
 	void Pkcs5HmacBlake2s_Boot::DeriveKey (const BufferPtr &key, const VolumePassword &password, const ConstBufferPtr &salt, int iterationCount) const
 	{
 		ValidateParameters (key, password, salt, iterationCount);
@@ -80,6 +82,7 @@ namespace VeraCrypt
 		ValidateParameters (key, password, salt, iterationCount);
 		derive_key_blake2s ((char *) password.DataPtr(), (int) password.Size(), (char *) salt.Get(), (int) salt.Size(), iterationCount, (char *) key.Get(), (int) key.Size());
 	}
+    #endif
 
 	void Pkcs5HmacSha256_Boot::DeriveKey (const BufferPtr &key, const VolumePassword &password, const ConstBufferPtr &salt, int iterationCount) const
 	{
@@ -99,6 +102,7 @@ namespace VeraCrypt
 		derive_key_sha512 ((char *) password.DataPtr(), (int) password.Size(), (char *) salt.Get(), (int) salt.Size(), iterationCount, (char *) key.Get(), (int) key.Size());
 	}
 
+    #ifndef WOLFCRYPT_BACKEND
 	void Pkcs5HmacWhirlpool::DeriveKey (const BufferPtr &key, const VolumePassword &password, const ConstBufferPtr &salt, int iterationCount) const
 	{
 		ValidateParameters (key, password, salt, iterationCount);
@@ -116,4 +120,5 @@ namespace VeraCrypt
 		ValidateParameters (key, password, salt, iterationCount);
 		derive_key_streebog ((char *) password.DataPtr(), (int) password.Size(), (char *) salt.Get(), (int) salt.Size(), iterationCount, (char *) key.Get(), (int) key.Size());
 	}
+    #endif
 }

--- a/src/Volume/Pkcs5Kdf.h
+++ b/src/Volume/Pkcs5Kdf.h
@@ -48,6 +48,7 @@ namespace VeraCrypt
 		Pkcs5Kdf &operator= (const Pkcs5Kdf &);
 	};
 
+    #ifndef WOLFCRYPT_BACKEND
 	class Pkcs5HmacBlake2s_Boot : public Pkcs5Kdf
 	{
 	public:
@@ -81,6 +82,7 @@ namespace VeraCrypt
 		Pkcs5HmacBlake2s (const Pkcs5HmacBlake2s &);
 		Pkcs5HmacBlake2s &operator= (const Pkcs5HmacBlake2s &);
 	};
+    #endif
 
 	class Pkcs5HmacSha256_Boot : public Pkcs5Kdf
 	{
@@ -132,7 +134,7 @@ namespace VeraCrypt
 		Pkcs5HmacSha512 (const Pkcs5HmacSha512 &);
 		Pkcs5HmacSha512 &operator= (const Pkcs5HmacSha512 &);
 	};
-
+    #ifndef WOLFCRYPT_BACKEND
 	class Pkcs5HmacWhirlpool : public Pkcs5Kdf
 	{
 	public:
@@ -183,6 +185,7 @@ namespace VeraCrypt
 		Pkcs5HmacStreebog_Boot (const Pkcs5HmacStreebog_Boot &);
 		Pkcs5HmacStreebog_Boot &operator= (const Pkcs5HmacStreebog_Boot &);
 	};
+    #endif
 }
 
 #endif // TC_HEADER_Encryption_Pkcs5

--- a/src/Volume/Volume.make
+++ b/src/Volume/Volume.make
@@ -16,7 +16,6 @@ OBJSNOOPT :=
 OBJS += Cipher.o
 OBJS += EncryptionAlgorithm.o
 OBJS += EncryptionMode.o
-OBJS += EncryptionModeXTS.o
 OBJS += EncryptionTest.o
 OBJS += EncryptionThreadPool.o
 OBJS += Hash.o
@@ -29,6 +28,12 @@ OBJS += VolumeInfo.o
 OBJS += VolumeLayout.o
 OBJS += VolumePassword.o
 OBJS += VolumePasswordCache.o
+
+ifeq "$(ENABLE_WOLFCRYPT)" "0"
+OBJS += EncryptionModeXTS.o
+else
+OBJS += EncryptionModeWolfCryptXTS.o
+endif
 
 ifeq "$(ENABLE_WOLFCRYPT)" "0"
     ifeq "$(PLATFORM)" "MacOSX"

--- a/src/Volume/Volume.make
+++ b/src/Volume/Volume.make
@@ -30,58 +30,62 @@ OBJS += VolumeLayout.o
 OBJS += VolumePassword.o
 OBJS += VolumePasswordCache.o
 
-ifeq "$(PLATFORM)" "MacOSX"
-    OBJSEX += ../Crypto/Aes_asm.oo
-    OBJS += ../Crypto/Aes_hw_cpu.o
-    OBJS += ../Crypto/Aescrypt.o
-    OBJSEX += ../Crypto/Twofish_asm.oo
-    OBJSEX += ../Crypto/Camellia_asm.oo
-	OBJSEX += ../Crypto/Camellia_aesni_asm.oo
-	OBJSEX += ../Crypto/sha256-nayuki.oo
-	OBJSEX += ../Crypto/sha512-nayuki.oo
-	OBJSEX += ../Crypto/sha256_avx1.oo
-	OBJSEX += ../Crypto/sha256_avx2.oo
-	OBJSEX += ../Crypto/sha256_sse4.oo
-	OBJSEX += ../Crypto/sha512_avx1.oo
-	OBJSEX += ../Crypto/sha512_avx2.oo
-	OBJSEX += ../Crypto/sha512_sse4.oo
-else ifeq "$(CPU_ARCH)" "x86"
-	OBJS += ../Crypto/Aes_x86.o
-ifeq "$(DISABLE_AESNI)" "0"
-	OBJS += ../Crypto/Aes_hw_cpu.o
-endif
-	OBJS += ../Crypto/sha256-x86-nayuki.o
-	OBJS += ../Crypto/sha512-x86-nayuki.o
-else ifeq "$(CPU_ARCH)" "x64"
-	OBJS += ../Crypto/Aes_x64.o
-ifeq "$(DISABLE_AESNI)" "0"
-	OBJS += ../Crypto/Aes_hw_cpu.o
-endif
-	OBJS += ../Crypto/Twofish_x64.o
-	OBJS += ../Crypto/Camellia_x64.o
-	OBJS += ../Crypto/Camellia_aesni_x64.o
-	OBJS += ../Crypto/sha512-x64-nayuki.o
-	OBJS += ../Crypto/sha256_avx1_x64.o
-	OBJS += ../Crypto/sha256_avx2_x64.o
-	OBJS += ../Crypto/sha256_sse4_x64.o
-	OBJS += ../Crypto/sha512_avx1_x64.o
-	OBJS += ../Crypto/sha512_avx2_x64.o
-	OBJS += ../Crypto/sha512_sse4_x64.o
+ifeq "$(ENABLE_WOLFCRYPT)" "0"
+    ifeq "$(PLATFORM)" "MacOSX"
+        OBJSEX += ../Crypto/Aes_asm.oo
+        OBJS += ../Crypto/Aes_hw_cpu.o
+        OBJS += ../Crypto/Aescrypt.o
+        OBJSEX += ../Crypto/Twofish_asm.oo
+        OBJSEX += ../Crypto/Camellia_asm.oo
+            OBJSEX += ../Crypto/Camellia_aesni_asm.oo
+            OBJSEX += ../Crypto/sha256-nayuki.oo
+            OBJSEX += ../Crypto/sha512-nayuki.oo
+            OBJSEX += ../Crypto/sha256_avx1.oo
+            OBJSEX += ../Crypto/sha256_avx2.oo
+            OBJSEX += ../Crypto/sha256_sse4.oo
+            OBJSEX += ../Crypto/sha512_avx1.oo
+            OBJSEX += ../Crypto/sha512_avx2.oo
+            OBJSEX += ../Crypto/sha512_sse4.oo
+    else ifeq "$(CPU_ARCH)" "x86"
+            OBJS += ../Crypto/Aes_x86.o
+    ifeq "$(DISABLE_AESNI)" "0"
+            OBJS += ../Crypto/Aes_hw_cpu.o
+    endif
+            OBJS += ../Crypto/sha256-x86-nayuki.o
+            OBJS += ../Crypto/sha512-x86-nayuki.o
+    else ifeq "$(CPU_ARCH)" "x64"
+            OBJS += ../Crypto/Aes_x64.o
+    ifeq "$(DISABLE_AESNI)" "0"
+            OBJS += ../Crypto/Aes_hw_cpu.o
+    endif
+            OBJS += ../Crypto/Twofish_x64.o
+            OBJS += ../Crypto/Camellia_x64.o
+            OBJS += ../Crypto/Camellia_aesni_x64.o
+            OBJS += ../Crypto/sha512-x64-nayuki.o
+            OBJS += ../Crypto/sha256_avx1_x64.o
+            OBJS += ../Crypto/sha256_avx2_x64.o
+            OBJS += ../Crypto/sha256_sse4_x64.o
+            OBJS += ../Crypto/sha512_avx1_x64.o
+            OBJS += ../Crypto/sha512_avx2_x64.o
+            OBJS += ../Crypto/sha512_sse4_x64.o
+    else
+            OBJS += ../Crypto/Aescrypt.o
+    endif
+
+    ifeq "$(GCC_GTEQ_430)" "1"
+    OBJSSSE41 += ../Crypto/blake2s_SSE41.osse41
+    OBJSSSSE3 += ../Crypto/blake2s_SSSE3.ossse3
+    else
+    OBJS += ../Crypto/blake2s_SSE41.o
+    OBJS += ../Crypto/blake2s_SSSE3.o
+    endif
 else
-	OBJS += ../Crypto/Aescrypt.o
+    OBJS += ../Crypto/wolfCrypt.o
 endif
 
-ifeq "$(GCC_GTEQ_430)" "1"
-OBJSSSE41 += ../Crypto/blake2s_SSE41.osse41
-OBJSSSSE3 += ../Crypto/blake2s_SSSE3.ossse3
-else
-OBJS += ../Crypto/blake2s_SSE41.o
-OBJS += ../Crypto/blake2s_SSSE3.o
-endif
-
+ifeq "$(ENABLE_WOLFCRYPT)" "0"
 OBJS += ../Crypto/Aeskey.o
 OBJS += ../Crypto/Aestab.o
-OBJS += ../Crypto/cpu.o
 OBJS += ../Crypto/blake2s.o
 OBJS += ../Crypto/blake2s_SSE2.o
 OBJS += ../Crypto/SerpentFast.o
@@ -93,6 +97,10 @@ OBJS += ../Crypto/Camellia.o
 OBJS += ../Crypto/Streebog.o
 OBJS += ../Crypto/kuznyechik.o
 OBJS += ../Crypto/kuznyechik_simd.o
+OBJS += ../Common/Pkcs5.o
+endif
+
+OBJS += ../Crypto/cpu.o
 
 OBJSNOOPT += ../Crypto/jitterentropy-base.o0
 
@@ -110,54 +118,55 @@ OBJS += ../Common/EMVCard.o
 OBJS += ../Common/EMVToken.o
 OBJS += ../Common/Endian.o
 OBJS += ../Common/GfMul.o
-OBJS += ../Common/Pkcs5.o
 OBJS += ../Common/SecurityToken.o
 
 VolumeLibrary: Volume.a
 
-ifeq "$(PLATFORM)" "MacOSX"
-../Crypto/Aes_asm.oo: ../Crypto/Aes_x86.asm ../Crypto/Aes_x64.asm
-	@echo Assembling $(<F)
-	$(AS) $(ASFLAGS32) -o ../Crypto/Aes_x86.o ../Crypto/Aes_x86.asm
-	$(AS) $(ASFLAGS64) -o ../Crypto/Aes_x64.o ../Crypto/Aes_x64.asm
-	lipo -create ../Crypto/Aes_x86.o ../Crypto/Aes_x64.o -output ../Crypto/Aes_asm.oo
-	rm -fr ../Crypto/Aes_x86.o ../Crypto/Aes_x64.o
-../Crypto/Twofish_asm.oo: ../Crypto/Twofish_x64.S
-	@echo Assembling $(<F)
-	$(AS) $(ASFLAGS64) -p gas -o ../Crypto/Twofish_asm.oo ../Crypto/Twofish_x64.S 
-../Crypto/Camellia_asm.oo: ../Crypto/Camellia_x64.S
-	@echo Assembling $(<F)
-	$(AS) $(ASFLAGS64) -p gas -o ../Crypto/Camellia_asm.oo ../Crypto/Camellia_x64.S
-../Crypto/Camellia_aesni_asm.oo: ../Crypto/Camellia_aesni_x64.S
-	@echo Assembling $(<F)
-	$(AS) $(ASFLAGS64) -p gas -o ../Crypto/Camellia_aesni_asm.oo ../Crypto/Camellia_aesni_x64.S
-../Crypto/sha256-nayuki.oo: ../Crypto/sha256-x86-nayuki.S
-	@echo Assembling $(<F)
-	$(AS) $(ASFLAGS32) -p gas -o ../Crypto/sha256-x86-nayuki.o ../Crypto/sha256-x86-nayuki.S
-	$(AS) $(ASFLAGS64) -p gas -o ../Crypto/sha256-x64-nayuki.o ../Crypto/sha256-x64-nayuki.S
-	lipo -create ../Crypto/sha256-x86-nayuki.o ../Crypto/sha256-x64-nayuki.o -output ../Crypto/sha256-nayuki.oo
-	rm -fr ../Crypto/sha256-x86-nayuki.o ../Crypto/sha256-x64-nayuki.o
-../Crypto/sha256_avx1.oo: ../Crypto/sha256_avx1_x64.asm
-	@echo Assembling $(<F)
-	$(AS) $(ASFLAGS64) -o ../Crypto/sha256_avx1.oo ../Crypto/sha256_avx1_x64.asm
-../Crypto/sha256_avx2.oo: ../Crypto/sha256_avx2_x64.asm
-	@echo Assembling $(<F)
-	$(AS) $(ASFLAGS64) -o ../Crypto/sha256_avx2.oo ../Crypto/sha256_avx2_x64.asm
-../Crypto/sha256_sse4.oo: ../Crypto/sha256_sse4_x64.asm
-	@echo Assembling $(<F)
-	$(AS) $(ASFLAGS64) -o ../Crypto/sha256_sse4.oo ../Crypto/sha256_sse4_x64.asm
-../Crypto/sha512-nayuki.oo: ../Crypto/sha512-x64-nayuki.S
-	@echo Assembling $(<F)
-	$(AS) -p gas $(ASFLAGS64) -o ../Crypto/sha512-nayuki.oo ../Crypto/sha512-x64-nayuki.S
-../Crypto/sha512_avx1.oo: ../Crypto/sha512_avx1_x64.asm
-	@echo Assembling $(<F)
-	$(AS) $(ASFLAGS64) -o ../Crypto/sha512_avx1.oo ../Crypto/sha512_avx1_x64.asm
-../Crypto/sha512_avx2.oo: ../Crypto/sha512_avx2_x64.asm
-	@echo Assembling $(<F)
-	$(AS) $(ASFLAGS64) -o ../Crypto/sha512_avx2.oo ../Crypto/sha512_avx2_x64.asm
-../Crypto/sha512_sse4.oo: ../Crypto/sha512_sse4_x64.asm
-	@echo Assembling $(<F)
-	$(AS) $(ASFLAGS64) -o ../Crypto/sha512_sse4.oo ../Crypto/sha512_sse4_x64.asm
+ifeq "$(ENABLE_WOLFCRYPT)" "0"
+    ifeq "$(PLATFORM)" "MacOSX"
+    ../Crypto/Aes_asm.oo: ../Crypto/Aes_x86.asm ../Crypto/Aes_x64.asm
+            @echo Assembling $(<F)
+            $(AS) $(ASFLAGS32) -o ../Crypto/Aes_x86.o ../Crypto/Aes_x86.asm
+            $(AS) $(ASFLAGS64) -o ../Crypto/Aes_x64.o ../Crypto/Aes_x64.asm
+            lipo -create ../Crypto/Aes_x86.o ../Crypto/Aes_x64.o -output ../Crypto/Aes_asm.oo
+            rm -fr ../Crypto/Aes_x86.o ../Crypto/Aes_x64.o
+    ../Crypto/Twofish_asm.oo: ../Crypto/Twofish_x64.S
+            @echo Assembling $(<F)
+            $(AS) $(ASFLAGS64) -p gas -o ../Crypto/Twofish_asm.oo ../Crypto/Twofish_x64.S 
+    ../Crypto/Camellia_asm.oo: ../Crypto/Camellia_x64.S
+            @echo Assembling $(<F)
+            $(AS) $(ASFLAGS64) -p gas -o ../Crypto/Camellia_asm.oo ../Crypto/Camellia_x64.S
+    ../Crypto/Camellia_aesni_asm.oo: ../Crypto/Camellia_aesni_x64.S
+            @echo Assembling $(<F)
+            $(AS) $(ASFLAGS64) -p gas -o ../Crypto/Camellia_aesni_asm.oo ../Crypto/Camellia_aesni_x64.S
+    ../Crypto/sha256-nayuki.oo: ../Crypto/sha256-x86-nayuki.S
+            @echo Assembling $(<F)
+            $(AS) $(ASFLAGS32) -p gas -o ../Crypto/sha256-x86-nayuki.o ../Crypto/sha256-x86-nayuki.S
+            $(AS) $(ASFLAGS64) -p gas -o ../Crypto/sha256-x64-nayuki.o ../Crypto/sha256-x64-nayuki.S
+            lipo -create ../Crypto/sha256-x86-nayuki.o ../Crypto/sha256-x64-nayuki.o -output ../Crypto/sha256-nayuki.oo
+            rm -fr ../Crypto/sha256-x86-nayuki.o ../Crypto/sha256-x64-nayuki.o
+    ../Crypto/sha256_avx1.oo: ../Crypto/sha256_avx1_x64.asm
+            @echo Assembling $(<F)
+            $(AS) $(ASFLAGS64) -o ../Crypto/sha256_avx1.oo ../Crypto/sha256_avx1_x64.asm
+    ../Crypto/sha256_avx2.oo: ../Crypto/sha256_avx2_x64.asm
+            @echo Assembling $(<F)
+            $(AS) $(ASFLAGS64) -o ../Crypto/sha256_avx2.oo ../Crypto/sha256_avx2_x64.asm
+    ../Crypto/sha256_sse4.oo: ../Crypto/sha256_sse4_x64.asm
+            @echo Assembling $(<F)
+            $(AS) $(ASFLAGS64) -o ../Crypto/sha256_sse4.oo ../Crypto/sha256_sse4_x64.asm
+    ../Crypto/sha512-nayuki.oo: ../Crypto/sha512-x64-nayuki.S
+            @echo Assembling $(<F)
+            $(AS) -p gas $(ASFLAGS64) -o ../Crypto/sha512-nayuki.oo ../Crypto/sha512-x64-nayuki.S
+    ../Crypto/sha512_avx1.oo: ../Crypto/sha512_avx1_x64.asm
+            @echo Assembling $(<F)
+            $(AS) $(ASFLAGS64) -o ../Crypto/sha512_avx1.oo ../Crypto/sha512_avx1_x64.asm
+    ../Crypto/sha512_avx2.oo: ../Crypto/sha512_avx2_x64.asm
+            @echo Assembling $(<F)
+            $(AS) $(ASFLAGS64) -o ../Crypto/sha512_avx2.oo ../Crypto/sha512_avx2_x64.asm
+    ../Crypto/sha512_sse4.oo: ../Crypto/sha512_sse4_x64.asm
+            @echo Assembling $(<F)
+            $(AS) $(ASFLAGS64) -o ../Crypto/sha512_sse4.oo ../Crypto/sha512_sse4_x64.asm
+    endif
 endif
 
 include $(BUILD_INC)/Makefile.inc

--- a/src/Volume/VolumeLayout.cpp
+++ b/src/Volume/VolumeLayout.cpp
@@ -66,6 +66,7 @@ namespace VeraCrypt
 		HeaderSize = TC_VOLUME_HEADER_SIZE_LEGACY;
 
 		SupportedEncryptionAlgorithms.push_back (shared_ptr <EncryptionAlgorithm> (new AES ()));
+        #ifndef WOLFCRYPT_BACKEND
 		SupportedEncryptionAlgorithms.push_back (shared_ptr <EncryptionAlgorithm> (new Serpent ()));
 		SupportedEncryptionAlgorithms.push_back (shared_ptr <EncryptionAlgorithm> (new Twofish ()));
 		SupportedEncryptionAlgorithms.push_back (shared_ptr <EncryptionAlgorithm> (new Camellia ()));
@@ -74,7 +75,7 @@ namespace VeraCrypt
 		SupportedEncryptionAlgorithms.push_back (shared_ptr <EncryptionAlgorithm> (new SerpentAES ()));
 		SupportedEncryptionAlgorithms.push_back (shared_ptr <EncryptionAlgorithm> (new SerpentTwofishAES ()));
 		SupportedEncryptionAlgorithms.push_back (shared_ptr <EncryptionAlgorithm> (new TwofishSerpent ()));
-
+        #endif
 		SupportedEncryptionModes.push_back (shared_ptr <EncryptionMode> (new EncryptionModeXTS ()));
 	}
 
@@ -97,6 +98,7 @@ namespace VeraCrypt
 		BackupHeaderOffset = -TC_VOLUME_HEADER_GROUP_SIZE;
 
 		SupportedEncryptionAlgorithms.push_back (shared_ptr <EncryptionAlgorithm> (new AES ()));
+        #ifndef WOLFCRYPT_BACKEND
 		SupportedEncryptionAlgorithms.push_back (shared_ptr <EncryptionAlgorithm> (new Serpent ()));
 		SupportedEncryptionAlgorithms.push_back (shared_ptr <EncryptionAlgorithm> (new Twofish ()));
 		SupportedEncryptionAlgorithms.push_back (shared_ptr <EncryptionAlgorithm> (new Camellia ()));
@@ -111,7 +113,7 @@ namespace VeraCrypt
 		SupportedEncryptionAlgorithms.push_back (shared_ptr <EncryptionAlgorithm> (new SerpentAES ()));
 		SupportedEncryptionAlgorithms.push_back (shared_ptr <EncryptionAlgorithm> (new SerpentTwofishAES ()));
 		SupportedEncryptionAlgorithms.push_back (shared_ptr <EncryptionAlgorithm> (new TwofishSerpent ()));
-
+        #endif
 		SupportedEncryptionModes.push_back (shared_ptr <EncryptionMode> (new EncryptionModeXTS ()));
 	}
 
@@ -142,6 +144,7 @@ namespace VeraCrypt
 		BackupHeaderOffset = -TC_HIDDEN_VOLUME_HEADER_OFFSET;
 
 		SupportedEncryptionAlgorithms.push_back (shared_ptr <EncryptionAlgorithm> (new AES ()));
+        #ifndef WOLFCRYPT_BACKEND
 		SupportedEncryptionAlgorithms.push_back (shared_ptr <EncryptionAlgorithm> (new Serpent ()));
 		SupportedEncryptionAlgorithms.push_back (shared_ptr <EncryptionAlgorithm> (new Twofish ()));
 		SupportedEncryptionAlgorithms.push_back (shared_ptr <EncryptionAlgorithm> (new Camellia ()));
@@ -156,7 +159,7 @@ namespace VeraCrypt
 		SupportedEncryptionAlgorithms.push_back (shared_ptr <EncryptionAlgorithm> (new SerpentAES ()));
 		SupportedEncryptionAlgorithms.push_back (shared_ptr <EncryptionAlgorithm> (new SerpentTwofishAES ()));
 		SupportedEncryptionAlgorithms.push_back (shared_ptr <EncryptionAlgorithm> (new TwofishSerpent ()));
-
+        #endif
 		SupportedEncryptionModes.push_back (shared_ptr <EncryptionMode> (new EncryptionModeXTS ()));
 	}
 
@@ -194,6 +197,7 @@ namespace VeraCrypt
 		HeaderSize = TC_BOOT_ENCRYPTION_VOLUME_HEADER_SIZE;
 
 		SupportedEncryptionAlgorithms.push_back (shared_ptr <EncryptionAlgorithm> (new AES ()));
+        #ifndef WOLFCRYPT_BACKEND
 		SupportedEncryptionAlgorithms.push_back (shared_ptr <EncryptionAlgorithm> (new Serpent ()));
 		SupportedEncryptionAlgorithms.push_back (shared_ptr <EncryptionAlgorithm> (new Twofish ()));
 		SupportedEncryptionAlgorithms.push_back (shared_ptr <EncryptionAlgorithm> (new Camellia ()));
@@ -208,7 +212,7 @@ namespace VeraCrypt
 		SupportedEncryptionAlgorithms.push_back (shared_ptr <EncryptionAlgorithm> (new SerpentAES ()));
 		SupportedEncryptionAlgorithms.push_back (shared_ptr <EncryptionAlgorithm> (new SerpentTwofishAES ()));
 		SupportedEncryptionAlgorithms.push_back (shared_ptr <EncryptionAlgorithm> (new TwofishSerpent ()));
-		
+        #endif		
 		SupportedEncryptionModes.push_back (shared_ptr <EncryptionMode> (new EncryptionModeXTS ()));
 	}
 
@@ -226,10 +230,12 @@ namespace VeraCrypt
 	{
 		Pkcs5KdfList l;
 		l.push_back (shared_ptr <Pkcs5Kdf> (new Pkcs5HmacSha256_Boot ()));
-		l.push_back (shared_ptr <Pkcs5Kdf> (new Pkcs5HmacBlake2s_Boot ()));
 		l.push_back (shared_ptr <Pkcs5Kdf> (new Pkcs5HmacSha512 ()));
+        #ifndef WOLFCRYPT_BACKEND
+		l.push_back (shared_ptr <Pkcs5Kdf> (new Pkcs5HmacBlake2s_Boot ()));
 		l.push_back (shared_ptr <Pkcs5Kdf> (new Pkcs5HmacWhirlpool ()));
 		l.push_back (shared_ptr <Pkcs5Kdf> (new Pkcs5HmacStreebog ()));
-		return l;
+        #endif
+                return l;
 	}
 }

--- a/src/Volume/VolumeLayout.cpp
+++ b/src/Volume/VolumeLayout.cpp
@@ -12,6 +12,9 @@
 
 #include "Volume/EncryptionMode.h"
 #include "Volume/EncryptionModeXTS.h"
+#ifdef WOLFCRYPT_BACKEND
+#include "Volume/EncryptionModeWolfCryptXTS.h"
+#endif
 #include "VolumeLayout.h"
 #include "Boot/Windows/BootCommon.h"
 
@@ -75,8 +78,11 @@ namespace VeraCrypt
 		SupportedEncryptionAlgorithms.push_back (shared_ptr <EncryptionAlgorithm> (new SerpentAES ()));
 		SupportedEncryptionAlgorithms.push_back (shared_ptr <EncryptionAlgorithm> (new SerpentTwofishAES ()));
 		SupportedEncryptionAlgorithms.push_back (shared_ptr <EncryptionAlgorithm> (new TwofishSerpent ()));
+
+                SupportedEncryptionModes.push_back (shared_ptr <EncryptionMode> (new EncryptionModeXTS ()));
+        #else
+                SupportedEncryptionModes.push_back (shared_ptr <EncryptionMode> (new EncryptionModeWolfCryptXTS ()));
         #endif
-		SupportedEncryptionModes.push_back (shared_ptr <EncryptionMode> (new EncryptionModeXTS ()));
 	}
 
 	uint64 VolumeLayoutV1Normal::GetDataOffset (uint64 volumeHostSize) const
@@ -113,9 +119,12 @@ namespace VeraCrypt
 		SupportedEncryptionAlgorithms.push_back (shared_ptr <EncryptionAlgorithm> (new SerpentAES ()));
 		SupportedEncryptionAlgorithms.push_back (shared_ptr <EncryptionAlgorithm> (new SerpentTwofishAES ()));
 		SupportedEncryptionAlgorithms.push_back (shared_ptr <EncryptionAlgorithm> (new TwofishSerpent ()));
-        #endif
 		SupportedEncryptionModes.push_back (shared_ptr <EncryptionMode> (new EncryptionModeXTS ()));
-	}
+        #else
+		SupportedEncryptionModes.push_back (shared_ptr <EncryptionMode> (new EncryptionModeWolfCryptXTS ()));
+        #endif
+
+        }
 
 	uint64 VolumeLayoutV2Normal::GetDataOffset (uint64 volumeHostSize) const
 	{
@@ -159,8 +168,11 @@ namespace VeraCrypt
 		SupportedEncryptionAlgorithms.push_back (shared_ptr <EncryptionAlgorithm> (new SerpentAES ()));
 		SupportedEncryptionAlgorithms.push_back (shared_ptr <EncryptionAlgorithm> (new SerpentTwofishAES ()));
 		SupportedEncryptionAlgorithms.push_back (shared_ptr <EncryptionAlgorithm> (new TwofishSerpent ()));
-        #endif
+
 		SupportedEncryptionModes.push_back (shared_ptr <EncryptionMode> (new EncryptionModeXTS ()));
+        #else
+		SupportedEncryptionModes.push_back (shared_ptr <EncryptionMode> (new EncryptionModeWolfCryptXTS ()));
+        #endif
 	}
 
 	uint64 VolumeLayoutV2Hidden::GetDataOffset (uint64 volumeHostSize) const
@@ -212,9 +224,13 @@ namespace VeraCrypt
 		SupportedEncryptionAlgorithms.push_back (shared_ptr <EncryptionAlgorithm> (new SerpentAES ()));
 		SupportedEncryptionAlgorithms.push_back (shared_ptr <EncryptionAlgorithm> (new SerpentTwofishAES ()));
 		SupportedEncryptionAlgorithms.push_back (shared_ptr <EncryptionAlgorithm> (new TwofishSerpent ()));
-        #endif		
-		SupportedEncryptionModes.push_back (shared_ptr <EncryptionMode> (new EncryptionModeXTS ()));
-	}
+
+                SupportedEncryptionModes.push_back (shared_ptr <EncryptionMode> (new EncryptionModeXTS ()));
+        #else
+		SupportedEncryptionModes.push_back (shared_ptr <EncryptionMode> (new EncryptionModeWolfCryptXTS ()));
+        #endif
+
+        }
 
 	uint64 VolumeLayoutSystemEncryption::GetDataOffset (uint64 volumeHostSize) const
 	{


### PR DESCRIPTION
Requires https://github.com/wolfSSL/wolfssl/pull/6806

See [src/Crypto/wolfCrypt.md](https://github.com/veracrypt/VeraCrypt/blob/a9e7812f7cba9f901c68dcc732885ac041c0b37b/src/Crypto/wolfCrypt.md)

Most modifications are compiling out hashing algorithms and encryption ciphers not supported by wolfCrypt