### PR TITLE
Allow compilation with g++17 by replacing "byte" with "uint8_t" to remove confusion with std::byte (c++17 feature)

### DIFF
--- a/src/Common/Tcdefs.h
+++ b/src/Common/Tcdefs.h
@@ -122,7 +122,6 @@ typedef int8_t int8;
 typedef int16_t int16;
 typedef int32_t int32;
 typedef int64_t int64;
-typedef uint8_t byte;
 typedef uint8_t uint8;
 typedef uint16_t uint16;
 typedef uint32_t uint32;

--- a/src/Crypto/Aes_hw_cpu.h
+++ b/src/Crypto/Aes_hw_cpu.h
@@ -21,13 +21,13 @@ extern "C"
 #endif
 
 #if defined (TC_WINDOWS_BOOT)
-byte is_aes_hw_cpu_supported ();
+uint8_t is_aes_hw_cpu_supported ();
 #endif
 void aes_hw_cpu_enable_sse ();
-void aes_hw_cpu_decrypt (const byte *ks, byte *data);
-void aes_hw_cpu_decrypt_32_blocks (const byte *ks, byte *data);
-void aes_hw_cpu_encrypt (const byte *ks, byte *data);
-void aes_hw_cpu_encrypt_32_blocks (const byte *ks, byte *data);
+void aes_hw_cpu_decrypt (const uint8_t *ks, uint8_t *data);
+void aes_hw_cpu_decrypt_32_blocks (const uint8_t *ks, uint8_t *data);
+void aes_hw_cpu_encrypt (const uint8_t *ks, uint8_t *data);
+void aes_hw_cpu_encrypt_32_blocks (const uint8_t *ks, uint8_t *data);
 
 #if defined(__cplusplus)
 }

--- a/src/Crypto/Camellia.c
+++ b/src/Crypto/Camellia.c
@@ -11,10 +11,10 @@
  * NTT (Nippon Telegraph and Telephone Corporation) . All rights reserved.
  *
  * SuperCop integration:
- * Copyright � 2013 Jussi Kivilinna <jussi.kivilinna@iki.fi>
+ * Copyright © 2013 Jussi Kivilinna <jussi.kivilinna@iki.fi>
  *
  * VeraCrypt integration:
- * Copyright � 2017 Mounir IDRASSI <mounir.idrassi@idrix.fr>
+ * Copyright © 2017 Mounir IDRASSI <mounir.idrassi@idrix.fr>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions

--- a/src/Crypto/Camellia.c
+++ b/src/Crypto/Camellia.c
@@ -11,10 +11,10 @@
  * NTT (Nippon Telegraph and Telephone Corporation) . All rights reserved.
  *
  * SuperCop integration:
- * Copyright © 2013 Jussi Kivilinna <jussi.kivilinna@iki.fi>
+ * Copyright ï¿½ 2013 Jussi Kivilinna <jussi.kivilinna@iki.fi>
  *
  * VeraCrypt integration:
- * Copyright © 2017 Mounir IDRASSI <mounir.idrassi@idrix.fr>
+ * Copyright ï¿½ 2017 Mounir IDRASSI <mounir.idrassi@idrix.fr>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -51,12 +51,12 @@
 extern int IsAesHwCpuSupported ();
 #endif
 
-void camellia_encrypt_asm(const byte *ctx, void *dst, const void *src);
-void camellia_decrypt_asm(const byte *ctx, void *dst, const void *src);
-void camellia_enc_blk2(const byte *ctx, byte *dst, const byte *src);
-void camellia_dec_blk2(const byte *ctx, byte *dst, const byte *src);
-void camellia_ecb_enc_16way(const byte *ctx, byte *dst, const byte *src);
-void camellia_ecb_dec_16way(const byte *ctx, byte *dst, const byte *src);
+void camellia_encrypt_asm(const uint8_t *ctx, void *dst, const void *src);
+void camellia_decrypt_asm(const uint8_t *ctx, void *dst, const void *src);
+void camellia_enc_blk2(const uint8_t *ctx, uint8_t *dst, const uint8_t *src);
+void camellia_dec_blk2(const uint8_t *ctx, uint8_t *dst, const uint8_t *src);
+void camellia_ecb_enc_16way(const uint8_t *ctx, uint8_t *dst, const uint8_t *src);
+void camellia_ecb_dec_16way(const uint8_t *ctx, uint8_t *dst, const uint8_t *src);
 
 /* key constants */
 
@@ -1093,7 +1093,7 @@ void camellia_decrypt(const unsigned __int8 *inBlock,  unsigned __int8 *outBlock
 	camellia_decrypt_asm (ks, outBlock, inBlock);
 }
 
