### PR TITLE
Update Language.zh-cn.xml

### DIFF
--- a/Translations/Language.zh-cn.xml
+++ b/Translations/Language.zh-cn.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <VeraCrypt>
   <localization prog-version= "1.26.9">
-    <language langid="zh-cn" name="简体中文" en-name="Chinese (Simplified)" version="1.0.2" translators="Barney Li, Zhangjintao, Nkh0472，风之暇想" />
-    <font lang="zh-cn" class="normal" size="11" face="Tahoma" />
-    <font lang="zh-cn" class="bold" size="14" face="Tahoma" />
-    <font lang="zh-cn" class="fixed" size="14" face="MingLiU" />
-    <font lang="zh-cn" class="title" size="21" face="Tahoma" />
+    <language langid="zh-cn" name="简体中文" en-name="Chinese (Simplified)" version="1.0.3" translators="Barney Li, Zhangjintao, Nkh0472，风之暇想" />
+    <font lang="zh-cn" class="normal" size="14" face="Microsoft YaHei" />
+    <font lang="zh-cn" class="bold" size="15" face="Microsoft YaHei" />
+    <font lang="zh-cn" class="fixed" size="14" face="Microsoft YaHei" />
+    <font lang="zh-cn" class="title" size="21" face="Microsoft YaHei" />
 
     <entry lang="zh-cn" key="IDCANCEL">取消</entry>
     <entry lang="zh-cn" key="IDC_ALL_USERS">为所有用户安装(&amp;F)</entry>

--- a/Translations/Language.zh-cn.xml
+++ b/Translations/Language.zh-cn.xml
@@ -2,8 +2,8 @@
 <VeraCrypt>
   <localization prog-version= "1.26.9">
     <language langid="zh-cn" name="简体中文" en-name="Chinese (Simplified)" version="1.0.3" translators="Barney Li, Zhangjintao, Nkh0472，风之暇想" />
-    <font lang="zh-cn" class="normal" size="14" face="Microsoft YaHei" />
-    <font lang="zh-cn" class="bold" size="15" face="Microsoft YaHei" />
+    <font lang="zh-cn" class="normal" size="12" face="Microsoft YaHei" />
+    <font lang="zh-cn" class="bold" size="14" face="Microsoft YaHei" />
     <font lang="zh-cn" class="fixed" size="14" face="Microsoft YaHei" />
     <font lang="zh-cn" class="title" size="21" face="Microsoft YaHei" />
 


### PR DESCRIPTION
修改字体为微软雅黑（Microsoft YaHei），
Tahoma适合阿拉伯/希腊等语言，MingLiU适合繁体中文；Windows简体中文系统的默认字体是微软雅黑。

![图片](https://github.com/veracrypt/VeraCrypt/assets/53783792/2fab975d-52dc-46e2-95b8-29ae2ec8235c)
修改后
![图片](https://github.com/veracrypt/VeraCrypt/assets/53783792/ef402305-1da8-487f-9bcf-b7b1a3816608)
