### PR TITLE
Improve and simplify macOS builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Because of incompatibility issues with OSXFUSE, the SDK 10.9 generates a
 VeraCrypt binary that has issues communicating with the OSXFUSE kernel extension.
 Thus, we recommend using a different OSX SDK version for building VeraCrypt.
 
-
+To build the installation package, you will need [packages](http://s.sudre.free.fr/Software/Packages/about.html)
 
 III. FreeBSD
 ============================

--- a/README.md
+++ b/README.md
@@ -151,9 +151,17 @@ of the SDK (i.e. 10.15), you can export the environment variable VC_OSX_TARGET:
 
 	$ export VC_OSX_TARGET=10.15
 
+For development dependencies management, you can use [homebrew](https://brew.sh).
 
-Before building under MacOSX, pkg-config must be installed if not yet available.
-Get it from https://pkgconfig.freedesktop.org/releases/pkg-config-0.28.tar.gz and
+	$ brew install pkg-config yasm wxwidgets
+
+You also need system dependencies
+
+	$ brew install --cask macfuse packages
+
+If you prefer to build from sources, or without homebrew, pkg-config and packages must be installed.
+
+Get pkg-config from https://pkgconfig.freedesktop.org/releases/pkg-config-0.28.tar.gz and
 compile using the following commands :
 
 	$ ./configure --with-internal-glib

--- a/README.md
+++ b/README.md
@@ -159,6 +159,12 @@ You also need system dependencies
 
 	$ brew install --cask macfuse packages
 
+After installating dependencies via brew, you can build a local development build
+
+	$ ./src/Build/build_veracrypt_macosx.sh -b
+
+If you want to build the package, you also need to pass `-p` to the build script above
+
 If you prefer to build from sources, or without homebrew, pkg-config and packages must be installed.
 
 Get pkg-config from https://pkgconfig.freedesktop.org/releases/pkg-config-0.28.tar.gz and

--- a/README.md
+++ b/README.md
@@ -163,7 +163,8 @@ After installating dependencies via brew, you can build a local development buil
 
 	$ ./src/Build/build_veracrypt_macosx.sh -b
 
-If you want to build the package, you also need to pass `-p` to the build script above
+If you want to build the package, you also need to pass `-p` to the build script above. The built
+executable will be in `.src/Main`
 
 If you prefer to build from sources, or without homebrew, pkg-config and packages must be installed.
 

--- a/src/Build/build_veracrypt_macosx.sh
+++ b/src/Build/build_veracrypt_macosx.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 #
 # Copyright (c) 2013-2019 IDRIX
 # Governed by the Apache License 2.0 the full text of which is contained
@@ -11,6 +13,32 @@ SCRIPTPATH=$(cd "$(dirname "$0")"; pwd)
 SOURCEPATH=$(cd "$(dirname "$SCRIPTPATH/../.")"; pwd)
 # directory where the VeraCrypt project has been checked out
 PARENTDIR=$(cd "$(dirname "$SCRIPTPATH/../../../.")"; pwd)
+
+while getopts bpr flag
+do
+    case "${flag}" in
+        b) brew=true;;
+        p) package=true;;
+    esac
+done
+
+if [ -n "$brew" ]; then
+    export VC_OSX_TARGET=10.9
+    export VC_OSX_SDK=$(xcrun --show-sdk-version) #use the latest version installed, this might fail
+    echo "Using MacOSX SDK $VC_OSX_SDK with target set to $VC_OSX_TARGET"
+    cd $SOURCEPATH
+
+    echo "Building VeraCrypt with precompiled homebrew packages"
+    cellar=$(brew --cellar "wxwidgets")
+    version=$(brew list --versions "wxwidgets" | head -1 | awk '{print $2}')
+    export WX_BUILD_DIR="$cellar/$version/bin"
+
+    make clean && make
+    if [ -n "$package" ]; then
+        make package
+    fi
+    exit 0
+fi
 
 # the sources of wxWidgets 3.1.2 must be extracted to the parent directory (for night mode)
 export WX_ROOT=$PARENTDIR/wxWidgets-3.2.2.1

