### PR TITLE
Prepare for changes in wxWidgets 3.3

### DIFF
--- a/src/Main/Application.cpp
+++ b/src/Main/Application.cpp
@@ -89,7 +89,7 @@ namespace VeraCrypt
 
 	FilePath Application::GetConfigFilePath (const wxString &configFileName, bool createConfigDir)
 	{
-		static wxScopedPtr<const wxString> configDirC;
+		static std::unique_ptr<const wxString> configDirC;
 		static bool configDirExists = false;
 
 		if (!configDirExists)

--- a/src/Main/Forms/VolumeCreationWizard.cpp
+++ b/src/Main/Forms/VolumeCreationWizard.cpp
@@ -975,7 +975,7 @@ namespace VeraCrypt
 						if (OuterVolume && VolumeSize > TC_MAX_FAT_SECTOR_COUNT * SectorSize)
 						{
 							uint64 limit = TC_MAX_FAT_SECTOR_COUNT * SectorSize / BYTES_PER_TB;
-							wstring err = StringFormatter (LangString["LINUX_ERROR_SIZE_HIDDEN_VOL"], limit, limit * 1024);
+							wstring err = static_cast<wstring>(StringFormatter (LangString["LINUX_ERROR_SIZE_HIDDEN_VOL"], limit, limit * 1024));
 
 							if (SectorSize < 4096)
 							{

--- a/src/Main/Resources.cpp
+++ b/src/Main/Resources.cpp
@@ -71,12 +71,12 @@ namespace VeraCrypt
 
 		UserPreferences Preferences;
 		Preferences.Load();
-		wstring preferredLang = Preferences.Language;
+		string preferredLang = string(Preferences.Language.begin(), Preferences.Language.end());
 #ifdef DEBUG
 		std::cout << "Config language: " << preferredLang << std::endl;
 #endif
 
-		if (preferredLang == L"system") {
+		if (preferredLang == "system") {
 			if (const char *env_p = getenv("LANG")) {
 				string lang(env_p);
 #ifdef DEBUG

--- a/src/Main/StringFormatter.h
+++ b/src/Main/StringFormatter.h
@@ -52,7 +52,7 @@ namespace VeraCrypt
 		StringFormatter (const wxString &format, StringFormatterArg arg0 = StringFormatterArg(), StringFormatterArg arg1 = StringFormatterArg(), StringFormatterArg arg2 = StringFormatterArg(), StringFormatterArg arg3 = StringFormatterArg(), StringFormatterArg arg4 = StringFormatterArg(), StringFormatterArg arg5 = StringFormatterArg(), StringFormatterArg arg6 = StringFormatterArg(), StringFormatterArg arg7 = StringFormatterArg(), StringFormatterArg arg8 = StringFormatterArg(), StringFormatterArg arg9 = StringFormatterArg());
 		virtual ~StringFormatter ();
 
-		operator wstring () const { return wstring (FormattedString); }
+		explicit operator wstring () const { return wstring (FormattedString); }
 		operator wxString () const { return FormattedString; }
 		operator StringFormatterArg () const { return FormattedString; }
 

--- a/src/Main/UserInterface.cpp
+++ b/src/Main/UserInterface.cpp
@@ -390,7 +390,7 @@ namespace VeraCrypt
 			errOutput += StringConverter::ToWide (execEx->GetErrorOutput());
 
 			if (errOutput.empty())
-				return errOutput + StringFormatter (LangString["LINUX_COMMAND_GET_ERROR"], execEx->GetCommand(), execEx->GetExitCode());
+				return errOutput + static_cast<wstring>(StringFormatter (LangString["LINUX_COMMAND_GET_ERROR"], execEx->GetCommand(), execEx->GetExitCode()));
 
 			return wxString (errOutput).Trim (true);
 		}
@@ -1516,7 +1516,7 @@ namespace VeraCrypt
 		EncryptionTest::TestAll();
 
 		// StringFormatter
-		if (StringFormatter (L"{9} {8} {7} {6} {5} {4} {3} {2} {1} {0} {{0}}", "1", L"2", '3', L'4', 5, 6, 7, 8, 9, 10) != L"10 9 8 7 6 5 4 3 2 1 {0}")
+		if (static_cast<wstring>(StringFormatter (L"{9} {8} {7} {6} {5} {4} {3} {2} {1} {0} {{0}}", "1", L"2", '3', L'4', 5, 6, 7, 8, 9, 10)) != L"10 9 8 7 6 5 4 3 2 1 {0}")
 			throw TestFailed (SRC_POS);
 		try
 		{


### PR DESCRIPTION
wxWidgets 3.3 which is going to be released this autumn according to the roadmap, is going to introduce some ABI breakage. This PR is going to suggest changes that ensure that when 3.3 hits the distro repositories, VeraCrypt will build against it.

Main breakage is caused by our reliance on implicit conversions from wxString, and as of [this commit](https://github.com/wxWidgets/wxWidgets/commit/35c35c235e9c29b40002131602e050dca8d65b8c) and the commit mentioned in it's message, wxWidgets 3.3 defaults to using STL classes which require explicit conversions, so our implicit conversions won't build anymore.

Another change in 3.3 caused the header for wxScopedPtr not being included anymore through our other includes. wxScopedPtr is deprecated and upstream recommends using STL smart pointers instead, so instead of re-including the header for the deprecated function, we can just change it to std::unique_ptr and avoid the include.

These changes mainly increase verbosity, explicitness and won't affect building against 3.2 which VeraCrypt currently uses. These changes make building against current wxWidgets master branch possible (with few small Makefile changes).