### PR TITLE
FreeBSD: Fix privilege escalation prompts not showing up

### DIFF
--- a/src/Core/Unix/CoreService.cpp
+++ b/src/Core/Unix/CoreService.cpp
@@ -309,7 +309,7 @@ namespace VeraCrypt
 					std::vector<char> buffer(128, 0);
 					std::string result;
 					
-					FILE* pipe = popen("sudo -n uptime 2>&1 | grep 'load average' | wc -l", "r");	//	We redirect stderr to stdout (2>&1) to be able to catch the result of the command
+					FILE* pipe = popen("sudo -n uptime 2>&1 | grep 'load average' | wc -l | tr -d '[:blank:]'", "r");	//	We redirect stderr to stdout (2>&1) to be able to catch the result of the command
 					if (pipe)
 					{
 						while (!feof(pipe))


### PR DESCRIPTION
The behaviour of `wc -l` is different on FreeBSD, in which the stdout result is padded by spaces in the beginning, which causes that the `result[0]` is not actually the value we care about. This patch adds a translate removing all whitespace from the output.