### PR TITLE
Fix regression in core service deserialization

### DIFF
--- a/src/Core/Unix/CoreUnix.cpp
+++ b/src/Core/Unix/CoreUnix.cpp
@@ -728,7 +728,6 @@ namespace VeraCrypt
 		}
 		catch (...)
 		{
-			wcout << L"Exception. Error mounting volume: " << wstring(*options.Path) << endl;
 			try
 			{
 				VolumeInfoList mountedVolumes = GetMountedVolumes (*options.Path);


### PR DESCRIPTION
Introducing data into the standard out in the core service will cause deserialization problems, as the pipes are used for interprocess communication.

I don't even think you would see this message anywhere on the terminal as the core service is a forked process. If you wanted to print or log the errors when attempting to mount FUSE devices, you could do something like:

`SystemLog::WriteError("Exception. Error mounting volume: " + static_cast<string>(*options.Path));`

Which would cause it to be printed in either syslog on Linux, or to the Console logs in macOS.