-void camellia_encrypt_blocks(unsigned __int8 *instance, const byte* in_blk, byte* out_blk, uint32 blockCount)
+void camellia_encrypt_blocks(unsigned __int8 *instance, const uint8_t* in_blk, uint8_t* out_blk, uint32 blockCount)
 {
 #if !defined (_UEFI)
 	if ((blockCount >= 16) && IsCpuIntel() && IsAesHwCpuSupported () && HasSAVX()) /* on AMD cpu, AVX is too slow */
@@ -1129,7 +1129,7 @@ void camellia_encrypt_blocks(unsigned __int8 *instance, const byte* in_blk, byte
 		camellia_encrypt (in_blk, out_blk, instance);		
 }
 
-void camellia_decrypt_blocks(unsigned __int8 *instance, const byte* in_blk, byte* out_blk, uint32 blockCount)
+void camellia_decrypt_blocks(unsigned __int8 *instance, const uint8_t* in_blk, uint8_t* out_blk, uint32 blockCount)
 {
 #if !defined (_UEFI)
 	if ((blockCount >= 16) && IsCpuIntel() && IsAesHwCpuSupported () && HasSAVX()) /* on AMD cpu, AVX is too slow */

--- a/src/Crypto/Camellia.h
+++ b/src/Crypto/Camellia.h
@@ -18,8 +18,8 @@ void camellia_encrypt(const unsigned __int8 *inBlock, unsigned __int8 *outBlock,
 void camellia_decrypt(const unsigned __int8 *inBlock,  unsigned __int8 *outBlock, unsigned __int8 *ks);
 
 #if CRYPTOPP_BOOL_X64 && !defined(CRYPTOPP_DISABLE_ASM)
-void camellia_encrypt_blocks(unsigned __int8 *ks, const byte* in_blk, byte* out_blk, uint32 blockCount);
-void camellia_decrypt_blocks(unsigned __int8 *ks, const byte* in_blk, byte* out_blk, uint32 blockCount);
+void camellia_encrypt_blocks(unsigned __int8 *ks, const uint8_t* in_blk, uint8_t* out_blk, uint32 blockCount);
+void camellia_decrypt_blocks(unsigned __int8 *ks, const uint8_t* in_blk, uint8_t* out_blk, uint32 blockCount);
 #endif
 
 #ifdef __cplusplus

--- a/src/Crypto/Sha2.c
+++ b/src/Crypto/Sha2.c
@@ -447,7 +447,7 @@ static void CRYPTOPP_FASTCALL X86_SHA256_HashBlocks(uint_32t *state, const uint_
 
 #if defined(__GNUC__)
 	#if CRYPTOPP_BOOL_X64
-		CRYPTOPP_ALIGN_DATA(16) byte workspace[LOCALS_SIZE] ;
+		CRYPTOPP_ALIGN_DATA(16) uint8_t workspace[LOCALS_SIZE] ;
 	#endif
 	__asm__ __volatile__
 	(

--- a/src/Crypto/Streebog.c
+++ b/src/Crypto/Streebog.c
@@ -2253,7 +2253,7 @@ stage3(STREEBOG_CTX *CTX)
     memcpy((CTX->hash), (CTX->h), 8 * sizeof(unsigned long long));
 }
 
-void STREEBOG_add(STREEBOG_CTX *CTX, const byte *data, size_t len)
+void STREEBOG_add(STREEBOG_CTX *CTX, const uint8_t *data, size_t len)
 {
     size_t chunksize;
 
@@ -2286,7 +2286,7 @@ void STREEBOG_add(STREEBOG_CTX *CTX, const byte *data, size_t len)
     }
 }
 
-void STREEBOG_finalize(STREEBOG_CTX *CTX, byte *digest)
+void STREEBOG_finalize(STREEBOG_CTX *CTX, uint8_t *digest)
 {
 	stage3(CTX);
 

--- a/src/Crypto/Streebog.h
+++ b/src/Crypto/Streebog.h
@@ -31,8 +31,8 @@ typedef STREEBOG_ALIGN(16) struct _STREEBOG_CTX
 
 void STREEBOG_init(STREEBOG_CTX *ctx);
 void STREEBOG_init256(STREEBOG_CTX *ctx);
-void STREEBOG_add(STREEBOG_CTX *ctx, const byte *msg, size_t len);
-void STREEBOG_finalize(STREEBOG_CTX *ctx, byte *out);
+void STREEBOG_add(STREEBOG_CTX *ctx, const uint8_t *msg, size_t len);
+void STREEBOG_finalize(STREEBOG_CTX *ctx, uint8_t *out);
 
 #ifdef __cplusplus
 }

--- a/src/Crypto/Twofish.c
+++ b/src/Crypto/Twofish.c
@@ -57,7 +57,7 @@
 #if CRYPTOPP_BOOL_X64 && !defined(CRYPTOPP_DISABLE_ASM)
 
 /* these are 64-bit assembly implementation taken from https://github.com/jkivilin/supercop-blockciphers
-   Copyright � 2011-2013 Jussi Kivilinna <jussi.kivilinna@iki.fi>
+   Copyright © 2011-2013 Jussi Kivilinna <jussi.kivilinna@iki.fi>
  */
 #if defined(__cplusplus)
 extern "C"

--- a/src/Crypto/Twofish.c
+++ b/src/Crypto/Twofish.c
@@ -57,25 +57,25 @@
 #if CRYPTOPP_BOOL_X64 && !defined(CRYPTOPP_DISABLE_ASM)
 
 /* these are 64-bit assembly implementation taken from https://github.com/jkivilin/supercop-blockciphers
-   Copyright © 2011-2013 Jussi Kivilinna <jussi.kivilinna@iki.fi>
+   Copyright ï¿½ 2011-2013 Jussi Kivilinna <jussi.kivilinna@iki.fi>
  */
 #if defined(__cplusplus)
 extern "C"
 {
 #endif
 
-void twofish_enc_blk(TwofishInstance *ks, byte *dst, const byte *src);
-void twofish_dec_blk(TwofishInstance *ks, byte *dst, const byte *src);
-void twofish_enc_blk2(TwofishInstance *ks, byte *dst, const byte *src);
-void twofish_dec_blk2(TwofishInstance *ks, byte *dst, const byte *src);
-void twofish_enc_blk3(TwofishInstance *ks, byte *dst, const byte *src);
-void twofish_dec_blk3(TwofishInstance *ks, byte *dst, const byte *src);
+void twofish_enc_blk(TwofishInstance *ks, uint8_t *dst, const uint8_t *src);
+void twofish_dec_blk(TwofishInstance *ks, uint8_t *dst, const uint8_t *src);
+void twofish_enc_blk2(TwofishInstance *ks, uint8_t *dst, const uint8_t *src);
+void twofish_dec_blk2(TwofishInstance *ks, uint8_t *dst, const uint8_t *src);
+void twofish_enc_blk3(TwofishInstance *ks, uint8_t *dst, const uint8_t *src);
+void twofish_dec_blk3(TwofishInstance *ks, uint8_t *dst, const uint8_t *src);
 
 #if defined(__cplusplus)
 }
 #endif
 
-void twofish_encrypt_blocks(TwofishInstance *instance, const byte* in_blk, byte* out_blk, uint32 blockCount)
+void twofish_encrypt_blocks(TwofishInstance *instance, const uint8_t* in_blk, uint8_t* out_blk, uint32 blockCount)
 {
 	while (blockCount >= 3)
 	{
@@ -96,7 +96,7 @@ void twofish_encrypt_blocks(TwofishInstance *instance, const byte* in_blk, byte*
 		
 }
 
-void twofish_decrypt_blocks(TwofishInstance *instance, const byte* in_blk, byte* out_blk, uint32 blockCount)
+void twofish_decrypt_blocks(TwofishInstance *instance, const uint8_t* in_blk, uint8_t* out_blk, uint32 blockCount)
 {
 	while (blockCount >= 3)
 	{
@@ -120,7 +120,7 @@ void twofish_decrypt_blocks(TwofishInstance *instance, const byte* in_blk, byte*
 
 #endif
 
-static const byte Q[2][256] = {
+static const uint8_t Q[2][256] = {
 	{
 		0xa9, 0x67, 0xb3, 0xe8, 0x04, 0xfd, 0xa3, 0x76, 0x9a, 0x92, 0x80, 0x78, 0xe4, 0xdd, 0xd1, 0x38,
 		0x0d, 0xc6, 0x35, 0x98, 0x18, 0xf7, 0xec, 0x6c, 0x43, 0x75, 0x37, 0x26, 0xfa, 0x13, 0x94, 0x48,
@@ -604,11 +604,11 @@ static const uint32 RS[8][256] = {
 void twofish_set_key(TwofishInstance *instance, const u4byte in_key[])
 {
 	union {
-		byte S8[16];
+		uint8_t S8[16];
 		uint32 S32[4];
 	} us;
 	unsigned int i;
-   const byte* key = (const byte*) in_key;
+   const uint8_t* key = (const uint8_t*) in_key;
 
 	us.S32[0] = RS[0][key[0]] ^ RS[1][key[1]] ^ RS[2][key[2]] ^ RS[3][key[3]] ^ RS[4][key[4]] ^ RS[5][key[5]] ^ RS[6][key[6]] ^ RS[7][key[7]];
 	us.S32[1] = RS[0][key[8]] ^ RS[1][key[9]] ^ RS[2][key[10]] ^ RS[3][key[11]] ^ RS[4][key[12]] ^ RS[5][key[13]] ^ RS[6][key[14]] ^ RS[7][key[15]];

--- a/src/Crypto/Twofish.h
+++ b/src/Crypto/Twofish.h
@@ -55,10 +55,10 @@ typedef struct
 /* in_key must be 32-bytes long */
 void twofish_set_key(TwofishInstance *instance, const u4byte in_key[]);
 #if CRYPTOPP_BOOL_X64 && !defined(CRYPTOPP_DISABLE_ASM)
-void twofish_encrypt_blocks(TwofishInstance *instance, const byte* in_blk, byte* out_blk, uint32 blockCount);
-void twofish_decrypt_blocks(TwofishInstance *instance, const byte* in_blk, byte* out_blk, uint32 blockCount);
-#define twofish_encrypt(instance,in_blk,out_blk)   twofish_encrypt_blocks(instance, (const byte*) in_blk, (byte*) out_blk, 1)
-#define twofish_decrypt(instance,in_blk,out_blk)   twofish_decrypt_blocks(instance, (const byte*) in_blk, (byte*) out_blk, 1)
+void twofish_encrypt_blocks(TwofishInstance *instance, const uint8_t* in_blk, uint8_t* out_blk, uint32 blockCount);
+void twofish_decrypt_blocks(TwofishInstance *instance, const uint8_t* in_blk, uint8_t* out_blk, uint32 blockCount);
+#define twofish_encrypt(instance,in_blk,out_blk)   twofish_encrypt_blocks(instance, (const uint8_t*) in_blk, (uint8_t*) out_blk, 1)
+#define twofish_decrypt(instance,in_blk,out_blk)   twofish_decrypt_blocks(instance, (const uint8_t*) in_blk, (uint8_t*) out_blk, 1)
 #else
 void twofish_encrypt(TwofishInstance *instance, const u4byte in_blk[4], u4byte out_blk[4]);
 void twofish_decrypt(TwofishInstance *instance, const u4byte in_blk[4], u4byte out_blk[4]);

--- a/src/Crypto/Whirlpool.c
+++ b/src/Crypto/Whirlpool.c
@@ -936,7 +936,7 @@ void WHIRLPOOL_add(const unsigned char * input,
 	else
 	{
 		uint64* dataBuf = ctx->data;
-		byte* data = (byte *)dataBuf;		
+		uint8_t* data = (uint8_t *)dataBuf;
 		num = oldCountLo & 63;
 
 		if (num != 0)	// process left over data
@@ -996,7 +996,7 @@ void WHIRLPOOL_finalize(WHIRLPOOL_CTX * const ctx,
 	unsigned int num = ctx->countLo & 63;
 	uint64* dataBuf = ctx->data;
 	uint64* stateBuf = ctx->state;
-	byte* data = (byte *)dataBuf;
+	uint8_t* data = (uint8_t *)dataBuf;
 
 	data[num++] = 0x80;
 	if (num <= 32)

--- a/src/Crypto/kuznyechik.c
+++ b/src/Crypto/kuznyechik.c
@@ -12,16 +12,16 @@ and released into public domain.
 #endif
 
 #if CRYPTOPP_BOOL_SSE2_INTRINSICS_AVAILABLE
-void kuznyechik_set_key_simd(const byte* key, kuznyechik_kds *kds);
-void kuznyechik_encrypt_block_simd(byte* out, const byte* in, kuznyechik_kds* kds);
-void kuznyechik_encrypt_blocks_simd(byte* out, const byte* in, size_t blocks, kuznyechik_kds* kds);
-void kuznyechik_decrypt_block_simd(byte* out, const byte* in, kuznyechik_kds* kds);
-void kuznyechik_decrypt_blocks_simd(byte* out, const byte* in, size_t blocks, kuznyechik_kds* kds);
+void kuznyechik_set_key_simd(const uint8_t* key, kuznyechik_kds *kds);
+void kuznyechik_encrypt_block_simd(uint8_t* out, const uint8_t* in, kuznyechik_kds* kds);
+void kuznyechik_encrypt_blocks_simd(uint8_t* out, const uint8_t* in, size_t blocks, kuznyechik_kds* kds);
+void kuznyechik_decrypt_block_simd(uint8_t* out, const uint8_t* in, kuznyechik_kds* kds);
+void kuznyechik_decrypt_blocks_simd(uint8_t* out, const uint8_t* in, size_t blocks, kuznyechik_kds* kds);
 #endif
 
 //#define CPPCRYPTO_DEBUG
 
-	static const byte S[256] = {
+	static const uint8_t S[256] = {
 		252, 238, 221, 17, 207, 110, 49, 22, 251, 196, 250, 218, 35, 197, 4, 77, 233, 119, 240, 219, 147, 46, 153, 186, 23, 54, 241, 187, 20, 205, 95, 193,
 		249, 24, 101, 90, 226, 92, 239, 33, 129, 28, 60, 66, 139, 1, 142, 79, 5, 132, 2, 174, 227, 106, 143, 160, 6, 11, 237, 152, 127, 212, 211, 31,
 		235, 52, 44, 81, 234, 200, 72, 171, 242, 42, 104, 162, 253, 58, 206, 204, 181, 112, 14, 86, 8, 12, 118, 18, 191, 114, 19, 71, 156, 183, 93, 135,
@@ -32,7 +32,7 @@ void kuznyechik_decrypt_blocks_simd(byte* out, const byte* in, size_t blocks, ku
 		32, 113, 103, 164, 45, 43, 9, 91, 203, 155, 37, 208, 190, 229, 108, 82, 89, 166, 116, 210, 230, 244, 180, 192, 209, 102, 175, 194, 57, 75, 99, 182
 	};
 
-	static const byte IS[256] = {
+	static const uint8_t IS[256] = {
 		165, 45, 50, 143, 14, 48, 56, 192, 84, 230, 158, 57, 85, 126, 82, 145, 100, 3, 87, 90, 28, 96, 7, 24, 33, 114, 168, 209, 41, 198, 164, 63,
 		224, 39, 141, 12, 130, 234, 174, 180, 154, 99, 73, 229, 66, 228, 21, 183, 200, 6, 112, 157, 65, 117, 25, 201, 170, 252, 77, 191, 42, 115, 132, 213,
 		195, 175, 43, 134, 167, 177, 178, 91, 70, 211, 159, 253, 212, 15, 156, 47, 155, 67, 239, 217, 121, 182, 83, 127, 193, 240, 35, 231, 37, 94, 181, 30,
@@ -2144,30 +2144,30 @@ void kuznyechik_decrypt_blocks_simd(byte* out, const byte* in, size_t blocks, ku
 	};
 
 #define LS(x1,x2,t1,t2) { \
-		t1 = T[0][(byte)(x1)][0] ^ T[1][(byte)(x1 >> 8)][0] ^ T[2][(byte)(x1 >> 16)][0] ^ T[3][(byte)(x1 >> 24)][0] ^ T[4][(byte)(x1 >> 32)][0] ^ T[5][(byte)(x1 >> 40)][0] ^ \
-			T[6][(byte)(x1 >> 48)][0] ^ T[7][(byte)(x1 >> 56)][0] ^ T[8][(byte)(x2)][0] ^ T[9][(byte)(x2 >> 8)][0] ^ T[10][(byte)(x2 >> 16)][0] ^ T[11][(byte)(x2 >> 24)][0] ^ \
-			T[12][(byte)(x2 >> 32)][0] ^ T[13][(byte)(x2 >> 40)][0] ^ T[14][(byte)(x2 >> 48)][0] ^ T[15][(byte)(x2 >> 56)][0]; \
-		t2 = T[0][(byte)(x1)][1] ^ T[1][(byte)(x1 >> 8)][1] ^ T[2][(byte)(x1 >> 16)][1] ^ T[3][(byte)(x1 >> 24)][1] ^ T[4][(byte)(x1 >> 32)][1] ^ T[5][(byte)(x1 >> 40)][1] ^ \
-			T[6][(byte)(x1 >> 48)][1] ^ T[7][(byte)(x1 >> 56)][1] ^ T[8][(byte)(x2)][1] ^ T[9][(byte)(x2 >> 8)][1] ^ T[10][(byte)(x2 >> 16)][1] ^ T[11][(byte)(x2 >> 24)][1] ^ \
-			T[12][(byte)(x2 >> 32)][1] ^ T[13][(byte)(x2 >> 40)][1] ^ T[14][(byte)(x2 >> 48)][1] ^ T[15][(byte)(x2 >> 56)][1]; \
+		t1 = T[0][(uint8_t)(x1)][0] ^ T[1][(uint8_t)(x1 >> 8)][0] ^ T[2][(uint8_t)(x1 >> 16)][0] ^ T[3][(uint8_t)(x1 >> 24)][0] ^ T[4][(uint8_t)(x1 >> 32)][0] ^ T[5][(uint8_t)(x1 >> 40)][0] ^ \
+			T[6][(uint8_t)(x1 >> 48)][0] ^ T[7][(uint8_t)(x1 >> 56)][0] ^ T[8][(uint8_t)(x2)][0] ^ T[9][(uint8_t)(x2 >> 8)][0] ^ T[10][(uint8_t)(x2 >> 16)][0] ^ T[11][(uint8_t)(x2 >> 24)][0] ^ \
+			T[12][(uint8_t)(x2 >> 32)][0] ^ T[13][(uint8_t)(x2 >> 40)][0] ^ T[14][(uint8_t)(x2 >> 48)][0] ^ T[15][(uint8_t)(x2 >> 56)][0]; \
+		t2 = T[0][(uint8_t)(x1)][1] ^ T[1][(uint8_t)(x1 >> 8)][1] ^ T[2][(uint8_t)(x1 >> 16)][1] ^ T[3][(uint8_t)(x1 >> 24)][1] ^ T[4][(uint8_t)(x1 >> 32)][1] ^ T[5][(uint8_t)(x1 >> 40)][1] ^ \
+			T[6][(uint8_t)(x1 >> 48)][1] ^ T[7][(uint8_t)(x1 >> 56)][1] ^ T[8][(uint8_t)(x2)][1] ^ T[9][(uint8_t)(x2 >> 8)][1] ^ T[10][(uint8_t)(x2 >> 16)][1] ^ T[11][(uint8_t)(x2 >> 24)][1] ^ \
+			T[12][(uint8_t)(x2 >> 32)][1] ^ T[13][(uint8_t)(x2 >> 40)][1] ^ T[14][(uint8_t)(x2 >> 48)][1] ^ T[15][(uint8_t)(x2 >> 56)][1]; \
 	}
 
 #define ILS(x1,x2,t1,t2) { \
-		t1 = IT[0][(byte)(x1)][0] ^ IT[1][(byte)(x1 >> 8)][0] ^ IT[2][(byte)(x1 >> 16)][0] ^ IT[3][(byte)(x1 >> 24)][0] ^ IT[4][(byte)(x1 >> 32)][0] ^ IT[5][(byte)(x1 >> 40)][0] ^ \
-			IT[6][(byte)(x1 >> 48)][0] ^ IT[7][(byte)(x1 >> 56)][0] ^ IT[8][(byte)(x2)][0] ^ IT[9][(byte)(x2 >> 8)][0] ^ IT[10][(byte)(x2 >> 16)][0] ^ IT[11][(byte)(x2 >> 24)][0] ^ \
-			IT[12][(byte)(x2 >> 32)][0] ^ IT[13][(byte)(x2 >> 40)][0] ^ IT[14][(byte)(x2 >> 48)][0] ^ IT[15][(byte)(x2 >> 56)][0]; \
-		t2 = IT[0][(byte)(x1)][1] ^ IT[1][(byte)(x1 >> 8)][1] ^ IT[2][(byte)(x1 >> 16)][1] ^ IT[3][(byte)(x1 >> 24)][1] ^ IT[4][(byte)(x1 >> 32)][1] ^ IT[5][(byte)(x1 >> 40)][1] ^ \
-			IT[6][(byte)(x1 >> 48)][1] ^ IT[7][(byte)(x1 >> 56)][1] ^ IT[8][(byte)(x2)][1] ^ IT[9][(byte)(x2 >> 8)][1] ^ IT[10][(byte)(x2 >> 16)][1] ^ IT[11][(byte)(x2 >> 24)][1] ^ \
-			IT[12][(byte)(x2 >> 32)][1] ^ IT[13][(byte)(x2 >> 40)][1] ^ IT[14][(byte)(x2 >> 48)][1] ^ IT[15][(byte)(x2 >> 56)][1]; \
+		t1 = IT[0][(uint8_t)(x1)][0] ^ IT[1][(uint8_t)(x1 >> 8)][0] ^ IT[2][(uint8_t)(x1 >> 16)][0] ^ IT[3][(uint8_t)(x1 >> 24)][0] ^ IT[4][(uint8_t)(x1 >> 32)][0] ^ IT[5][(uint8_t)(x1 >> 40)][0] ^ \
+			IT[6][(uint8_t)(x1 >> 48)][0] ^ IT[7][(uint8_t)(x1 >> 56)][0] ^ IT[8][(uint8_t)(x2)][0] ^ IT[9][(uint8_t)(x2 >> 8)][0] ^ IT[10][(uint8_t)(x2 >> 16)][0] ^ IT[11][(uint8_t)(x2 >> 24)][0] ^ \
+			IT[12][(uint8_t)(x2 >> 32)][0] ^ IT[13][(uint8_t)(x2 >> 40)][0] ^ IT[14][(uint8_t)(x2 >> 48)][0] ^ IT[15][(uint8_t)(x2 >> 56)][0]; \
+		t2 = IT[0][(uint8_t)(x1)][1] ^ IT[1][(uint8_t)(x1 >> 8)][1] ^ IT[2][(uint8_t)(x1 >> 16)][1] ^ IT[3][(uint8_t)(x1 >> 24)][1] ^ IT[4][(uint8_t)(x1 >> 32)][1] ^ IT[5][(uint8_t)(x1 >> 40)][1] ^ \
+			IT[6][(uint8_t)(x1 >> 48)][1] ^ IT[7][(uint8_t)(x1 >> 56)][1] ^ IT[8][(uint8_t)(x2)][1] ^ IT[9][(uint8_t)(x2 >> 8)][1] ^ IT[10][(uint8_t)(x2 >> 16)][1] ^ IT[11][(uint8_t)(x2 >> 24)][1] ^ \
+			IT[12][(uint8_t)(x2 >> 32)][1] ^ IT[13][(uint8_t)(x2 >> 40)][1] ^ IT[14][(uint8_t)(x2 >> 48)][1] ^ IT[15][(uint8_t)(x2 >> 56)][1]; \
 	}
 
 #define ILSS(x1,x2,t1,t2) { \
-		t1 = IT[0][S[(byte)(x1)]][0] ^ IT[1][S[(byte)(x1 >> 8)]][0] ^ IT[2][S[(byte)(x1 >> 16)]][0] ^ IT[3][S[(byte)(x1 >> 24)]][0] ^ IT[4][S[(byte)(x1 >> 32)]][0] ^ IT[5][S[(byte)(x1 >> 40)]][0] ^ \
-			IT[6][S[(byte)(x1 >> 48)]][0] ^ IT[7][S[(byte)(x1 >> 56)]][0] ^ IT[8][S[(byte)(x2)]][0] ^ IT[9][S[(byte)(x2 >> 8)]][0] ^ IT[10][S[(byte)(x2 >> 16)]][0] ^ IT[11][S[(byte)(x2 >> 24)]][0] ^ \
-			IT[12][S[(byte)(x2 >> 32)]][0] ^ IT[13][S[(byte)(x2 >> 40)]][0] ^ IT[14][S[(byte)(x2 >> 48)]][0] ^ IT[15][S[(byte)(x2 >> 56)]][0]; \
-		t2 = IT[0][S[(byte)(x1)]][1] ^ IT[1][S[(byte)(x1 >> 8)]][1] ^ IT[2][S[(byte)(x1 >> 16)]][1] ^ IT[3][S[(byte)(x1 >> 24)]][1] ^ IT[4][S[(byte)(x1 >> 32)]][1] ^ IT[5][S[(byte)(x1 >> 40)]][1] ^ \
-			IT[6][S[(byte)(x1 >> 48)]][1] ^ IT[7][S[(byte)(x1 >> 56)]][1] ^ IT[8][S[(byte)(x2)]][1] ^ IT[9][S[(byte)(x2 >> 8)]][1] ^ IT[10][S[(byte)(x2 >> 16)]][1] ^ IT[11][S[(byte)(x2 >> 24)]][1] ^ \
-			IT[12][S[(byte)(x2 >> 32)]][1] ^ IT[13][S[(byte)(x2 >> 40)]][1] ^ IT[14][S[(byte)(x2 >> 48)]][1] ^ IT[15][S[(byte)(x2 >> 56)]][1]; \
+		t1 = IT[0][S[(uint8_t)(x1)]][0] ^ IT[1][S[(uint8_t)(x1 >> 8)]][0] ^ IT[2][S[(uint8_t)(x1 >> 16)]][0] ^ IT[3][S[(uint8_t)(x1 >> 24)]][0] ^ IT[4][S[(uint8_t)(x1 >> 32)]][0] ^ IT[5][S[(uint8_t)(x1 >> 40)]][0] ^ \
+			IT[6][S[(uint8_t)(x1 >> 48)]][0] ^ IT[7][S[(uint8_t)(x1 >> 56)]][0] ^ IT[8][S[(uint8_t)(x2)]][0] ^ IT[9][S[(uint8_t)(x2 >> 8)]][0] ^ IT[10][S[(uint8_t)(x2 >> 16)]][0] ^ IT[11][S[(uint8_t)(x2 >> 24)]][0] ^ \
+			IT[12][S[(uint8_t)(x2 >> 32)]][0] ^ IT[13][S[(uint8_t)(x2 >> 40)]][0] ^ IT[14][S[(uint8_t)(x2 >> 48)]][0] ^ IT[15][S[(uint8_t)(x2 >> 56)]][0]; \
+		t2 = IT[0][S[(uint8_t)(x1)]][1] ^ IT[1][S[(uint8_t)(x1 >> 8)]][1] ^ IT[2][S[(uint8_t)(x1 >> 16)]][1] ^ IT[3][S[(uint8_t)(x1 >> 24)]][1] ^ IT[4][S[(uint8_t)(x1 >> 32)]][1] ^ IT[5][S[(uint8_t)(x1 >> 40)]][1] ^ \
+			IT[6][S[(uint8_t)(x1 >> 48)]][1] ^ IT[7][S[(uint8_t)(x1 >> 56)]][1] ^ IT[8][S[(uint8_t)(x2)]][1] ^ IT[9][S[(uint8_t)(x2 >> 8)]][1] ^ IT[10][S[(uint8_t)(x2 >> 16)]][1] ^ IT[11][S[(uint8_t)(x2 >> 24)]][1] ^ \
+			IT[12][S[(uint8_t)(x2 >> 32)]][1] ^ IT[13][S[(uint8_t)(x2 >> 40)]][1] ^ IT[14][S[(uint8_t)(x2 >> 48)]][1] ^ IT[15][S[(uint8_t)(x2 >> 56)]][1]; \
 	}
 
 #define ISI(val) { \
@@ -2199,7 +2199,7 @@ void kuznyechik_decrypt_blocks_simd(byte* out, const byte* in, size_t blocks, ku
 		} \
 	}
 
-	void kuznyechik_set_key(const byte* key, kuznyechik_kds* kds)
+	void kuznyechik_set_key(const uint8_t* key, kuznyechik_kds* kds)
 	{
 #if CRYPTOPP_BOOL_SSE2_INTRINSICS_AVAILABLE && !defined(_UEFI) && (!defined (TC_WINDOWS_DRIVER) || (!defined (DEBUG) && defined (_WIN64)))
 		if(HasSSE2())
@@ -2258,7 +2258,7 @@ void kuznyechik_decrypt_blocks_simd(byte* out, const byte* in, size_t blocks, ku
 
 	}
 
-	void kuznyechik_encrypt_block(byte* out, const byte* in, kuznyechik_kds* kds)
+	void kuznyechik_encrypt_block(uint8_t* out, const uint8_t* in, kuznyechik_kds* kds)
 	{
 #if CRYPTOPP_BOOL_SSE2_INTRINSICS_AVAILABLE && !defined(_UEFI) && (!defined (TC_WINDOWS_DRIVER) || (!defined (DEBUG) && defined (_WIN64)))
 		if(HasSSE2())
@@ -2305,7 +2305,7 @@ void kuznyechik_decrypt_blocks_simd(byte* out, const byte* in, size_t blocks, ku
 		}
 	}
 
-	void kuznyechik_encrypt_blocks(byte* out, const byte* in, size_t blocks, kuznyechik_kds* kds)
+	void kuznyechik_encrypt_blocks(uint8_t* out, const uint8_t* in, size_t blocks, kuznyechik_kds* kds)
 	{
 #if CRYPTOPP_BOOL_SSE2_INTRINSICS_AVAILABLE && !defined(_UEFI) && (!defined (DEBUG) || !defined (TC_WINDOWS_DRIVER))
 		if(HasSSE2())
@@ -2325,7 +2325,7 @@ void kuznyechik_decrypt_blocks_simd(byte* out, const byte* in, size_t blocks, ku
 		}
 	}
 
-	void kuznyechik_decrypt_block(byte* out, const byte* in, kuznyechik_kds* kds)
+	void kuznyechik_decrypt_block(uint8_t* out, const uint8_t* in, kuznyechik_kds* kds)
 	{
 #if CRYPTOPP_BOOL_SSE2_INTRINSICS_AVAILABLE && !defined(_UEFI) && (!defined (TC_WINDOWS_DRIVER) || (!defined (DEBUG) && defined (_WIN64)))
 		if(HasSSE2())
@@ -2366,8 +2366,8 @@ void kuznyechik_decrypt_blocks_simd(byte* out, const byte* in, size_t blocks, ku
 			ILS(x1, x2, t1, t2);
 			t1 ^= kds->rkd[2];
 			t2 ^= kds->rkd[3];
-			ISI((byte*)&t1);
-			ISI((byte*)&t2);
+			ISI((uint8_t*)&t1);
+			ISI((uint8_t*)&t2);
 			t1 ^= kds->rkd[0];
 			t2 ^= kds->rkd[1];
 			*(uint64*)out = t1;
@@ -2375,7 +2375,7 @@ void kuznyechik_decrypt_blocks_simd(byte* out, const byte* in, size_t blocks, ku
 		}
 	}
 
-	void kuznyechik_decrypt_blocks(byte* out, const byte* in, size_t blocks, kuznyechik_kds* kds)
+	void kuznyechik_decrypt_blocks(uint8_t* out, const uint8_t* in, size_t blocks, kuznyechik_kds* kds)
 	{
 #if CRYPTOPP_BOOL_SSE2_INTRINSICS_AVAILABLE && !defined(_UEFI) && (!defined (DEBUG) || !defined (TC_WINDOWS_DRIVER))
 		if(HasSSE2())

--- a/src/Crypto/kuznyechik.h
+++ b/src/Crypto/kuznyechik.h
@@ -22,11 +22,11 @@ typedef struct _kuznyechik_kds
 
 #define KUZNYECHIK_KS				(sizeof(kuznyechik_kds))
 
-void kuznyechik_encrypt_block(byte* out, const byte* in, kuznyechik_kds* kds);
-void kuznyechik_encrypt_blocks(byte* out, const byte* in, size_t blocks, kuznyechik_kds* kds);
-void kuznyechik_decrypt_block(byte* out, const byte* in, kuznyechik_kds* kds);
-void kuznyechik_decrypt_blocks(byte* out, const byte* in, size_t blocks, kuznyechik_kds* kds);
-void kuznyechik_set_key(const byte* key, kuznyechik_kds *kds);
+void kuznyechik_encrypt_block(uint8_t* out, const uint8_t* in, kuznyechik_kds* kds);
+void kuznyechik_encrypt_blocks(uint8_t* out, const uint8_t* in, size_t blocks, kuznyechik_kds* kds);
+void kuznyechik_decrypt_block(uint8_t* out, const uint8_t* in, kuznyechik_kds* kds);
+void kuznyechik_decrypt_blocks(uint8_t* out, const uint8_t* in, size_t blocks, kuznyechik_kds* kds);
+void kuznyechik_set_key(const uint8_t* key, kuznyechik_kds *kds);
 
 #ifdef __cplusplus
 }

--- a/src/Crypto/kuznyechik_simd.c
+++ b/src/Crypto/kuznyechik_simd.c
@@ -9169,7 +9169,7 @@ VC_INLINE void scheduleDecryptionRoundKeysForGost15(
 	applyLSTransformation_4(data1_, data2_, data3_,data4_); \
 }
 
-void kuznyechik_encrypt_block_simd(byte* out, const byte* in, kuznyechik_kds* kds)
+void kuznyechik_encrypt_block_simd(uint8_t* out, const uint8_t* in, kuznyechik_kds* kds)
 {
 	const uint_64t *roundKeys_ = (const uint_64t *) kds->rke;
 	__m128i data_;
@@ -9200,7 +9200,7 @@ void kuznyechik_encrypt_block_simd(byte* out, const byte* in, kuznyechik_kds* kd
 	_mm_storeu_si128((__m128i*) out, data_);
 }
 
-void kuznyechik_encrypt_blocks_simd(byte* out, const byte* in, size_t blocks, kuznyechik_kds* kds)
+void kuznyechik_encrypt_blocks_simd(uint8_t* out, const uint8_t* in, size_t blocks, kuznyechik_kds* kds)
 {
 	const uint_64t *roundKeys_ = (const uint_64t *) kds->rke;
 	__m128i data1_, data2_, data3_, data4_;
@@ -9347,7 +9347,7 @@ void kuznyechik_encrypt_blocks_simd(byte* out, const byte* in, size_t blocks, ku
 	data4_ = _mm_xor_si128(data4_, cache11_); \
 }
 
-void kuznyechik_decrypt_block_simd(byte* out, const byte* in, kuznyechik_kds* kds)
+void kuznyechik_decrypt_block_simd(uint8_t* out, const uint8_t* in, kuznyechik_kds* kds)
 {
 	const uint_64t *roundKeys_ = kds->rkd;
 	__m128i data_;
@@ -9383,7 +9383,7 @@ void kuznyechik_decrypt_block_simd(byte* out, const byte* in, kuznyechik_kds* kd
 	_mm_storeu_si128((__m128i*) out, data_);
 }
 
-void kuznyechik_decrypt_blocks_simd(byte* out, const byte* in, size_t blocks, kuznyechik_kds* kds)
+void kuznyechik_decrypt_blocks_simd(uint8_t* out, const uint8_t* in, size_t blocks, kuznyechik_kds* kds)
 {
 	const uint_64t *roundKeys_ = kds->rkd;
 	__m128i data1_, data2_,data3_,data4_;
@@ -9508,7 +9508,7 @@ void kuznyechik_decrypt_blocks_simd(byte* out, const byte* in, size_t blocks, ku
 		kuznyechik_decrypt_block_simd (out, in, kds);
 }
 
-void kuznyechik_set_key_simd(const byte* key, kuznyechik_kds *kds)
+void kuznyechik_set_key_simd(const uint8_t* key, kuznyechik_kds *kds)
 {
 	scheduleEncryptionRoundKeysForGost15 (kds->rke, key);
 	scheduleDecryptionRoundKeysForGost15 (kds->rkd, key);

--- a/src/Makefile
+++ b/src/Makefile
@@ -214,10 +214,6 @@ ifeq "$(shell uname -s)" "Linux"
 	else ifeq ($(GCC_VERSION), 408)
 		# GCC version 4.8 supports C++11 features through the switch -std=c++11
 		CXXFLAGS += -std=c++11
-	else ifeq ($(shell expr $(GCC_VERSION) \>= 1100), 1)
-		# GNU GCC version 11 and higher compile with -std=gnu++17 by default
-		# which breaks "byte" definitions in Crypto++ library. So set -std=gnu++14 instead.
-		CXXFLAGS += -std=gnu++14
 	endif
 
 	

--- a/src/Volume/Cipher.cpp
+++ b/src/Volume/Cipher.cpp
@@ -49,7 +49,7 @@ namespace VeraCrypt
 	{
 	}
 
-	void Cipher::DecryptBlock (byte *data) const
+	void Cipher::DecryptBlock (uint8_t *data) const
 	{
 		if (!Initialized)
 			throw NotInitialized (SRC_POS);
@@ -57,7 +57,7 @@ namespace VeraCrypt
 		Decrypt (data);
 	}
 
-	void Cipher::DecryptBlocks (byte *data, size_t blockCount) const
+	void Cipher::DecryptBlocks (uint8_t *data, size_t blockCount) const
 	{
 		if (!Initialized)
 			throw NotInitialized (SRC_POS);
@@ -69,7 +69,7 @@ namespace VeraCrypt
 		}
 	}
 
-	void Cipher::EncryptBlock (byte *data) const
+	void Cipher::EncryptBlock (uint8_t *data) const
 	{
 		if (!Initialized)
 			throw NotInitialized (SRC_POS);
@@ -77,7 +77,7 @@ namespace VeraCrypt
 		Encrypt (data);
 	}
 
-	void Cipher::EncryptBlocks (byte *data, size_t blockCount) const
+	void Cipher::EncryptBlocks (uint8_t *data, size_t blockCount) const
 	{
 		if (!Initialized)
 			throw NotInitialized (SRC_POS);
@@ -130,7 +130,7 @@ namespace VeraCrypt
 		Initialized = true;
 	}
 
-         void Cipher::EncryptBlockXTS (byte *data, uint64 length, uint64 startDataUnitNo) const
+         void Cipher::EncryptBlockXTS (uint8_t *data, uint64 length, uint64 startDataUnitNo) const
 	{
 		if (!Initialized)
 			throw NotInitialized (SRC_POS);
@@ -138,7 +138,7 @@ namespace VeraCrypt
 		EncryptXTS (data, length, startDataUnitNo);
 	}
 
-        void Cipher::DecryptBlockXTS (byte *data, uint64 length, uint64 startDataUnitNo) const
+        void Cipher::DecryptBlockXTS (uint8_t *data, uint64 length, uint64 startDataUnitNo) const
 	{
 		if (!Initialized)
 			throw NotInitialized (SRC_POS);
@@ -155,7 +155,7 @@ namespace VeraCrypt
 
 
 	// AES
-	void CipherAES::Decrypt (byte *data) const
+	void CipherAES::Decrypt (uint8_t *data) const
 	{
 #ifdef TC_AES_HW_CPU
 		if (IsHwSupportAvailable())
@@ -165,7 +165,7 @@ namespace VeraCrypt
 			aes_decrypt (data, data, (aes_decrypt_ctx *) (ScheduledKey.Ptr() + sizeof (aes_encrypt_ctx)));
 	}
 
-	void CipherAES::DecryptBlocks (byte *data, size_t blockCount) const
+	void CipherAES::DecryptBlocks (uint8_t *data, size_t blockCount) const
 	{
 		if (!Initialized)
 			throw NotInitialized (SRC_POS);
@@ -187,7 +187,7 @@ namespace VeraCrypt
 			Cipher::DecryptBlocks (data, blockCount);
 	}
 
-	void CipherAES::Encrypt (byte *data) const
+	void CipherAES::Encrypt (uint8_t *data) const
 	{
 #ifdef TC_AES_HW_CPU
 		if (IsHwSupportAvailable())
@@ -197,7 +197,7 @@ namespace VeraCrypt
 			aes_encrypt (data, data, (aes_encrypt_ctx *) ScheduledKey.Ptr());
 	}
 
-	void CipherAES::EncryptBlocks (byte *data, size_t blockCount) const
+	void CipherAES::EncryptBlocks (uint8_t *data, size_t blockCount) const
 	{
 		if (!Initialized)
 			throw NotInitialized (SRC_POS);
@@ -219,17 +219,17 @@ namespace VeraCrypt
 			Cipher::EncryptBlocks (data, blockCount);
 	}
     #ifdef WOLFCRYPT_BACKEND
-        void CipherAES::EncryptXTS (byte *data, uint64 length, uint64 startDataUnitNo) const
+        void CipherAES::EncryptXTS (uint8_t *data, uint64 length, uint64 startDataUnitNo) const
 	{
 	    xts_encrypt (data, data, length, startDataUnitNo, (aes_encrypt_ctx *) ScheduledKey.Ptr());
 	}
 
-        void CipherAES::DecryptXTS (byte *data, uint64 length, uint64 startDataUnitNo) const
+        void CipherAES::DecryptXTS (uint8_t *data, uint64 length, uint64 startDataUnitNo) const
 	{
 	    xts_decrypt (data, data, length, startDataUnitNo, (aes_decrypt_ctx *) (ScheduledKey.Ptr() + sizeof (aes_encrypt_ctx)));
 	}
 
-        void CipherAES::SetCipherKeyXTS (const byte *key)
+        void CipherAES::SetCipherKeyXTS (const uint8_t *key)
 	{
 		if (xts_encrypt_key256 (key, (aes_encrypt_ctx *) ScheduledKey.Ptr()) != EXIT_SUCCESS)
 			throw CipherInitError (SRC_POS);
@@ -261,7 +261,7 @@ namespace VeraCrypt
 #endif
 	}
 
-	void CipherAES::SetCipherKey (const byte *key)
+	void CipherAES::SetCipherKey (const uint8_t *key)
 	{
 		if (aes_encrypt_key256 (key, (aes_encrypt_ctx *) ScheduledKey.Ptr()) != EXIT_SUCCESS)
 			throw CipherInitError (SRC_POS);
@@ -272,12 +272,12 @@ namespace VeraCrypt
 
     #ifndef WOLFCRYPT_BACKEND
 	// Serpent
-	void CipherSerpent::Decrypt (byte *data) const
+	void CipherSerpent::Decrypt (uint8_t *data) const
 	{
 		serpent_decrypt (data, data, ScheduledKey);
 	}
 
-	void CipherSerpent::Encrypt (byte *data) const
+	void CipherSerpent::Encrypt (uint8_t *data) const
 	{
 		serpent_encrypt (data, data, ScheduledKey);
 	}
@@ -287,12 +287,12 @@ namespace VeraCrypt
 		return 140*4;
 	}
 
-	void CipherSerpent::SetCipherKey (const byte *key)
+	void CipherSerpent::SetCipherKey (const uint8_t *key)
 	{
 		serpent_set_key (key, ScheduledKey);
 	}
 	
-	void CipherSerpent::EncryptBlocks (byte *data, size_t blockCount) const
+	void CipherSerpent::EncryptBlocks (uint8_t *data, size_t blockCount) const
 	{
 		if (!Initialized)
 			throw NotInitialized (SRC_POS);
@@ -308,7 +308,7 @@ namespace VeraCrypt
 			Cipher::EncryptBlocks (data, blockCount);
 	}
 	
-	void CipherSerpent::DecryptBlocks (byte *data, size_t blockCount) const
+	void CipherSerpent::DecryptBlocks (uint8_t *data, size_t blockCount) const
 	{
 		if (!Initialized)
 			throw NotInitialized (SRC_POS);
@@ -343,12 +343,12 @@ namespace VeraCrypt
 
 
 	// Twofish
-	void CipherTwofish::Decrypt (byte *data) const
+	void CipherTwofish::Decrypt (uint8_t *data) const
 	{
 		twofish_decrypt ((TwofishInstance *) ScheduledKey.Ptr(), (unsigned int *)data, (unsigned int *)data);
 	}
 
-	void CipherTwofish::Encrypt (byte *data) const
+	void CipherTwofish::Encrypt (uint8_t *data) const
 	{
 		twofish_encrypt ((TwofishInstance *) ScheduledKey.Ptr(), (unsigned int *)data, (unsigned int *)data);
 	}
@@ -358,12 +358,12 @@ namespace VeraCrypt
 		return TWOFISH_KS;
 	}
 
-	void CipherTwofish::SetCipherKey (const byte *key)
+	void CipherTwofish::SetCipherKey (const uint8_t *key)
 	{
 		twofish_set_key ((TwofishInstance *) ScheduledKey.Ptr(), (unsigned int *) key);
 	}
 	
-	void CipherTwofish::EncryptBlocks (byte *data, size_t blockCount) const
+	void CipherTwofish::EncryptBlocks (uint8_t *data, size_t blockCount) const
 	{
 		if (!Initialized)
 			throw NotInitialized (SRC_POS);
@@ -375,7 +375,7 @@ namespace VeraCrypt
 #endif
 	}
 	
-	void CipherTwofish::DecryptBlocks (byte *data, size_t blockCount) const
+	void CipherTwofish::DecryptBlocks (uint8_t *data, size_t blockCount) const
 	{
 		if (!Initialized)
 			throw NotInitialized (SRC_POS);
@@ -397,12 +397,12 @@ namespace VeraCrypt
 	}
 	
 	// Camellia
-	void CipherCamellia::Decrypt (byte *data) const
+	void CipherCamellia::Decrypt (uint8_t *data) const
 	{
 		camellia_decrypt (data, data, ScheduledKey.Ptr());
 	}
 
-	void CipherCamellia::Encrypt (byte *data) const
+	void CipherCamellia::Encrypt (uint8_t *data) const
 	{
 		camellia_encrypt (data, data, ScheduledKey.Ptr());
 	}
@@ -412,12 +412,12 @@ namespace VeraCrypt
 		return CAMELLIA_KS;
 	}
 
-	void CipherCamellia::SetCipherKey (const byte *key)
+	void CipherCamellia::SetCipherKey (const uint8_t *key)
 	{
 		camellia_set_key (key, ScheduledKey.Ptr());
 	}
 	
-	void CipherCamellia::EncryptBlocks (byte *data, size_t blockCount) const
+	void CipherCamellia::EncryptBlocks (uint8_t *data, size_t blockCount) const
 	{
 		if (!Initialized)
 			throw NotInitialized (SRC_POS);
@@ -429,7 +429,7 @@ namespace VeraCrypt
 #endif
 	}
 	
-	void CipherCamellia::DecryptBlocks (byte *data, size_t blockCount) const
+	void CipherCamellia::DecryptBlocks (uint8_t *data, size_t blockCount) const
 	{
 		if (!Initialized)
 			throw NotInitialized (SRC_POS);
@@ -451,12 +451,12 @@ namespace VeraCrypt
 	}
 
 	// Kuznyechik
-	void CipherKuznyechik::Decrypt (byte *data) const
+	void CipherKuznyechik::Decrypt (uint8_t *data) const
 	{
 		kuznyechik_decrypt_block (data, data, (kuznyechik_kds *) ScheduledKey.Ptr());
 	}
 
-	void CipherKuznyechik::Encrypt (byte *data) const
+	void CipherKuznyechik::Encrypt (uint8_t *data) const
 	{
 		kuznyechik_encrypt_block (data, data, (kuznyechik_kds *) ScheduledKey.Ptr());
 	}
@@ -466,11 +466,11 @@ namespace VeraCrypt
 		return KUZNYECHIK_KS;
 	}
 
-	void CipherKuznyechik::SetCipherKey (const byte *key)
+	void CipherKuznyechik::SetCipherKey (const uint8_t *key)
 	{
 		kuznyechik_set_key (key, (kuznyechik_kds *) ScheduledKey.Ptr());
 	}
-	void CipherKuznyechik::EncryptBlocks (byte *data, size_t blockCount) const
+	void CipherKuznyechik::EncryptBlocks (uint8_t *data, size_t blockCount) const
 	{
 		if (!Initialized)
 			throw NotInitialized (SRC_POS);
@@ -486,7 +486,7 @@ namespace VeraCrypt
 			Cipher::EncryptBlocks (data, blockCount);
 	}
 	
-	void CipherKuznyechik::DecryptBlocks (byte *data, size_t blockCount) const
+	void CipherKuznyechik::DecryptBlocks (uint8_t *data, size_t blockCount) const
 	{
 		if (!Initialized)
 			throw NotInitialized (SRC_POS);


### PR DESCRIPTION
C++17 features std::byte which breaks "byte" definitions in Crypto++ library. This pull requests fixes this.