### PR TITLE
fix Language.hu.xml invalid character

### DIFF
--- a/Translations/Language.hu.xml
+++ b/Translations/Language.hu.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <VeraCrypt>
   <localization prog-version= "1.26.20">
-    <language langid="hu" name="Magyar" en-name="Hungarian" version="1.0.0" translators="Nyul Balazs > Szaki, Zityi's Translator Te@m" />
+    <language langid="hu" name="Magyar" en-name="Hungarian" version="1.0.0" translators="Nyul Balazs &gt; Szaki, Zityi's Translator Te@m" />
     <font lang="hu" class="normal" size="11" face="default" />
     <font lang="hu" class="bold" size="13" face="Arial" />
     <font lang="hu" class="fixed" size="12" face="Lucida Console" />


### PR DESCRIPTION
This patch fixes the invalid XML in the Hungarian translation XML file, which cause the following error when trying to launch Veracrypt:

ParameterIncorrect at VeraCrypt::XmlParser::GetNodes:82