### PR TITLE
FreeBSD: Support automatic detection and mounting of ext2/3/4, exFAT, NTFS filesystems

### DIFF
--- a/src/Core/Unix/FreeBSD/CoreFreeBSD.cpp
+++ b/src/Core/Unix/FreeBSD/CoreFreeBSD.cpp
@@ -207,20 +207,25 @@ namespace VeraCrypt
 			}
 		}
 		
-		if ((result.find("ext") == 0) || StringConverter::ToLower(filesystemType).find("ext") == 0) {
-			chosenFilesystem = "ext2fs";
-		}
-		else if ((result.find("exfat") == 0) || StringConverter::ToLower(filesystemType).find("exfat") == 0) {
-			chosenFilesystem = "exfat";
-			modifiedMountOptions += string(!systemMountOptions.empty() ? "," : "") + "mountprog=/usr/local/sbin/mount.exfat";
-		}
-		else if ((result.find("ntfs") == 0) || StringConverter::ToLower(filesystemType).find("ntfs") == 0) {
-			chosenFilesystem = "ntfs-3g";
-			modifiedMountOptions += string(!systemMountOptions.empty() ? "," : "") + "mountprog=/usr/local/bin/ntfs-3g";
-		}
-		else if (!filesystemType.empty()) {
-			// Filesystem is specified but is none of the above, then supply as is
-			chosenFilesystem = filesystemType;
+		if (modifiedMountOptions.find("mountprog") == string::npos) {
+			// Make sure we don't override user defined mountprog
+			if (result.find("ext") == 0 || StringConverter::ToLower(filesystemType).find("ext") == 0) {
+				chosenFilesystem = "ext2fs";
+			}
+			else if (result.find("exfat") == 0 || StringConverter::ToLower(filesystemType) == "exfat") {
+				chosenFilesystem = "exfat";
+				modifiedMountOptions += string(!systemMountOptions.empty() ? "," : "")
+							+ "mountprog=/usr/local/sbin/mount.exfat";
+			}
+			else if (result.find("ntfs") == 0 || StringConverter::ToLower(filesystemType) == "ntfs") {
+				chosenFilesystem = "ntfs";
+				modifiedMountOptions += string(!systemMountOptions.empty() ? "," : "")
+							+ "mountprog=/usr/local/bin/ntfs-3g";
+			}
+			else if (!filesystemType.empty()) {
+				// Filesystem is specified but is none of the above, then supply as is
+				chosenFilesystem = filesystemType;
+			}
 		}
 
 		try

--- a/src/Core/Unix/FreeBSD/CoreFreeBSD.cpp
+++ b/src/Core/Unix/FreeBSD/CoreFreeBSD.cpp
@@ -226,7 +226,8 @@ namespace VeraCrypt
 				// Filesystem is specified but is none of the above, then supply as is
 				chosenFilesystem = filesystemType;
 			}
-		}
+		} else if (!filesystemType.empty())
+			chosenFilesystem = filesystemType;
 
 		try
 		{

--- a/src/Core/Unix/FreeBSD/CoreFreeBSD.cpp
+++ b/src/Core/Unix/FreeBSD/CoreFreeBSD.cpp
@@ -83,7 +83,7 @@ namespace VeraCrypt
 #ifdef TC_MACOSX
 		const string busType = "rdisk";
 #else
-		foreach (const string &busType, StringConverter::Split ("ad da"))
+		foreach (const string &busType, StringConverter::Split ("ad da vtbd"))
 #endif
 		{
 			for (int devNumber = 0; devNumber < 64; devNumber++)

--- a/src/Core/Unix/FreeBSD/CoreFreeBSD.cpp
+++ b/src/Core/Unix/FreeBSD/CoreFreeBSD.cpp
@@ -236,7 +236,7 @@ namespace VeraCrypt
 			if (!filesystemType.empty())
 				throw;
 
-			CoreUnix::MountFilesystem (devicePath, mountPoint, filesystemType, readOnly, modifiedMountOptions);
+			CoreUnix::MountFilesystem (devicePath, mountPoint, filesystemType, readOnly, systemMountOptions);
 		}
 	}
 

--- a/src/Core/Unix/FreeBSD/CoreFreeBSD.cpp
+++ b/src/Core/Unix/FreeBSD/CoreFreeBSD.cpp
@@ -187,13 +187,14 @@ namespace VeraCrypt
 	{
 		std::string chosenFilesystem = "msdos";
 		std::string modifiedMountOptions = systemMountOptions;
-		std::string result;
 
-		if (filesystemType.empty()) {
+		if (filesystemType.empty() && modifiedMountOptions.find("mountprog") == string::npos) {
 			// No filesystem type specified through CLI, attempt to identify with blkid
 			// as mount is unable to probe filesystem type on BSD
+			// Make sure we don't override user defined mountprog
 			std::vector<char> buffer(128,0);
 			std::string cmd = "blkid -o value -s TYPE " + static_cast<std::string>(devicePath) + " 2>/dev/null";
+			std::string result;
 
 			FILE* pipe = popen(cmd.c_str(), "r");
 			if (pipe) {
@@ -205,10 +206,7 @@ namespace VeraCrypt
 				pclose(pipe);
 				pipe = nullptr;
 			}
-		}
-		
-		if (modifiedMountOptions.find("mountprog") == string::npos) {
-			// Make sure we don't override user defined mountprog
+
 			if (result.find("ext") == 0 || StringConverter::ToLower(filesystemType).find("ext") == 0) {
 				chosenFilesystem = "ext2fs";
 			}
@@ -226,7 +224,7 @@ namespace VeraCrypt
 				// Filesystem is specified but is none of the above, then supply as is
 				chosenFilesystem = filesystemType;
 			}
-		} else if (!filesystemType.empty())
+		} else
 			chosenFilesystem = filesystemType;
 
 		try

