### PR TITLE
Windows: disable dropdown split button in volume expander

### DIFF
--- a/src/Mount/Mount.c
+++ b/src/Mount/Mount.c
@@ -702,7 +702,9 @@ void EnableDisableButtons (HWND hwndDlg)
 
 	case TC_MLIST_ITEM_FREE:
 	default:
+#if !defined(VCEXPANDER)
 		EnableSplitButton(hwndDlg, IDOK);
+#endif
 		SetWindowTextW (hOKButton, GetString ("MOUNT_BUTTON"));
 		// Invalid the button IDOK so that it will be redrawn
 		InvalidateRect (hOKButton, NULL, TRUE);
@@ -8134,6 +8136,7 @@ BOOL CALLBACK MainDialogProc (HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lPa
 				}
 			}
 		}
+#if !defined(VCEXPANDER)
 		else
 		{
 			LPNMHDR pnmh = (LPNMHDR)lParam;
@@ -8146,6 +8149,7 @@ BOOL CALLBACK MainDialogProc (HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lPa
 				DestroyMenu(hmenu);
 			}
 		}
+#endif
 		return 0;
 
 	case WM_ERASEBKGND:


### PR DESCRIPTION
This change removes the split button in the Volume Expander because the "Mount Without Cache" option isn't available. Having a dropdown button without a dropdown menu behind it can be confusing.

![image](https://github.com/user-attachments/assets/58213c69-27e2-4554-8acf-2f3c2a02783e)

![image](https://github.com/user-attachments/assets/0dd04ca6-2eb6-4394-9b68-c99a44448a8f)