--- a/src/Build/build_veracrypt_macosx.sh
+++ b/src/Build/build_veracrypt_macosx.sh
@@ -37,6 +37,7 @@ if [ -n "$brew" ]; then
     # don't build a universal binary, just build for the local arch
     export CPU_ARCH=$(uname -m)
     export AS=$(which yasm)
+    export COMPILE_ASM=$( if [[ "$CPU_ARCH" != "arm64" ]]; then echo true; else echo false; fi )
     make clean && make
     if [ -n "$package" ]; then
         make package

--- a/src/Build/build_veracrypt_macosx.sh
+++ b/src/Build/build_veracrypt_macosx.sh
@@ -23,8 +23,8 @@ do
 done
 
 if [ -n "$brew" ]; then
-    export VC_OSX_TARGET=10.9
     export VC_OSX_SDK=$(xcrun --show-sdk-version) #use the latest version installed, this might fail
+    export VC_OSX_TARGET=${VC_OSX_SDK}
     echo "Using MacOSX SDK $VC_OSX_SDK with target set to $VC_OSX_TARGET"
     cd $SOURCEPATH
 
@@ -52,7 +52,7 @@ echo "Using wxWidgets sources in $WX_ROOT"
 # this will be the temporary wxWidgets directory
 export WX_BUILD_DIR=$PARENTDIR/wxBuild-3.2.2.1
 
-# define the SDK version to use and OSX minimum target. We target 10.9 by default
+# define the SDK version to use and OSX minimum target. We target 12 by default
 export VC_OSX_TARGET=12
 export VC_OSX_SDK=13
 echo "Using MacOSX SDK $VC_OSX_SDK with target set to $VC_OSX_TARGET"

--- a/src/Build/build_veracrypt_macosx.sh
+++ b/src/Build/build_veracrypt_macosx.sh
@@ -32,8 +32,11 @@ if [ -n "$brew" ]; then
     cellar=$(brew --cellar "wxwidgets")
     version=$(brew list --versions "wxwidgets" | head -1 | awk '{print $2}')
     export WX_BUILD_DIR="$cellar/$version/bin"
+    # skips signing
     export LOCAL_DEVELOPMENT_BUILD=true
-
+    # don't build a universal binary, just build for the local arch
+    export CPU_ARCH=$(uname -m)
+    export AS=$(which yasm)
     make clean && make
     if [ -n "$package" ]; then
         make package

--- a/src/Build/build_veracrypt_macosx.sh
+++ b/src/Build/build_veracrypt_macosx.sh
@@ -32,9 +32,9 @@ if [ -n "$brew" ]; then
     cellar=$(brew --cellar "wxwidgets")
     version=$(brew list --versions "wxwidgets" | head -1 | awk '{print $2}')
     export WX_BUILD_DIR="$cellar/$version/bin"
-    # skips signing
+    # skip signing and build only for local arch
     export LOCAL_DEVELOPMENT_BUILD=true
-    # don't build a universal binary, just build for the local arch
+    # set the correct CPU arch for Makefile
     export CPU_ARCH=$(uname -m)
     export AS=$(which yasm)
     export COMPILE_ASM=$( if [[ "$CPU_ARCH" != "arm64" ]]; then echo true; else echo false; fi )

--- a/src/Build/build_veracrypt_macosx.sh
+++ b/src/Build/build_veracrypt_macosx.sh
@@ -32,6 +32,7 @@ if [ -n "$brew" ]; then
     cellar=$(brew --cellar "wxwidgets")
     version=$(brew list --versions "wxwidgets" | head -1 | awk '{print $2}')
     export WX_BUILD_DIR="$cellar/$version/bin"
+    export LOCAL_DEVELOPMENT_BUILD=true
 
     make clean && make
     if [ -n "$package" ]; then

--- a/src/Main/Main.make
+++ b/src/Main/Main.make
@@ -210,7 +210,7 @@ else
 	sed -e 's/_VERSION_/$(patsubst %a,%.1,$(patsubst %b,%.2,$(TC_VERSION)))/' ../Build/Resources/MacOSX/Info.plist.xml >$(APPNAME).app/Contents/Info.plist
 endif
 	chmod -R go-w $(APPNAME).app
