### PR TITLE
Add Option to Enable/Disable Screen Capture

### DIFF
--- a/src/Main/CommandLineInterface.cpp
+++ b/src/Main/CommandLineInterface.cpp
@@ -29,6 +29,7 @@ namespace VeraCrypt
 		ArgPim (-1),
 		ArgSize (0),
 		ArgVolumeType (VolumeType::Unknown),
+		ArgAllowScreencapture (false),
 		ArgDisableFileSizeCheck (false),
 		ArgUseLegacyPassword (false),
 #if defined(TC_LINUX ) || defined (TC_FREEBSD)
@@ -41,6 +42,7 @@ namespace VeraCrypt
 
 		parser.SetSwitchChars (L"-");
 
+		parser.AddSwitch (L"",  L"allow-screencapture",	_("Allow window to be included in screenshots and screen captures (Windows/MacOS)"));
 		parser.AddOption (L"",  L"auto-mount",			_("Auto mount device-hosted/favorite volumes"));
 		parser.AddSwitch (L"",  L"backup-headers",		_("Backup volume headers"));
 		parser.AddSwitch (L"",  L"background-task",		_("Start Background Task"));
@@ -141,6 +143,8 @@ namespace VeraCrypt
 			Preferences.Load();
 			ArgMountOptions = Preferences.DefaultMountOptions;
 		}
+
+		ArgAllowScreencapture = parser.Found (L"allow-screencapture");
 
 		// Commands
 		if (parser.Found (L"auto-mount", &str))

--- a/src/Main/CommandLineInterface.h
+++ b/src/Main/CommandLineInterface.h
@@ -84,6 +84,7 @@ namespace VeraCrypt
 		VolumeInfoList ArgVolumes;
 		VolumeType::Enum ArgVolumeType;
         shared_ptr<SecureBuffer> ArgTokenPin;
+        bool ArgAllowScreencapture;
         bool ArgDisableFileSizeCheck;
         bool ArgUseLegacyPassword;
 #if defined(TC_LINUX ) || defined (TC_FREEBSD)

--- a/src/Main/Forms/MainFrame.cpp
+++ b/src/Main/Forms/MainFrame.cpp
@@ -84,6 +84,7 @@ namespace VeraCrypt
 		InitTaskBarIcon();
 		InitEvents();
 		InitMessageFilter();
+		InitWindowPrivacy();
 
 		if (!GetPreferences().SecurityTokenModule.IsEmpty() && !SecurityToken::IsInitialized())
 		{
@@ -468,6 +469,12 @@ namespace VeraCrypt
 		MainFrameWndProc = (WNDPROC) GetWindowLongPtr (mainFrameHwnd, GWL_WNDPROC);
 		SetWindowLongPtr (mainFrameHwnd, GWL_WNDPROC, (LONG_PTR) MainFrameWndProcFilter);
 #endif
+	}
+
+
+	void MainFrame::InitWindowPrivacy ()
+	{
+		Gui->SetContentProtection(!CmdLine->ArgAllowScreencapture);
 	}
 
 	void MainFrame::InitPreferences ()

--- a/src/Main/Forms/MainFrame.h
+++ b/src/Main/Forms/MainFrame.h
@@ -84,6 +84,7 @@ namespace VeraCrypt
 		void InitMessageFilter ();
 		void InitPreferences ();
 		void InitTaskBarIcon ();
+		void InitWindowPrivacy();
 		bool IsFreeSlotSelected () const { return SlotListCtrl->GetSelectedItemCount() == 1 && Gui->GetListCtrlSubItemText (SlotListCtrl, SelectedItemIndex, ColumnPath).empty(); }
 		bool IsMountedSlotSelected () const { return SlotListCtrl->GetSelectedItemCount() == 1 && !Gui->GetListCtrlSubItemText (SlotListCtrl, SelectedItemIndex, ColumnPath).empty(); }
 		void LoadFavoriteVolumes ();

--- a/src/Main/GraphicUserInterface.cpp
+++ b/src/Main/GraphicUserInterface.cpp
@@ -1874,6 +1874,14 @@ namespace VeraCrypt
 		listCtrl->SetMinSize (wxSize (width, listCtrl->GetMinSize().GetHeight()));
 	}
 
+
+	void GraphicUserInterface::SetContentProtection (bool enable) const
+	{
+#if defined(TC_WINDOWS) || defined(TC_MACOSX)
+		GetActiveWindow()->SetContentProtection(enable ? wxCONTENT_PROTECTION_ENABLED : wxCONTENT_PROTECTION_NONE);
+#endif
+	}
+
 	void GraphicUserInterface::ShowErrorTopMost (const wxString &message) const
 	{
 		ShowMessage (message, wxOK | wxICON_ERROR, true);

--- a/src/Main/GraphicUserInterface.h
+++ b/src/Main/GraphicUserInterface.h
@@ -86,6 +86,7 @@ namespace VeraCrypt
 		virtual void SetListCtrlColumnWidths (wxListCtrl *listCtrl, list <int> columnWidthPermilles, bool hasVerticalScrollbar = true) const;
 		virtual void SetListCtrlHeight (wxListCtrl *listCtrl, size_t rowCount) const;
 		virtual void SetListCtrlWidth (wxListCtrl *listCtrl, size_t charCount, bool hasVerticalScrollbar = true) const;
+		virtual void SetContentProtection(bool enable) const;
 		virtual void ShowErrorTopMost (char *langStringId) const { ShowErrorTopMost (LangString[langStringId]); }
 		virtual void ShowErrorTopMost (const wxString &message) const;
 		virtual void ShowInfoTopMost (char *langStringId) const { ShowInfoTopMost (LangString[langStringId]); }


### PR DESCRIPTION
Veracrypt currently appears in screenshots and screen captures, which can unintentionally expose sensitive information, such as the fact that Veracrypt is running or the location of your volumes.

Both Windows and macOS offer mechanisms to exclude specific windows from being captured. While not foolproof, this is a useful preventative measure. The method is a no-op for Linux/FreeBSD.

For more details on the wxWidgets API, see: [wxTopLevelWindow::SetContentProtection](https://docs.wxwidgets.org/3.2/classwx_top_level_window.html#a337b9cec62b0cbd3b1b1545a83270f64)