### PR TITLE
Update Corsican translation on 2023-11

### DIFF
--- a/Translations/Language.co.xml
+++ b/Translations/Language.co.xml
@@ -10,7 +10,7 @@ Information about Corsican localization:
 	- Updated in 2023 by Patriccollu di Santa Maria è Sichè: May 29th (1.26), May 30th (1.26), June 1st (1.26),
 	          June 2nd (1.26), June 5th (1.26.2), June 21st (1.26.2), June 23rd (1.26.2), June 25th (1.26.2),
 	          June 29th (1.26.2), July 1st (1.26.3), July 30th (1.26.4), Aug. 14th (1.26.5), Sep. 8th (1.26.5),
-	          Sep. 20th (1.26.5), Sep. 24th (1.26.10)
+	          Sep. 20th (1.26.5), Sep. 24th (1.26.6), Nov. 20th (1.26.10)
 	- Updated on March 23rd, 2022 for version 1.26 by Patriccollu di Santa Maria è Sichè
 	- Created on March 6th, 2022 for version 1.25.9 by Patriccollu di Santa Maria è Sichè
 
@@ -19,7 +19,7 @@ Information about Corsican localization:
 -->
 <VeraCrypt>
 	<localization prog-version="1.26.10">
-		<language langid="co" name="Corsu" en-name="Corsican" version="1.4.3" translators="Patriccollu di Santa Maria è Sichè"/>
+		<language langid="co" name="Corsu" en-name="Corsican" version="1.4.4" translators="Patriccollu di Santa Maria è Sichè"/>
 		<font lang="co" class="normal" size="11" face="default"/>
 		<font lang="co" class="bold" size="13" face="Arial"/>
 		<font lang="co" class="fixed" size="12" face="Lucida Console"/>
@@ -1654,8 +1654,8 @@ Information about Corsican localization:
 		<entry lang="co" key="IDC_DISABLE_MEMORY_PROTECTION">Disattivà a prutezzione di memoria per a cumpatibilità cù l’attrezzi d’accessibilità</entry>
 		<entry lang="co" key="DISABLE_MEMORY_PROTECTION_WARNING">AVERTIMENTU : A disattivazione di prutezzione di memoria riduce a sicurità d’una manera significativa. Attivà st’ozzione SOLU s’è vo impiegate l’attrezzi d’accessibilità, cum’è i lettori di screnu, per interagisce cù l’interfaccia grafica di VeraCrypt.</entry>
 		<entry lang="co" key="LINUX_LANGUAGE">Lingua</entry>
-		<entry lang="en" key="LINUX_SELECT_SYS_DEFAULT_LANG">Select system's default language</entry>
-		<entry lang="en" key="LINUX_RESTART_FOR_LANGUAGE_CHANGE">For the language change to come into effect, VeraCrypt needs to be restarted.</entry>
+		<entry lang="co" key="LINUX_SELECT_SYS_DEFAULT_LANG">Selezziunà a lingua predefinita di u sistema</entry>
+		<entry lang="co" key="LINUX_RESTART_FOR_LANGUAGE_CHANGE">VeraCrypt deve esse rilanciatu per piglià in contu u cambiamentu di lingua.</entry>
 	</localization>
 	<xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
 		<xs:element name="VeraCrypt">


### PR DESCRIPTION
Hello,

This is an update of **Corsican** (co) localization to take this commit into account:

 * https://github.com/veracrypt/VeraCrypt/commit/6a1780864c57d598446eb0c1d4faf7ea238c04d4 Linux/FreeBSD/macOS: Implement language selection settings (#1253)

Cheers,
Patriccollu.