-ifneq ($(LOCAL_DEVELOPMENT_BUILD),"TRUE")
+ifneq ($(LOCAL_DEVELOPMENT_BUILD),"true")
 	codesign -s "Developer ID Application: IDRIX (Z933746L2S)" --timestamp $(APPNAME).app
 endif
 

--- a/src/Main/Main.make
+++ b/src/Main/Main.make
@@ -210,7 +210,9 @@ else
 	sed -e 's/_VERSION_/$(patsubst %a,%.1,$(patsubst %b,%.2,$(TC_VERSION)))/' ../Build/Resources/MacOSX/Info.plist.xml >$(APPNAME).app/Contents/Info.plist
 endif
 	chmod -R go-w $(APPNAME).app
+ifneq ($(LOCAL_DEVELOPMENT_BUILD),"TRUE")
 	codesign -s "Developer ID Application: IDRIX (Z933746L2S)" --timestamp $(APPNAME).app
+endif
 
 install: prepare
 	cp -R $(APPNAME).app /Applications/.

--- a/src/Makefile
+++ b/src/Makefile
@@ -295,7 +295,7 @@ ifeq "$(shell uname -s)" "Darwin"
 	PLATFORM := MacOSX
 	APPNAME := VeraCrypt
 
-	export VC_OSX_TARGET ?= 10.9
+	export VC_OSX_TARGET ?= 12
 	export VC_OSX_SDK ?= $(VC_OSX_TARGET)
 
 	#check to see if XCode 3 path exists.Otherwise, use XCode 4 path

--- a/src/Makefile
+++ b/src/Makefile
@@ -352,8 +352,21 @@ ifeq "$(shell uname -s)" "Darwin"
 		S := $(C_CXX_FLAGS)
 		C_CXX_FLAGS = $(subst -MMD,,$(S))
 
-		C_CXX_FLAGS += -gfull -arch $(CPU_ARCH)
-		LFLAGS += -Wl,-dead_strip -arch $(CPU_ARCH)
+		# only build local arch in development builds
+		ifeq "$(LOCAL_DEVELOPMENT_BUILD)" "true"
+			ifeq "$(CPU_ARCH)" "arm64"
+				C_CXX_FLAGS += -gfull -arch $(CPU_ARCH)
+				LFLAGS += -Wl,-dead_strip -arch $(CPU_ARCH)
+			else
+				C_CXX_FLAGS += -gfull -arch x86_64
+				LFLAGS += -Wl,-dead_strip -arch x86_64
+			endif
+		else
+			# leave previous logic as is
+			C_CXX_FLAGS += -gfull -arch x86_64
+			LFLAGS += -Wl,-dead_strip -arch x86_64
+		endif
+
 		
 		WX_CONFIGURE_FLAGS += --without-libpng --disable-gif --disable-pcx --disable-tga --disable-iff --disable-gif --disable-svg
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -295,7 +295,7 @@ ifeq "$(shell uname -s)" "Darwin"
 	PLATFORM := MacOSX
 	APPNAME := VeraCrypt
 
-	export VC_OSX_TARGET ?= 10.7
+	export VC_OSX_TARGET ?= 10.9
 	export VC_OSX_SDK ?= $(VC_OSX_TARGET)
 
 	#check to see if XCode 3 path exists.Otherwise, use XCode 4 path
@@ -323,7 +323,7 @@ ifeq "$(shell uname -s)" "Darwin"
 	endif
 	
 	ifeq "$(CPU_ARCH)" "arm64"
-		CPU_ARCH = x86
+		CPU_ARCH = arm64
 	endif
 
 	CFLAGS += -msse2
@@ -339,7 +339,7 @@ ifeq "$(shell uname -s)" "Darwin"
 		CXXFLAGS += -mssse3 -msse4.1
 	endif
 