--- a/src/Core/Unix/FreeBSD/CoreFreeBSD.cpp
+++ b/src/Core/Unix/FreeBSD/CoreFreeBSD.cpp
@@ -187,14 +187,14 @@ namespace VeraCrypt
 	{
 		std::string chosenFilesystem = "msdos";
 
-		// No filesystem type specified through CLI, attempt to identify with blkid
-		// as mount is unable to probe filesystem type on BSD
 		if (filesystemType.empty()) {
+			// No filesystem type specified through CLI, attempt to identify with blkid
+			// as mount is unable to probe filesystem type on BSD
 			std::vector<char> buffer(128,0);
 			std::string result;
-			std::string command = std::string("blkid -o value -s TYPE ") + static_cast<std::string>(devicePath);
+			std::string cmd = "blkid -o value -s TYPE " + static_cast<std::string>(devicePath) + " 2>/dev/null";
 
-			FILE* pipe = popen(command.c_str(), "r");
+			FILE* pipe = popen(cmd.c_str(), "r");
 			if (pipe) {
 				while (!feof(pipe)) {
 					if (fgets(buffer.data(), 128, pipe) != nullptr)
@@ -209,11 +209,11 @@ namespace VeraCrypt
 						chosenFilesystem = "ext2fs";
 				}
 			}
-		// Filesystem is specified through CLI, if starts with Ext, change to use ext2fs
 		} else if (StringConverter::ToLower(filesystemType).find("ext") == 0) {
+			// Filesystem is specified and it starts with Ext, change to use ext2fs
 			chosenFilesystem = "ext2fs";
-		// Filesystem is specified but not Ext, supply as is
 		} else {
+			// Filesystem is specified but not Ext, supply as is
 			chosenFilesystem = filesystemType;
 		}
 

--- a/src/Main/CommandLineInterface.cpp
+++ b/src/Main/CommandLineInterface.cpp
@@ -347,6 +347,12 @@ namespace VeraCrypt
 #elif defined (TC_FREEBSD) || defined (TC_SOLARIS)
 				else if (str.IsSameAs (L"UFS", false))
 					ArgFilesystem = VolumeCreationOptions::FilesystemType::UFS;
+				else if (str.IsSameAs (L"Ext2", false))
+					ArgFilesystem = VolumeCreationOptions::FilesystemType::Ext2;
+				else if (str.IsSameAs (L"Ext3", false))
+					ArgFilesystem = VolumeCreationOptions::FilesystemType::Ext3;
+				else if (str.IsSameAs (L"Ext4", false))
+					ArgFilesystem = VolumeCreationOptions::FilesystemType::Ext4;
 #endif
 				else
 					throw_err (LangString["UNKNOWN_OPTION"] + L": " + str);

--- a/src/Main/CommandLineInterface.cpp
+++ b/src/Main/CommandLineInterface.cpp
@@ -353,6 +353,10 @@ namespace VeraCrypt
 					ArgFilesystem = VolumeCreationOptions::FilesystemType::Ext3;
 				else if (str.IsSameAs (L"Ext4", false))
 					ArgFilesystem = VolumeCreationOptions::FilesystemType::Ext4;
+				else if (str.IsSameAs (L"NTFS", false))
+					ArgFilesystem = VolumeCreationOptions::FilesystemType::NTFS;
+				else if (str.IsSameAs (L"exFAT", false))
+					ArgFilesystem = VolumeCreationOptions::FilesystemType::exFAT;
 #endif
 				else
 					throw_err (LangString["UNKNOWN_OPTION"] + L": " + str);


### PR DESCRIPTION
Currently the `mount` implementation on FreeBSD does not support automatic filesystem detection on mount. We can alternatively use `blkid` which allows us to detect the filesystem that is contained on the virtual device before we attempt to mount the filesystem. The `blkid` program is part of the `e2fsprogs` package, which also provides the ext2/3/4 driver and is very likely to be installed on the user's system, if not, it will silently fail and behave like it has previously.

This patch adds support for automatic mounting of:
- Ext2/3/4 (requires `e2fsprogs`)
- exFAT via mount.exfat (requires `fusefs-exfat`)
- NTFS via ntfs-3g (requires `fusefs-ntfs`)

Related: https://github.com/veracrypt/VeraCrypt/issues/576