### PR TITLE
src/Setup/Linux: Specify icon in mime info

### DIFF
--- a/src/Setup/Linux/veracrypt.xml
+++ b/src/Setup/Linux/veracrypt.xml
@@ -2,10 +2,12 @@
 <mime-info xmlns='http://www.freedesktop.org/standards/shared-mime-info'>
 	<mime-type type="application/x-veracrypt-volume">
 		<comment>VeraCrypt Volume</comment>
+		<icon name="veracrypt"></icon>
 		<glob pattern="*.hc"/>
 	</mime-type>
 	<mime-type type="application/x-truecrypt-volume">
 		<comment>TrueCrypt Volume</comment>
+		<icon name="veracrypt"></icon>
 		<glob pattern="*.tc"/>
 	</mime-type>
 </mime-info>


### PR DESCRIPTION
Otherwise file managers will just use a generic missing icon icon.