### PR TITLE
Avoid assert by verifying folder for installed languages exists

### DIFF
--- a/src/Main/Forms/PreferencesDialog.cpp
+++ b/src/Main/Forms/PreferencesDialog.cpp
@@ -82,14 +82,16 @@ namespace VeraCrypt
 		LanguageListBox->Append("System default");
 		LanguageListBox->Append("English");
 
-		size_t langCount;
-		langCount = wxDir::GetAllFiles(languagesFolder.GetName(), &langArray, wxEmptyString, wxDIR_FILES);
-		for (size_t i = 0; i < langCount; ++i) {
-			wxFileName filename(langArray[i]);
-			wxString langId = filename.GetName().AfterLast('.');
-			wxString langNative = langEntries[langId];
-			if (!langNative.empty()) {
-				LanguageListBox->Append(langNative);
+		if (wxDir::Exists(languagesFolder.GetName())) {
+			size_t langCount;
+			langCount = wxDir::GetAllFiles(languagesFolder.GetName(), &langArray, wxEmptyString, wxDIR_FILES);
+			for (size_t i = 0; i < langCount; ++i) {
+				wxFileName filename(langArray[i]);
+				wxString langId = filename.GetName().AfterLast('.');
+				wxString langNative = langEntries[langId];
+				if (!langNative.empty()) {
+					LanguageListBox->Append(langNative);
+				}
 			}
 		}
 #endif


### PR DESCRIPTION
wxDir::GetAllFiles will throw an assert when opening the preferences dialog if for some reason the user has not installed VeraCrypt properly and is missing the intended folder. This patch adds a check to ensure the folder first exists before querying its files.

There was two options, leaving the two options of "System language" and "English" in the combo box when no languages are found, or putting these two options also inside the `if` block leaving the combo box empty. I think it's clearer to the user when they only see two options to wonder "how do I get more languages?" instead of being faced with an empty selection box and wondering if it is bugged. 