-	AS := $(BASE_DIR)/Build/Tools/MacOSX/yasm
+	AS ?= $(BASE_DIR)/Build/Tools/MacOSX/yasm
 	export ASFLAGS32 := -D __GNUC__ -D __YASM__ -D __BITS__=32 --prefix=_ -f macho32
 	export ASFLAGS64 := -D __GNUC__ -D __YASM__ -D __BITS__=64 --prefix=_ -f macho64
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -326,8 +326,10 @@ ifeq "$(shell uname -s)" "Darwin"
 		CPU_ARCH = arm64
 	endif
 
-	CFLAGS += -msse2
-	CXXFLAGS += -msse2
+	ifneq "$(CPU_ARCH)" "arm64"
+		CFLAGS += -msse2
+		CXXFLAGS += -msse2
+	endif
 
 	ifeq "$(origin SSSE3)" "command line"
 		CFLAGS += -mssse3
@@ -350,8 +352,8 @@ ifeq "$(shell uname -s)" "Darwin"
 		S := $(C_CXX_FLAGS)
 		C_CXX_FLAGS = $(subst -MMD,,$(S))
 
-		C_CXX_FLAGS += -gfull -arch x86_64
-		LFLAGS += -Wl,-dead_strip -arch x86_64
+		C_CXX_FLAGS += -gfull -arch $(CPU_ARCH)
+		LFLAGS += -Wl,-dead_strip -arch $(CPU_ARCH)
 		
 		WX_CONFIGURE_FLAGS += --without-libpng --disable-gif --disable-pcx --disable-tga --disable-iff --disable-gif --disable-svg
 
@@ -364,7 +366,11 @@ ifeq "$(shell uname -s)" "Darwin"
 			CXXFLAGS += -std=c++11			
 			C_CXX_FLAGS += -arch arm64
 			LFLAGS += -arch arm64
-			WX_CONFIGURE_FLAGS += --enable-universal_binary=arm64,x86_64
+			ifeq "$(LOCAL_DEVELOPMENT_BUILD)" "true"
+				WX_CONFIGURE_FLAGS += --disable-universal_binary
+			else
+				WX_CONFIGURE_FLAGS += --enable-universal_binary=arm64,x86_64
+			endif
 		endif
 
 		WXCONFIG_CFLAGS += -gfull

--- a/src/Makefile
+++ b/src/Makefile
@@ -366,7 +366,6 @@ ifeq "$(shell uname -s)" "Darwin"
 			C_CXX_FLAGS += -gfull -arch x86_64
 			LFLAGS += -Wl,-dead_strip -arch x86_64
 		endif
-
 		
 		WX_CONFIGURE_FLAGS += --without-libpng --disable-gif --disable-pcx --disable-tga --disable-iff --disable-gif --disable-svg
 
@@ -376,12 +375,20 @@ ifeq "$(shell uname -s)" "Darwin"
 			LFLAGS += -arch i386
 			WX_CONFIGURE_FLAGS += --enable-universal_binary=i386,x86_64
 		else
-			CXXFLAGS += -std=c++11			
-			C_CXX_FLAGS += -arch arm64
-			LFLAGS += -arch arm64
+			CXXFLAGS += -std=c++11
 			ifeq "$(LOCAL_DEVELOPMENT_BUILD)" "true"
+				ifeq "$(CPU_ARCH)" "arm64"
+					C_CXX_FLAGS += -arch arm64
+					LFLAGS += -arch arm64
+				else
+					C_CXX_FLAGS += -arch x86_64
+					LFLAGS += -arch x86_64
+				endif
 				WX_CONFIGURE_FLAGS += --disable-universal_binary
 			else
+				# leave previous logic as is
+				C_CXX_FLAGS += -arch arm64
+				LFLAGS += -arch arm64
 				WX_CONFIGURE_FLAGS += --enable-universal_binary=arm64,x86_64
 			endif
 		endif

--- a/src/Volume/Volume.make
+++ b/src/Volume/Volume.make
@@ -37,7 +37,7 @@ endif
 
 ifeq "$(ENABLE_WOLFCRYPT)" "0"
 ifeq "$(PLATFORM)" "MacOSX"
