### PR TITLE
Fix exceptions to match the correct language strings

### DIFF
--- a/src/Main/UserInterface.cpp
+++ b/src/Main/UserInterface.cpp
@@ -510,9 +510,9 @@ namespace VeraCrypt
 		EX2MSG (EMVIccCertNotFound,					LangString["EMV_ICC_CERT_NOTFOUND"]);
 		EX2MSG (EMVIssuerCertNotFound,				LangString["EMV_ISSUER_CERT_NOTFOUND"]);
 		EX2MSG (EMVCPLCNotFound,					LangString["EMV_CPLC_NOTFOUND"]);
-		EX2MSG (InvalidEMVPath,						LangString["EMV_PAN_NOTFOUND"]);
-		EX2MSG (EMVKeyfileDataNotFound,				LangString["INVALID_EMV_PATH"]);
-		EX2MSG (EMVPANNotFound,						LangString["EMV_KEYFILE_DATA_NOTFOUND"]);
+		EX2MSG (InvalidEMVPath,						LangString["INVALID_EMV_PATH"]);
+		EX2MSG (EMVKeyfileDataNotFound,				LangString["EMV_KEYFILE_DATA_NOTFOUND"]);
+		EX2MSG (EMVPANNotFound,						LangString["EMV_PAN_NOTFOUND"]);
 
 #if defined (TC_LINUX)
 		EX2MSG (TerminalNotFound,					LangString["LINUX_EX2MSG_TERMINALNOTFOUND"]);


### PR DESCRIPTION
This is something I accidentally stumbled upon while searching for something else, and thought it looked incorrect when the exception name didn't match the language string it's supposed to be associated with.

Fixes the order of the language strings to match the correct exceptions.