### PR TITLE
Revert "Linux: Make the C++ code compatible with old compilers..."

### DIFF
--- a/src/Common/SCard.cpp
+++ b/src/Common/SCard.cpp
@@ -6,7 +6,7 @@ namespace VeraCrypt
 {
 	SCardManager SCard::manager;
 
-	SCard::SCard()
+	SCard::SCard() : m_reader(NULL)
 	{
 	}
 

--- a/src/Common/SCardLoader.cpp
+++ b/src/Common/SCardLoader.cpp
@@ -320,7 +320,7 @@ namespace VeraCrypt
 		return scardStatus(hCard, mszReaderNames, pcchReaderLen, pdwState, pdwProtocol, pbAtr, pcbAtrLen);
 	}
 	
-	LONG SCardLoader::SCardGetStatusChange(SCARDCONTEXT hContext, DWORD dwTimeout, SCARD_READERSTATE* rgReaderStates, DWORD cReaders)
+	LONG SCardLoader::SCardGetStatusChange(SCARDCONTEXT hContext, DWORD dwTimeout, LPSCARD_READERSTATE rgReaderStates, DWORD cReaders)
 	{
 		Initialize();
 

--- a/src/Common/SCardLoader.h
+++ b/src/Common/SCardLoader.h
@@ -13,6 +13,8 @@
 #include <PCSC/winscard.h>
 #include <PCSC/wintypes.h>
 #include "reader.h"
+typedef LPSCARD_READERSTATE_A LPSCARD_READERSTATE;
+using VeraCrypt::uint8;
 #define BOOL int
 #else
 #undef BOOL
@@ -20,6 +22,7 @@
 #include <winscard.h>
 #include <wintypes.h>
 #include <reader.h>
+using VeraCrypt::uint8;
 #define BOOL int
 #endif
 #endif
@@ -45,7 +48,7 @@ namespace VeraCrypt
 	typedef LONG (SCARD_CALL_SPEC *SCardBeginTransactionPtr)(SCARDHANDLE hCard);
 	typedef LONG (SCARD_CALL_SPEC *SCardEndTransactionPtr)(SCARDHANDLE hCard, DWORD dwDisposition);
 	typedef LONG (SCARD_CALL_SPEC *SCardStatusPtr)(SCARDHANDLE hCard, LPTSTR mszReaderNames, LPDWORD pcchReaderLen, LPDWORD pdwState, LPDWORD pdwProtocol, BYTE* pbAtr, LPDWORD pcbAtrLen);
-	typedef LONG (SCARD_CALL_SPEC *SCardGetStatusChangePtr)(SCARDCONTEXT hContext, DWORD dwTimeout, SCARD_READERSTATE* rgReaderStates, DWORD cReaders);
+	typedef LONG (SCARD_CALL_SPEC *SCardGetStatusChangePtr)(SCARDCONTEXT hContext, DWORD dwTimeout, LPSCARD_READERSTATE rgReaderStates, DWORD cReaders);
 	typedef LONG (SCARD_CALL_SPEC *SCardControlPtr)(SCARDHANDLE hCard, DWORD dwControlCode, LPCVOID pbSendBuffer, DWORD cbSendLength, LPVOID pbRecvBuffer, DWORD cbRecvLength, LPDWORD lpBytesReturned);
 	typedef LONG (SCARD_CALL_SPEC *SCardTransmitPtr)(SCARDHANDLE hCard, LPCSCARD_IO_REQUEST pioSendPci, const BYTE* pbSendBuffer, DWORD cbSendLength, LPSCARD_IO_REQUEST pioRecvPci, BYTE* pbRecvBuffer, LPDWORD pcbRecvLength);
 	typedef LONG (SCARD_CALL_SPEC *SCardListReaderGroupsPtr)(SCARDCONTEXT hContext, LPTSTR mszGroups, LPDWORD pcchGroups);
@@ -108,7 +111,7 @@ namespace VeraCrypt
 		static LONG SCardBeginTransaction(SCARDHANDLE hCard);
 		static LONG SCardEndTransaction(SCARDHANDLE hCard, DWORD dwDisposition);
 		static LONG SCardStatus(SCARDHANDLE hCard, LPTSTR mszReaderNames, LPDWORD pcchReaderLen, LPDWORD pdwState, LPDWORD pdwProtocol, BYTE* pbAtr, LPDWORD pcbAtrLen);
-		static LONG SCardGetStatusChange(SCARDCONTEXT hContext, DWORD dwTimeout, SCARD_READERSTATE* rgReaderStates, DWORD cReaders);
+		static LONG SCardGetStatusChange(SCARDCONTEXT hContext, DWORD dwTimeout, LPSCARD_READERSTATE rgReaderStates, DWORD cReaders);
 		static LONG SCardControl(SCARDHANDLE hCard, DWORD dwControlCode, LPCVOID pbSendBuffer, DWORD cbSendLength, LPVOID pbRecvBuffer, DWORD cbRecvLength, LPDWORD lpBytesReturned);
 		static LONG SCardTransmit(SCARDHANDLE hCard, LPCSCARD_IO_REQUEST pioSendPci, const BYTE* pbSendBuffer, DWORD cbSendLength, LPSCARD_IO_REQUEST pioRecvPci, BYTE* pbRecvBuffer, LPDWORD pcbRecvLength);
 		static LONG SCardListReaderGroups(SCARDCONTEXT hContext, LPTSTR mszGroups, LPDWORD pcchGroups);

--- a/src/Common/SCardReader.cpp
+++ b/src/Common/SCardReader.cpp
@@ -17,7 +17,7 @@ namespace VeraCrypt
 		}
 		else 
 		{
-			m_scardLoader.reset();
+			m_scardLoader = NULL;
 			m_hSCReaderContext = 0;
 		}
 		m_hCard = hCard;
