### PR TITLE
Unix CLI: Don't initially re-ask PIM if it was already specified

### DIFF
--- a/src/Main/TextUserInterface.cpp
+++ b/src/Main/TextUserInterface.cpp
@@ -1409,7 +1409,6 @@ namespace VeraCrypt
 			{
 				ShowInfo (e);
 				options.Password.reset();
-				options.Pim = -1;
 			}
 		}
 


### PR DESCRIPTION
We don't need to reset PIM in PasswordException as it is immediately fell back to if PIM is specified in text mode, but password is not. This causes an exception that resets the PIM when it shouldn't. If a password is given incorrectly, we still get caught by PasswordIncorrect and PIM is correctly reset to -1 as proposed and implemented in https://github.com/veracrypt/VeraCrypt/commit/eb61010ce2f1e9ed16f136500c6e76d2839bfd08 based on #1026.

Fixes #1286