### PR TITLE
macOS: Use correct Disk Utility location when "check filesystem" is ran

### DIFF
--- a/src/Core/Unix/MacOSX/CoreMacOSX.cpp
+++ b/src/Core/Unix/MacOSX/CoreMacOSX.cpp
@@ -107,7 +107,13 @@ namespace VeraCrypt
 	void CoreMacOSX::CheckFilesystem (shared_ptr <VolumeInfo> mountedVolume, bool repair) const
 	{
 		list <string> args;
-		args.push_back ("/Applications/Utilities/Disk Utility.app");
+		struct stat sb;
+
+		if (stat("/Applications/Utilities/Disk Utility.app", &sb) == 0)
+			args.push_back ("/Applications/Utilities/Disk Utility.app");
+		else
+			args.push_back ("/System/Applications/Utilities/Disk Utility.app");
+
 		Process::Execute ("open", args);
 	}
 


### PR DESCRIPTION
As of macOS Catalina (version 10.15) some system tools are moved to /System/Applications/. The old path could probably be just replaced with the new location as the older macOS versions are not officially supported, but it is probably safer to just check in case.