@@ -84,7 +84,7 @@ namespace VeraCrypt
 	void SCardReader::Clear(void)
 	{
 		m_szSCReaderName = L"";
-		m_scardLoader.reset();
+		m_scardLoader = NULL;
 		m_hSCReaderContext = 0;
 		m_hCard = 0;
 		m_dwProtocol = 0;

--- a/src/Common/TLVParser.cpp
+++ b/src/Common/TLVParser.cpp
@@ -169,7 +169,7 @@ namespace VeraCrypt
 	shared_ptr<TLVNode> TLVParser::TLV_Find(shared_ptr<TLVNode> node, uint16 tag)
 	{
 		size_t i = 0;
-		shared_ptr<TLVNode> tmpnode;
+		shared_ptr<TLVNode> tmpnode = NULL;
 		if (node->Tag == tag)
 		{
 			return node;
@@ -177,11 +177,11 @@ namespace VeraCrypt
 		for (i = 0; i < node->Subs->size(); i++)
 		{
 			tmpnode = TLV_Find(node->Subs->at(i),tag);
-			if (tmpnode)
+			if (tmpnode != NULL)
 			{
 				return tmpnode;
 			}
 		}
-		return shared_ptr<TLVNode>();
+		return NULL;
 	}
 }

--- a/src/Main/Forms/PreferencesDialog.cpp
+++ b/src/Main/Forms/PreferencesDialog.cpp
@@ -82,51 +82,6 @@ namespace VeraCrypt
 		LanguageListBox->Append("System default");
 		LanguageListBox->Append("English");
 
-		langEntries = {
-				{"system", L"System default"},
-				{"ar", L"العربية"},
-				{"be", L"Беларуская"},
-				{"bg", L"Български"},
-				{"ca", L"Català"},
-				{"co", L"Corsu"},
-				{"cs", L"Čeština"},
-				{"da", L"Dansk"},
-				{"de", L"Deutsch"},
-				{"el", L"Ελληνικά"},
-				{"en", L"English"},
-				{"es", L"Español"},
-				{"et", L"Eesti"},
-				{"eu", L"Euskara"},
-				{"fa", L"فارسي"},
-				{"fi", L"Suomi"},
-				{"fr", L"Français"},
-				{"he", L"עברית"},
-				{"hu", L"Magyar"},
-				{"id", L"Bahasa Indonesia"},
-				{"it", L"Italiano"},
-				{"ja", L"日本語"},
-				{"ka", L"ქართული"},
-				{"ko", L"한국어"},
-				{"lv", L"Latviešu"},
-				{"nl", L"Nederlands"},
-				{"nn", L"Norsk Nynorsk"},
-				{"pl", L"Polski"},
-				{"ro", L"Română"},
-				{"ru", L"Русский"},
-				{"pt-br", L"Português-Brasil"},
-				{"sk", L"Slovenčina"},
-				{"sl", L"Slovenščina"},
-				{"sv", L"Svenska"},
-				{"th", L"ภาษาไทย"},
-				{"tr", L"Türkçe"},
-				{"uk", L"Українська"},
-				{"uz", L"Ўзбекча"},
-				{"vi", L"Tiếng Việt"},
-				{"zh-cn", L"简体中文"},
-				{"zh-hk", L"繁體中文(香港)"},
-				{"zh-tw", L"繁體中文"}
-		};
-
 		if (wxDir::Exists(languagesFolder.GetName())) {
 			size_t langCount;
 			langCount = wxDir::GetAllFiles(languagesFolder.GetName(), &langArray, wxEmptyString, wxDIR_FILES);
@@ -480,11 +435,11 @@ namespace VeraCrypt
 
 		if (LanguageListBox->GetSelection() != wxNOT_FOUND) {
 			wxString langToFind = LanguageListBox->GetString(LanguageListBox->GetSelection());
-			for (map<wxString, std::wstring>::const_iterator each = langEntries.begin(); each != langEntries.end(); ++each) {
-				if (each->second == langToFind) {
-					Preferences.Language = each->first;
+			for (const auto &each: langEntries) {
+				if (each.second == langToFind) {
+					Preferences.Language = each.first;
 #ifdef DEBUG
-					cout << "Lang set to: " << each->first << endl;
+					cout << "Lang set to: " << each.first << endl;
 #endif
 				}
 			}

--- a/src/Main/Forms/PreferencesDialog.h
+++ b/src/Main/Forms/PreferencesDialog.h
@@ -60,7 +60,50 @@ namespace VeraCrypt
 		UserPreferences Preferences;
 		bool RestoreValidatorBell;
 		HotkeyList UnregisteredHotkeys;
-		map<wxString, wstring> langEntries;
+		map<wxString, wstring> langEntries = {
+				{"system", L"System default"},
+				{"ar", L"العربية"},
+				{"be", L"Беларуская"},
+				{"bg", L"Български"},
+				{"ca", L"Català"},
+				{"co", L"Corsu"},
+				{"cs", L"Čeština"},
+				{"da", L"Dansk"},
+				{"de", L"Deutsch"},
+				{"el", L"Ελληνικά"},
+				{"en", L"English"},
+				{"es", L"Español"},
+				{"et", L"Eesti"},
+				{"eu", L"Euskara"},
+				{"fa", L"فارسي"},
+				{"fi", L"Suomi"},
+				{"fr", L"Français"},
+				{"he", L"עברית"},
+				{"hu", L"Magyar"},
+				{"id", L"Bahasa Indonesia"},
+				{"it", L"Italiano"},
+				{"ja", L"日本語"},
+				{"ka", L"ქართული"},
+				{"ko", L"한국어"},
+				{"lv", L"Latviešu"},
+				{"nl", L"Nederlands"},
+				{"nn", L"Norsk Nynorsk"},
+				{"pl", L"Polski"},
+				{"ro", L"Română"},
+				{"ru", L"Русский"},
+				{"pt-br", L"Português-Brasil"},
+				{"sk", L"Slovenčina"},
+				{"sl", L"Slovenščina"},
+				{"sv", L"Svenska"},
+				{"th", L"ภาษาไทย"},
+				{"tr", L"Türkçe"},
+				{"uk", L"Українська"},
+				{"uz", L"Ўзбекча"},
+				{"vi", L"Tiếng Việt"},
+				{"zh-cn", L"简体中文"},
+				{"zh-hk", L"繁體中文(香港)"},
+				{"zh-tw", L"繁體中文"}
+		};
 	};
 }
 

--- a/src/Main/Forms/VolumeCreationWizard.cpp
+++ b/src/Main/Forms/VolumeCreationWizard.cpp
@@ -37,19 +37,6 @@
 
 namespace VeraCrypt
 {
-	class OpenOuterVolumeFunctor : public Functor
-	{
-		public:
-		OpenOuterVolumeFunctor (const DirectoryPath &outerVolumeMountPoint) : OuterVolumeMountPoint (outerVolumeMountPoint) { }
-
-		virtual void operator() ()
-		{
-			Gui->OpenExplorerWindow (OuterVolumeMountPoint);
-		}
-
-		DirectoryPath OuterVolumeMountPoint;
-	};
-
 #ifdef TC_MACOSX
 
 	bool VolumeCreationWizard::ProcessEvent(wxEvent& event)
@@ -350,6 +337,18 @@ namespace VeraCrypt
 					Close();
 					return new InfoWizardPage (GetPageParent());
 				}
+
+				struct OpenOuterVolumeFunctor : public Functor
+				{
+					OpenOuterVolumeFunctor (const DirectoryPath &outerVolumeMountPoint) : OuterVolumeMountPoint (outerVolumeMountPoint) { }
+
+					virtual void operator() ()
+					{
+						Gui->OpenExplorerWindow (OuterVolumeMountPoint);
+					}
+
+					DirectoryPath OuterVolumeMountPoint;
+				};
 
 				InfoWizardPage *page = new InfoWizardPage (GetPageParent(), LangString["LINUX_OPEN_OUTER_VOL"],
 					shared_ptr <Functor> (new OpenOuterVolumeFunctor (MountedOuterVolume->MountPoint)));

--- a/src/Main/GraphicUserInterface.cpp
+++ b/src/Main/GraphicUserInterface.cpp
@@ -37,33 +37,6 @@
 
 namespace VeraCrypt
 {
-	class AdminPasswordRequestHandler : public GetStringFunctor
-	{
-		public:
-		virtual void operator() (string &passwordStr)
-		{
-
-			wxString sValue;
-			if (Gui->GetWaitDialog())
-			{
-				Gui->GetWaitDialog()->RequestAdminPassword(sValue);
-				if (sValue.IsEmpty())
-					throw UserAbort (SRC_POS);
-			}
-			else
-			{
-				wxPasswordEntryDialog dialog (Gui->GetActiveWindow(), LangString["LINUX_ADMIN_PW_QUERY"], LangString["LINUX_ADMIN_PW_QUERY_TITLE"]);
-				if (dialog.ShowModal() != wxID_OK)
-					throw UserAbort (SRC_POS);
-				sValue = dialog.GetValue();
-			}
-			wstring wPassword (sValue);	// A copy of the password is created here by wxWidgets, which cannot be erased
-			finally_do_arg (wstring *, &wPassword, { StringConverter::Erase (*finally_arg); });
-
-			StringConverter::ToSingle (wPassword, passwordStr);
-		}
-	};
-
 #ifdef TC_MACOSX
 	int GraphicUserInterface::g_customIdCmdV = 0;
 	int GraphicUserInterface::g_customIdCmdA = 0;
@@ -479,6 +452,32 @@ namespace VeraCrypt
 
 	shared_ptr <GetStringFunctor> GraphicUserInterface::GetAdminPasswordRequestHandler ()
 	{
+		struct AdminPasswordRequestHandler : public GetStringFunctor
+		{
+			virtual void operator() (string &passwordStr)
+			{
+
+				wxString sValue;
+				if (Gui->GetWaitDialog())
+				{
+					Gui->GetWaitDialog()->RequestAdminPassword(sValue);
+					if (sValue.IsEmpty())
+						throw UserAbort (SRC_POS);
+				}
+				else
+				{
+					wxPasswordEntryDialog dialog (Gui->GetActiveWindow(), LangString["LINUX_ADMIN_PW_QUERY"], LangString["LINUX_ADMIN_PW_QUERY_TITLE"]);
+					if (dialog.ShowModal() != wxID_OK)
+						throw UserAbort (SRC_POS);
+					sValue = dialog.GetValue();
+				}
+				wstring wPassword (sValue);	// A copy of the password is created here by wxWidgets, which cannot be erased
+				finally_do_arg (wstring *, &wPassword, { StringConverter::Erase (*finally_arg); });
+
+				StringConverter::ToSingle (wPassword, passwordStr);
+			}
+		};
+
 		return shared_ptr <GetStringFunctor> (new AdminPasswordRequestHandler);
 	}
 

--- a/src/Main/StringFormatter.h
+++ b/src/Main/StringFormatter.h
@@ -52,10 +52,7 @@ namespace VeraCrypt
 		StringFormatter (const wxString &format, StringFormatterArg arg0 = StringFormatterArg(), StringFormatterArg arg1 = StringFormatterArg(), StringFormatterArg arg2 = StringFormatterArg(), StringFormatterArg arg3 = StringFormatterArg(), StringFormatterArg arg4 = StringFormatterArg(), StringFormatterArg arg5 = StringFormatterArg(), StringFormatterArg arg6 = StringFormatterArg(), StringFormatterArg arg7 = StringFormatterArg(), StringFormatterArg arg8 = StringFormatterArg(), StringFormatterArg arg9 = StringFormatterArg());
 		virtual ~StringFormatter ();
 
-#if (__cplusplus >= 201103L)
-		explicit 
-#endif
-		operator wstring () const { return wstring (FormattedString); }
+		explicit operator wstring () const { return wstring (FormattedString); }
 		operator wxString () const { return FormattedString; }
 		operator StringFormatterArg () const { return FormattedString; }
 

--- a/src/Main/TextUserInterface.cpp
+++ b/src/Main/TextUserInterface.cpp
@@ -30,27 +30,6 @@
 
 namespace VeraCrypt
 {
-	class AdminPasswordRequestHandler : public GetStringFunctor
-	{
-		public:
-		AdminPasswordRequestHandler (TextUserInterface *userInterface) : UI (userInterface) { }
-		virtual void operator() (string &passwordStr)
-		{
-			UI->ShowString (_("Enter your user password or administrator password: "));
-
-			TextUserInterface::SetTerminalEcho (false);
-			finally_do ({ TextUserInterface::SetTerminalEcho (true); });
-
-			wstring wPassword (UI->ReadInputStreamLine());
-			finally_do_arg (wstring *, &wPassword, { StringConverter::Erase (*finally_arg); });
-
-			UI->ShowString (L"\n");
-
-			StringConverter::ToSingle (wPassword, passwordStr);
-		}
-		TextUserInterface *UI;
-	};
-
 	TextUserInterface::TextUserInterface ()
 	{
 #ifdef TC_UNIX
@@ -1116,6 +1095,26 @@ namespace VeraCrypt
 
 	shared_ptr <GetStringFunctor> TextUserInterface::GetAdminPasswordRequestHandler ()
 	{
+		struct AdminPasswordRequestHandler : public GetStringFunctor
+		{
+			AdminPasswordRequestHandler (TextUserInterface *userInterface) : UI (userInterface) { }
+			virtual void operator() (string &passwordStr)
+			{
+				UI->ShowString (_("Enter your user password or administrator password: "));
+
+				TextUserInterface::SetTerminalEcho (false);
+				finally_do ({ TextUserInterface::SetTerminalEcho (true); });
+
+				wstring wPassword (UI->ReadInputStreamLine());
+				finally_do_arg (wstring *, &wPassword, { StringConverter::Erase (*finally_arg); });
+
+				UI->ShowString (L"\n");
+
+				StringConverter::ToSingle (wPassword, passwordStr);
+			}
+			TextUserInterface *UI;
+		};
+
 		return shared_ptr <GetStringFunctor> (new AdminPasswordRequestHandler (this));
 	}
 

--- a/src/Main/TextUserInterface.h
+++ b/src/Main/TextUserInterface.h
@@ -19,11 +19,9 @@
 
 namespace VeraCrypt
 {
-	class AdminPasswordRequestHandler;
 	class TextUserInterface : public UserInterface
 	{
 	public:
-		friend class AdminPasswordRequestHandler;
 		TextUserInterface ();
 		virtual ~TextUserInterface ();
 

--- a/src/Main/UserInterface.cpp
+++ b/src/Main/UserInterface.cpp
@@ -32,15 +32,6 @@
 
 namespace VeraCrypt
 {
-	class AdminPasswordRequestHandler : public GetStringFunctor
-	{
-		public:
-		virtual void operator() (string &str)
-		{
-			throw ElevationFailed (SRC_POS, "sudo", 1, "");
-		}
-	};
-
 	UserInterface::UserInterface ()
 	{
 	}
@@ -567,6 +558,14 @@ namespace VeraCrypt
 		}
 		else
 		{
+			struct AdminPasswordRequestHandler : public GetStringFunctor
+			{
+				virtual void operator() (string &str)
+				{
+					throw ElevationFailed (SRC_POS, "sudo", 1, "");
+				}
+			};
+
 			Core->SetAdminPasswordCallback (shared_ptr <GetStringFunctor> (new AdminPasswordRequestHandler));
 		}
 


### PR DESCRIPTION
This reverts commit 96974169199d347172fc5d4a2924f092d602b3de.

This commit breaks admin prompts on Linux causing a segmentation fault for example when mounting a volume.

Tested on Ubuntu 23.10.

```
#0  0x0000555555769f61 in VeraCrypt::AdminPasswordRequestHandler::operator()(std::basic_string<char, std::char_traits<char>, std::allocator<char> >&) ()
#1  0x0000555555896944 in std::unique_ptr<VeraCrypt::MountVolumeResponse, std::default_delete<VeraCrypt::MountVolumeResponse> > VeraCrypt::CoreService::SendRequest<VeraCrypt::MountVolumeResponse>(VeraCrypt::CoreServiceRequest&) ()
#2  0x000055555588fac4 in VeraCrypt::CoreService::RequestMountVolume(VeraCrypt::MountOptions&) ()
#3  0x00005555558b4bda in VeraCrypt::CoreServiceProxy<VeraCrypt::CoreLinux>::MountVolume(VeraCrypt::MountOptions&) ()
#4  0x00005555557becf4 in VeraCrypt::MountThreadRoutine::ExecutionCode() ()
#5  0x000055555587a923 in VeraCrypt::WaitThreadRoutine::Execute() ()
#6  0x0000555555877c3b in VeraCrypt::WaitThread::Entry() ()
#7  0x0000555555c866ee in wxThreadInternal::PthreadStart(wxThread*) ()
#8  0x00007ffff6897b5a in start_thread (arg=<optimized out>) at ./nptl/pthread_create.c:444
        ret = <optimized out>
        pd = <optimized out>
        out = <optimized out>
        unwind_buf = {cancel_jmp_buf = {{jmp_buf = {140737329592432, 6416269201991415161, -152, 11, 140737488333712, 140737010200576, -6416242813289482887, -6416283895114877575}, mask_was_saved = 0}}, priv = {pad = {0x0, 0x0, 0x0, 0x0}, data = {prev = 0x0, cleanup = 0x0, canceltype = 0}}}
        not_first_call = <optimized out>
#9  0x00007ffff69285fc in clone3 () at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:78
```

Also I don't know how valuable it is to provide support for so old versions. When I was attempting to setup a VM with CentOS 6 for building, I had to give up after a bit as even the package repos will tell you "This directory (and version of CentOS) is deprecated" and "The whole CentOS 6 is *dead* and *shouldn't* be used anywhere at *all*". These changes are really hard to test as even setting up an environment is such a hassle.

The commit should probably be reverted before the relevant bits are refactored into working order, if that is still your goal.