### PR TITLE
Linux/FreeBSD: Improvements on installation scripts

### DIFF
--- a/src/Main/Main.make
+++ b/src/Main/Main.make
@@ -179,7 +179,7 @@ endif
 GUI_CONDITION := $(filter gui,$(INSTALLER_TYPE))
 GTK2_CONDITION := $(filter 2,$(GTK_VERSION))
 
-INTERNAL_INSTALLER_NAME := veracrypt_install_f$(SYSTEMNAME)_$(INSTALLER_TYPE)_$(CPU_ARCH).sh
+INTERNAL_INSTALLER_NAME := veracrypt_install_$(SYSTEMNAME)_$(INSTALLER_TYPE)_$(CPU_ARCH).sh
 
 ifneq (,$(GUI_CONDITION))
 ifneq (,$(GTK2_CONDITION))
@@ -354,7 +354,7 @@ prepare: $(APPNAME)
 	mkdir -p $(BASE_DIR)/Setup/FreeBSD/usr/bin
 	mkdir -p $(BASE_DIR)/Setup/FreeBSD/usr/share/doc/$(APPNAME)/HTML
 	cp $(BASE_DIR)/Main/$(APPNAME) $(BASE_DIR)/Setup/FreeBSD/usr/bin/$(APPNAME)
-	cp $(BASE_DIR)/Setup/Linux/$(APPNAME)-uninstall.sh $(BASE_DIR)/Setup/FreeBSD/usr/bin/$(APPNAME)-uninstall.sh
+	cp $(BASE_DIR)/Setup/FreeBSD/$(APPNAME)-uninstall.sh $(BASE_DIR)/Setup/FreeBSD/usr/bin/$(APPNAME)-uninstall.sh
 	chmod +x $(BASE_DIR)/Setup/FreeBSD/usr/bin/$(APPNAME)-uninstall.sh
 	cp $(BASE_DIR)/License.txt $(BASE_DIR)/Setup/FreeBSD/usr/share/doc/$(APPNAME)/License.txt
 	cp -R $(BASE_DIR)/../doc/html/* "$(BASE_DIR)/Setup/FreeBSD/usr/share/doc/$(APPNAME)/HTML"
@@ -364,10 +364,10 @@ prepare: $(APPNAME)
 ifndef TC_NO_GUI
 	mkdir -p $(BASE_DIR)/Setup/FreeBSD/usr/share/applications
 	mkdir -p $(BASE_DIR)/Setup/FreeBSD/usr/share/pixmaps
-	mkdir -p $(BASE_DIR)/Setup/Linux/usr/share/mime/packages
+	mkdir -p $(BASE_DIR)/Setup/FreeBSD/usr/share/mime/packages
 	cp $(BASE_DIR)/Resources/Icons/VeraCrypt-256x256.xpm $(BASE_DIR)/Setup/FreeBSD/usr/share/pixmaps/$(APPNAME).xpm
-	cp $(BASE_DIR)/Setup/Linux/$(APPNAME).desktop $(BASE_DIR)/Setup/FreeBSD/usr/share/applications/$(APPNAME).desktop
-	cp $(BASE_DIR)/Setup/Linux/$(APPNAME).xml $(BASE_DIR)/Setup/Linux/usr/share/mime/packages/$(APPNAME).xml
+	cp $(BASE_DIR)/Setup/FreeBSD/$(APPNAME).desktop $(BASE_DIR)/Setup/FreeBSD/usr/share/applications/$(APPNAME).desktop
+	cp $(BASE_DIR)/Setup/FreeBSD/$(APPNAME).xml $(BASE_DIR)/Setup/FreeBSD/usr/share/mime/packages/$(APPNAME).xml
 endif
 	chown -R root:wheel $(BASE_DIR)/Setup/FreeBSD/usr
 	chmod -R go-w $(BASE_DIR)/Setup/FreeBSD/usr

--- a/src/Setup/FreeBSD/veracrypt-uninstall.sh
+++ b/src/Setup/FreeBSD/veracrypt-uninstall.sh
@@ -1,12 +1,19 @@
 #!/bin/sh
 V="$(mount | grep veracrypt_aux_mnt)"
-[ "$V" ] && echo Error: All volumes must be dismounted first. && exit 1
+[ "$V" ] && echo "Error: All volumes must be dismounted first." 1>&2 && exit 1
 
-rm -f /usr/bin/veracrypt
-rm -f /usr/share/applications/veracrypt.desktop
-rm -f /usr/share/pixmaps/veracrypt.xpm
-rm -fr /usr/share/veracrypt
-rm -fr /usr/share/doc/veracrypt
+removal_failed() {
+	echo "Error: File removal failed, please run the script with elevated privileges." 1>&2 && exit 1
+}
+
+rm -f /usr/bin/veracrypt || removal_failed
+rm -f /usr/share/applications/veracrypt.desktop || removal_failed
+rm -f /usr/share/pixmaps/veracrypt.xpm || removal_failed
+rm -f /usr/share/mime/packages/veracrypt.xml || removal_failed
+rm -fr /usr/share/veracrypt || removal_failed
+rm -fr /usr/share/doc/veracrypt || removal_failed
+rm -f /usr/bin/veracrypt-uninstall.sh || removal_failed
+update-mime-database /usr/share/mime >/dev/null 2>&1
+update-desktop-database -q
 
 echo VeraCrypt uninstalled.
-rm -f /usr/bin/veracrypt-uninstall.sh

--- a/src/Setup/FreeBSD/veracrypt.desktop
+++ b/src/Setup/FreeBSD/veracrypt.desktop
@@ -1,10 +1,11 @@
 [Desktop Entry]
-Encoding=UTF-8
-Name=VeraCrypt
-GenericName=VeraCrypt
-Comment=VeraCrypt
-Exec=/usr/bin/veracrypt
-Icon=veracrypt
-Terminal=false
 Type=Application
-Categories=Encryption;Encryption Tools;Utility;
+Name=VeraCrypt
+GenericName=VeraCrypt volume manager
+Comment=Create and mount VeraCrypt encrypted volumes
+Icon=veracrypt
+Exec=/usr/bin/veracrypt %f
+Categories=Security;Utility;Filesystem
+Keywords=encryption,filesystem
+Terminal=false
+MimeType=application/x-veracrypt-volume;application/x-truecrypt-volume;

--- a/src/Setup/FreeBSD/veracrypt.xml
+++ b/src/Setup/FreeBSD/veracrypt.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mime-info xmlns='http://www.freedesktop.org/standards/shared-mime-info'>
+	<mime-type type="application/x-veracrypt-volume">
+		<comment>VeraCrypt Volume</comment>
+		<glob pattern="*.hc"/>
+	</mime-type>
+	<mime-type type="application/x-truecrypt-volume">
+		<comment>TrueCrypt Volume</comment>
+		<glob pattern="*.tc"/>
+	</mime-type>
+</mime-info>

--- a/src/Setup/FreeBSD/veracrypt_install_template.sh
+++ b/src/Setup/FreeBSD/veracrypt_install_template.sh
@@ -52,7 +52,7 @@ then
 
 	if [ $XMESSAGE -eq 0 ] || ([ $XTERM -eq 0 ] && [ $GTERM -eq 0 ] && [ $KTERM -eq 0 ])
 	then
-		which gnome-terminal && exec gnome-terminal -e "$0"
+		which gnome-terminal && exec gnome-terminal -- "$0"
 		which konsole && exec konsole -e "$0"
 		which xterm && exec xterm -e "$0"
 
@@ -77,7 +77,7 @@ show_message()
 	then
 		if [ $XMESSAGE -eq 1 ]
 		then
-			xmessage -center -buttons OK -default OK "$*"
+			xmessage -title "VeraCrypt Setup" -center -buttons OK -default OK "$*"
 		else
 			if [ $TTY -eq 1 ]
 			then
@@ -89,11 +89,11 @@ show_message()
 				else
 					if [ $GTERM -eq 1 ]
 					then
-						gnome-terminal --title='VeraCrypt Setup' -e "sh -c \"echo $*; read A\""
+						gnome-terminal --title='VeraCrypt Setup' -- sh -c "echo $*; read A"
 					else
 						if [ $KTERM -eq 1 ]
 						then
-							konsole --qwindowtitle 'VeraCrypt Setup' --caption 'VeraCrypt Setup' -e sh -c "echo $*; read A"
+							konsole --qwindowtitle 'VeraCrypt Setup' -e sh -c "echo $*; read A"
 						fi
 					fi
 				fi
@@ -845,7 +845,7 @@ INSTALL=-1
 if [ $XMESSAGE -eq 1 ]
 then
 
-	cat <<_END | xmessage -center -file - -buttons "Exit:1,Extract .$PACKAGE_TYPE Package File:20,Install VeraCrypt:10" -default 'Install VeraCrypt'
+	cat <<_END | xmessage -title "VeraCrypt Setup" -center -file - -buttons "Exit:1,Extract .$PACKAGE_TYPE Package File:20,Install VeraCrypt:10" -default 'Install VeraCrypt'
 VeraCrypt $VERSION Setup
 ====================
  VeraCrypt is a free disk encryption software brought to you by IDRIX
@@ -934,7 +934,7 @@ then
 
 # GUI license agreement
 
-	cat <<_END | cat - $LICENSE | xmessage -center -file - -buttons 'I accept and agree to be bound by the license terms:10,I do not accept:20'
+	cat <<_END | cat - $LICENSE | xmessage -title "VeraCrypt Setup" -center -file - -buttons 'I accept and agree to be bound by the license terms:10,I do not accept:20'
 
 Before you can use, extract, or install VeraCrypt, you must accept these
 license terms.
@@ -1038,7 +1038,7 @@ Requirements for Running VeraCrypt:
 -----------------------------------
 
  - FUSE library and tools
- - device mapper tool
+ - device mapper tools
  - PC/SC Lite (optional)
 
 _INFO
@@ -1066,21 +1066,21 @@ then
 	then
 		if [ $XTERM -eq 1 ]
 		then
-			exec xterm -T 'VeraCrypt Setup' -e sh -c "echo Installing package...; $SUDO $PACKAGE_INSTALLER $PACKAGE_INSTALLER_OPTS $PACKAGE; rm -f $PACKAGE; echo; echo Press Enter to exit...; read A"
+			exec xterm -T 'VeraCrypt Setup' -e sh -c "echo Installing package...; $SUDO $PACKAGE_INSTALLER $PACKAGE_INSTALLER_OPTS $PACKAGE; rm -f $PACKAGE; $SUDO update-mime-database /usr/share/mime >/dev/null 2>&1; $SUDO update-desktop-database -q; echo; echo Press Enter to exit...; read A"
 		else
 			if [ $GTERM -eq 1 ]
 			then
-				exec gnome-terminal --title='VeraCrypt Setup' -e "sh -c \"echo Installing package...; $SUDO $PACKAGE_INSTALLER $PACKAGE_INSTALLER_OPTS $PACKAGE; rm -f $PACKAGE; echo; echo Press Enter to exit...; read A\""
+				exec gnome-terminal --title='VeraCrypt Setup' -- sh -c "echo Installing package...; $SUDO $PACKAGE_INSTALLER $PACKAGE_INSTALLER_OPTS $PACKAGE; rm -f $PACKAGE; $SUDO update-mime-database /usr/share/mime >/dev/null 2>&1; $SUDO update-desktop-database -q; echo; echo Press Enter to exit...; read A"
 			else
 				if [ $KTERM -eq 1 ]
 				then
-					exec konsole --qwindowtitle 'VeraCrypt Setup' --caption 'VeraCrypt Setup' -e sh -c "echo Installing package...; $SUDO $PACKAGE_INSTALLER $PACKAGE_INSTALLER_OPTS $PACKAGE; rm -f $PACKAGE; echo; echo Press Enter to exit...; read A"
+					exec konsole --qwindowtitle 'VeraCrypt Setup' -e sh -c "echo Installing package...; $SUDO $PACKAGE_INSTALLER $PACKAGE_INSTALLER_OPTS $PACKAGE; rm -f $PACKAGE; $SUDO update-mime-database /usr/share/mime >/dev/null 2>&1; $SUDO update-desktop-database -q; echo; echo Press Enter to exit...; read A"
 				fi
 			fi
 		fi
 	else
 		echo 'Installing package...'
-		$SUDO $PACKAGE_INSTALLER $PACKAGE_INSTALLER_OPTS $PACKAGE && INSTALLED=1
+		$SUDO $PACKAGE_INSTALLER $PACKAGE_INSTALLER_OPTS $PACKAGE && INSTALLED=1 && $SUDO update-mime-database /usr/share/mime >/dev/null 2>&1 && $SUDO update-desktop-database -q
 
 		if [ $INSTALLED -eq 1 ]
 		then

--- a/src/Setup/Linux/veracrypt-uninstall.sh
+++ b/src/Setup/Linux/veracrypt-uninstall.sh
@@ -1,14 +1,20 @@
 #!/bin/sh
 V="$(mount | grep veracrypt_aux_mnt)"
-[ "$V" ] && echo Error: All volumes must be dismounted first. >&2 && exit 1
+[ "$V" ] && echo "Error: All volumes must be dismounted first." 1>&2 && exit 1
 
-rm -f /usr/bin/veracrypt
-rm -f /usr/sbin/mount.veracrypt
-rm -f /usr/share/applications/veracrypt.desktop
-rm -f /usr/share/pixmaps/veracrypt.xpm
-rm -f /usr/share/mime/packages/veracrypt.xml
-rm -fr /usr/share/veracrypt
-rm -fr /usr/share/doc/veracrypt
+removal_failed() {
+	echo "Error: File removal failed, please run the script with elevated privileges." 1>&2 && exit 1
+}
+
+rm -f /usr/bin/veracrypt || removal_failed
+rm -f /usr/sbin/mount.veracrypt || removal_failed
+rm -f /usr/share/applications/veracrypt.desktop || removal_failed
+rm -f /usr/share/pixmaps/veracrypt.xpm || removal_failed
+rm -f /usr/share/mime/packages/veracrypt.xml || removal_failed
+rm -fr /usr/share/veracrypt || removal_failed
+rm -fr /usr/share/doc/veracrypt || removal_failed
+rm -f /usr/bin/veracrypt-uninstall.sh || removal_failed
+update-mime-database /usr/share/mime >/dev/null 2>&1
+update-desktop-database -q
 
 echo VeraCrypt uninstalled.
-rm -f /usr/bin/veracrypt-uninstall.sh

--- a/src/Setup/Linux/veracrypt_install_template.sh
+++ b/src/Setup/Linux/veracrypt_install_template.sh
@@ -56,7 +56,7 @@ then
 
 	if [ $XMESSAGE -eq 0 ] || ([ $XTERM -eq 0 ] && [ $GTERM -eq 0 ] && [ $KTERM -eq 0 ])
 	then
-		which gnome-terminal && exec gnome-terminal -e "$0"
+		which gnome-terminal && exec gnome-terminal -- "$0"
 		which konsole && exec konsole -e "$0"
 		which xterm && exec xterm -e "$0"
 
@@ -81,7 +81,7 @@ show_message()
 	then
 		if [ $XMESSAGE -eq 1 ]
 		then
-			xmessage -center -buttons OK -default OK "$*"
+			xmessage -title "VeraCrypt Setup" -center -buttons OK -default OK "$*"
 		else
 			if [ $TTY -eq 1 ]
 			then
@@ -93,7 +93,7 @@ show_message()
 				else
 					if [ $GTERM -eq 1 ]
 					then
-						gnome-terminal --title='VeraCrypt Setup' -e "sh -c \"echo $*; read A\""
+						gnome-terminal --title='VeraCrypt Setup' -- sh -c "echo $*; read A"
 					else
 						if [ $KTERM -eq 1 ]
 						then
@@ -849,7 +849,7 @@ INSTALL=-1
 if [ $XMESSAGE -eq 1 ]
 then
 
-	cat <<_END | xmessage -center -file - -buttons "Exit:1,Extract .$PACKAGE_TYPE Package File:20,Install VeraCrypt:10" -default 'Install VeraCrypt'
+	cat <<_END | xmessage -title "VeraCrypt Setup" -center -file - -buttons "Exit:1,Extract .$PACKAGE_TYPE Package File:20,Install VeraCrypt:10" -default 'Install VeraCrypt'
 VeraCrypt $VERSION Setup
 ====================
  VeraCrypt is a free disk encryption software brought to you by IDRIX
@@ -938,7 +938,7 @@ then
 
 # GUI license agreement
 
-	cat <<_END | cat - $LICENSE | xmessage -center -file - -buttons 'I accept and agree to be bound by the license terms:10,I do not accept:20'
+	cat <<_END | cat - $LICENSE | xmessage -title "VeraCrypt Setup" -center -file - -buttons 'I accept and agree to be bound by the license terms:10,I do not accept:20'
 
 Before you can use, extract, or install VeraCrypt, you must accept these
 license terms.
@@ -1070,21 +1070,21 @@ then
 	then
 		if [ $XTERM -eq 1 ]
 		then
-			exec xterm -T 'VeraCrypt Setup' -e sh -c "echo Installing package...; $SUDO $PACKAGE_INSTALLER $PACKAGE_INSTALLER_OPTS $PACKAGE; rm -f $PACKAGE; echo; echo Press Enter to exit...; read A"
+			exec xterm -T 'VeraCrypt Setup' -e sh -c "echo Installing package...; $SUDO $PACKAGE_INSTALLER $PACKAGE_INSTALLER_OPTS $PACKAGE; rm -f $PACKAGE; $SUDO update-mime-database /usr/share/mime >/dev/null 2>&1; $SUDO update-desktop-database -q; echo; echo Press Enter to exit...; read A"
 		else
 			if [ $GTERM -eq 1 ]
 			then
-				exec gnome-terminal --title='VeraCrypt Setup' -e "sh -c \"echo Installing package...; $SUDO $PACKAGE_INSTALLER $PACKAGE_INSTALLER_OPTS $PACKAGE; rm -f $PACKAGE; echo; echo Press Enter to exit...; read A\""
+				exec gnome-terminal --title='VeraCrypt Setup' -- sh -c "echo Installing package...; $SUDO $PACKAGE_INSTALLER $PACKAGE_INSTALLER_OPTS $PACKAGE; rm -f $PACKAGE; $SUDO update-mime-database /usr/share/mime >/dev/null 2>&1; $SUDO update-desktop-database -q; echo; echo Press Enter to exit...; read A"
 			else
 				if [ $KTERM -eq 1 ]
 				then
-					exec konsole --qwindowtitle 'VeraCrypt Setup' -e sh -c "echo Installing package...; $SUDO $PACKAGE_INSTALLER $PACKAGE_INSTALLER_OPTS $PACKAGE; rm -f $PACKAGE; echo; echo Press Enter to exit...; read A"
+					exec konsole --qwindowtitle 'VeraCrypt Setup' -e sh -c "echo Installing package...; $SUDO $PACKAGE_INSTALLER $PACKAGE_INSTALLER_OPTS $PACKAGE; rm -f $PACKAGE; $SUDO update-mime-database /usr/share/mime >/dev/null 2>&1; $SUDO update-desktop-database -q; echo; echo Press Enter to exit...; read A"
 				fi
 			fi
 		fi
 	else
 		echo 'Installing package...'
-		$SUDO $PACKAGE_INSTALLER $PACKAGE_INSTALLER_OPTS $PACKAGE && INSTALLED=1
+		$SUDO $PACKAGE_INSTALLER $PACKAGE_INSTALLER_OPTS $PACKAGE && INSTALLED=1 && $SUDO update-mime-database /usr/share/mime >/dev/null 2>&1 && $SUDO update-desktop-database -q
 
 		if [ $INSTALLED -eq 1 ]
 		then


### PR DESCRIPTION
Few improvements on Linux/FreeBSD installation and package scripts, and user experience when using generic installer:
- Use correct files in FreeBSD installation scripts and separate the files from the Linux counterparts to make differing changes clear
- Ensures mime-types and desktop files are updated on the system when generic installer is used as we're not relying on a package distributor to do it
- Ensure the files are properly removed through `veracrypt-uninstall.sh` before printing success
- Move from deprecated `-e` syntax to `--` in gnome-terminal
- Adds title to xmessage windows
- Remove unsupported konsole `--caption` option from FreeBSD installation script