-ifeq "$(COMPILE_ASM)" "true"
+ifneq "$(COMPILE_ASM)" "false"
 	OBJSEX += ../Crypto/Aes_asm.oo
 	OBJS += ../Crypto/Aes_hw_cpu.o
 	OBJS += ../Crypto/Aescrypt.o
@@ -131,7 +131,7 @@ VolumeLibrary: Volume.a
 
 ifeq "$(ENABLE_WOLFCRYPT)" "0"
 ifeq "$(PLATFORM)" "MacOSX"
-ifeq "$(COMPILE_ASM)" "true"
+ifneq "$(COMPILE_ASM)" "false"
 ../Crypto/Aes_asm.oo: ../Crypto/Aes_x86.asm ../Crypto/Aes_x64.asm
 	@echo Assembling $(<F)
 	$(AS) $(ASFLAGS32) -o ../Crypto/Aes_x86.o ../Crypto/Aes_x86.asm

--- a/src/Volume/Volume.make
+++ b/src/Volume/Volume.make
@@ -37,6 +37,7 @@ endif
 
 ifeq "$(ENABLE_WOLFCRYPT)" "0"
 ifeq "$(PLATFORM)" "MacOSX"
+ifeq "$(COMPILE_ASM)" "true"
 	OBJSEX += ../Crypto/Aes_asm.oo
 	OBJS += ../Crypto/Aes_hw_cpu.o
 	OBJS += ../Crypto/Aescrypt.o
@@ -75,6 +76,7 @@ else ifeq "$(CPU_ARCH)" "x64"
 	OBJS += ../Crypto/sha512_sse4_x64.o
 else
 	OBJS += ../Crypto/Aescrypt.o
+endif
 endif
 
 ifeq "$(GCC_GTEQ_430)" "1"
@@ -129,6 +131,7 @@ VolumeLibrary: Volume.a
 
 ifeq "$(ENABLE_WOLFCRYPT)" "0"
 ifeq "$(PLATFORM)" "MacOSX"
+ifeq "$(COMPILE_ASM)" "true"
 ../Crypto/Aes_asm.oo: ../Crypto/Aes_x86.asm ../Crypto/Aes_x64.asm
 	@echo Assembling $(<F)
 	$(AS) $(ASFLAGS32) -o ../Crypto/Aes_x86.o ../Crypto/Aes_x86.asm
@@ -137,7 +140,7 @@ ifeq "$(PLATFORM)" "MacOSX"
 	rm -fr ../Crypto/Aes_x86.o ../Crypto/Aes_x64.o
 ../Crypto/Twofish_asm.oo: ../Crypto/Twofish_x64.S
 	@echo Assembling $(<F)
-	$(AS) $(ASFLAGS64) -p gas -o ../Crypto/Twofish_asm.oo ../Crypto/Twofish_x64.S 
+	$(AS) $(ASFLAGS64) -p gas -o ../Crypto/Twofish_asm.oo ../Crypto/Twofish_x64.S
 ../Crypto/Camellia_asm.oo: ../Crypto/Camellia_x64.S
 	@echo Assembling $(<F)
 	$(AS) $(ASFLAGS64) -p gas -o ../Crypto/Camellia_asm.oo ../Crypto/Camellia_x64.S
@@ -171,6 +174,7 @@ ifeq "$(PLATFORM)" "MacOSX"
 ../Crypto/sha512_sse4.oo: ../Crypto/sha512_sse4_x64.asm
 	@echo Assembling $(<F)
 	$(AS) $(ASFLAGS64) -o ../Crypto/sha512_sse4.oo ../Crypto/sha512_sse4_x64.asm
+endif
 endif
 endif
 


### PR DESCRIPTION
This series of commits aims to simplify the building of Veracrypt on macOS. This PR is currently draft and some commits require a rewrite as they are not atomic and require some fixes to the logic and the text.

1. Commit eca3086a1dac6af8d08a6d7b2ee9d9095dba2377 needs to be rewritten with the _packages_ location that Veracrypt internally uses, the public version in this commit is outdated
2. We need to make sure it's clear in the docs that homebrew instructions are only for development purposes