### PR TITLE
Linux: Allows GUI to launch in a Wayland-only environment

### DIFF
--- a/src/Main/Unix/Main.cpp
+++ b/src/Main/Unix/Main.cpp
@@ -76,7 +76,7 @@ int main (int argc, char **argv)
 #endif
 
 #ifdef __WXGTK__
-		if (!getenv ("DISPLAY"))
+		if (!getenv ("DISPLAY") && !getenv ("WAYLAND_DISPLAY"))
 			forceTextUI = true;
 #endif
 


### PR DESCRIPTION
Currently we check whether the system has DISPLAY environment variable set, which is the case in a system that uses X11 natively or XWayland. This variable is not set in a system with only Wayland which forces us to text-only mode, so need to also check whether WAYLAND_DISPLAY is set.

Fixes: #184