### PR TITLE
Linux: Focus PIM field when selected

### DIFF
--- a/src/Main/Forms/VolumePasswordPanel.cpp
+++ b/src/Main/Forms/VolumePasswordPanel.cpp
@@ -467,6 +467,7 @@ namespace VeraCrypt
 			VolumePimStaticText->Show (true);
 			VolumePimTextCtrl->Show (true);
 			VolumePimHelpStaticText->Show (true);
+			VolumePimTextCtrl->SetFocus();
 
 			if (DisplayPasswordCheckBox->IsChecked ())
 				DisplayPassword (true, &VolumePimTextCtrl, 3);


### PR DESCRIPTION
Improve accessibility by focusing VolumePimTextCtrl initially when the checkbox is selected.

Fixes #1238 