### PR TITLE
Linux: Fix generic installation script on Konsole in Wayland

### DIFF
--- a/src/Setup/FreeBSD/veracrypt_install_template.sh
+++ b/src/Setup/FreeBSD/veracrypt_install_template.sh
@@ -93,7 +93,7 @@ show_message()
 					else
 						if [ $KTERM -eq 1 ]
 						then
-							konsole --title 'VeraCrypt Setup' --caption 'VeraCrypt Setup' -e sh -c "echo $*; read A"
+							konsole --qwindowtitle 'VeraCrypt Setup' --caption 'VeraCrypt Setup' -e sh -c "echo $*; read A"
 						fi
 					fi
 				fi
@@ -1074,7 +1074,7 @@ then
 			else
 				if [ $KTERM -eq 1 ]
 				then
-					exec konsole --title 'VeraCrypt Setup' --caption 'VeraCrypt Setup' -e sh -c "echo Installing package...; $SUDO $PACKAGE_INSTALLER $PACKAGE_INSTALLER_OPTS $PACKAGE; rm -f $PACKAGE; echo; echo Press Enter to exit...; read A"
+					exec konsole --qwindowtitle 'VeraCrypt Setup' --caption 'VeraCrypt Setup' -e sh -c "echo Installing package...; $SUDO $PACKAGE_INSTALLER $PACKAGE_INSTALLER_OPTS $PACKAGE; rm -f $PACKAGE; echo; echo Press Enter to exit...; read A"
 				fi
 			fi
 		fi

--- a/src/Setup/Linux/veracrypt_install_template.sh
+++ b/src/Setup/Linux/veracrypt_install_template.sh
@@ -97,7 +97,7 @@ show_message()
 					else
 						if [ $KTERM -eq 1 ]
 						then
-							konsole --title 'VeraCrypt Setup' -e sh -c "echo $*; read A"
+							konsole --qwindowtitle 'VeraCrypt Setup' -e sh -c "echo $*; read A"
 						fi
 					fi
 				fi
@@ -1078,7 +1078,7 @@ then
 			else
 				if [ $KTERM -eq 1 ]
 				then
-					exec konsole --title 'VeraCrypt Setup' -e sh -c "echo Installing package...; $SUDO $PACKAGE_INSTALLER $PACKAGE_INSTALLER_OPTS $PACKAGE; rm -f $PACKAGE; echo; echo Press Enter to exit...; read A"
+					exec konsole --qwindowtitle 'VeraCrypt Setup' -e sh -c "echo Installing package...; $SUDO $PACKAGE_INSTALLER $PACKAGE_INSTALLER_OPTS $PACKAGE; rm -f $PACKAGE; echo; echo Press Enter to exit...; read A"
 				fi
 			fi
 		fi


### PR DESCRIPTION
Currently the generic installation script will break on Konsole in a Wayland session as the x11 aliases such as --title are only available in the Qt application if the XDG_SESSION_TYPE is x11. Instead of using an alias, we can use --qwindowtitle directly.

Not tested on FreeBSD but should apply similarly.