### PR TITLE
Refactor: Use symbolic constants for volume header magic numbers

### DIFF
--- a/src/Common/BootEncryption.cpp
+++ b/src/Common/BootEncryption.cpp
@@ -4322,7 +4322,7 @@ namespace VeraCrypt
 
 		DecryptBuffer (RescueVolumeHeader + HEADER_ENCRYPTED_DATA_OFFSET, HEADER_ENCRYPTED_DATA_SIZE, cryptoInfo);
 
-		if (GetHeaderField32 (RescueVolumeHeader, TC_HEADER_OFFSET_MAGIC) != 0x56455241)
+		if (GetHeaderField32 (RescueVolumeHeader, TC_HEADER_OFFSET_MAGIC) != TC_HEADER_MAGIC_NUMBER)
 			throw ParameterIncorrect (SRC_POS);
 
 		uint8 *fieldPos = RescueVolumeHeader + TC_HEADER_OFFSET_ENCRYPTED_AREA_LENGTH;

--- a/src/Common/Volumes.c
+++ b/src/Common/Volumes.c
@@ -457,8 +457,8 @@ KeyReady:	;
 
 				DecryptBuffer (header + HEADER_ENCRYPTED_DATA_OFFSET, HEADER_ENCRYPTED_DATA_SIZE, cryptoInfo);
 
-				// Magic 'VERA'
-				if (GetHeaderField32 (header, TC_HEADER_OFFSET_MAGIC) != 0x56455241)
+				// Magic number
+				if (GetHeaderField32 (header, TC_HEADER_OFFSET_MAGIC) != TC_HEADER_MAGIC_NUMBER)
 					continue;
 
 				// Header version
@@ -768,7 +768,7 @@ int ReadVolumeHeader (BOOL bBoot, unsigned char *header, Password *password, int
 		DecryptBuffer (header + HEADER_ENCRYPTED_DATA_OFFSET, HEADER_ENCRYPTED_DATA_SIZE, cryptoInfo);
 
 		// Check magic 'VERA' and CRC-32 of header fields and master keydata
-		if (GetHeaderField32 (header, TC_HEADER_OFFSET_MAGIC) != 0x56455241
+		if (GetHeaderField32 (header, TC_HEADER_OFFSET_MAGIC) != TC_HEADER_MAGIC_NUMBER
 			|| (GetHeaderField16 (header, TC_HEADER_OFFSET_VERSION) >= 4 && GetHeaderField32 (header, TC_HEADER_OFFSET_HEADER_CRC) != GetCrc32 (header + TC_HEADER_OFFSET_MAGIC, TC_HEADER_OFFSET_HEADER_CRC - TC_HEADER_OFFSET_MAGIC))
 			|| GetHeaderField32 (header, TC_HEADER_OFFSET_KEY_AREA_CRC) != GetCrc32 (header + HEADER_MASTER_KEYDATA_OFFSET, MASTER_KEYDATA_SIZE))
 		{
@@ -1040,8 +1040,8 @@ int CreateVolumeHeaderInMemory (HWND hwndDlg, BOOL bBoot, unsigned char *header,
 	// Salt
 	mputBytes (p, keyInfo.salt, PKCS5_SALT_SIZE);
 
-	// Magic
-	mputLong (p, 0x56455241);
+	// Magic number
+	mputLong (p, TC_HEADER_MAGIC_NUMBER);
 
 	// Header version
 	mputWord (p, VOLUME_HEADER_VERSION);

--- a/src/Common/Volumes.h
+++ b/src/Common/Volumes.h
@@ -21,6 +21,12 @@ extern "C" {
 // Volume header version
 #define VOLUME_HEADER_VERSION					0x0005 
 
+// Volume header magic identifiers
+// 32-bit magic number identifying a valid VeraCrypt volume header ("VERA" in ASCII)
+#define TC_HEADER_MAGIC_NUMBER							0x56455241
+// 64-bit magic number identifier for boot drive filter extension ("VERABEXT" in ASCII)
+#define TC_BOOT_DRIVE_FILTER_EXTENSION_MAGIC_NUMBER		0x5645524142455854ULL
+
 // Version number written to volume header during format;
 // specifies the minimum program version required to mount the volume
 #define TC_VOLUME_MIN_REQUIRED_PROGRAM_VERSION	0x010b

--- a/src/Driver/DriveFilter.c
+++ b/src/Driver/DriveFilter.c
@@ -730,7 +730,7 @@ static NTSTATUS SaveDriveVolumeHeader (DriveFilterExtension *Extension)
 
 		DecryptBuffer (header + HEADER_ENCRYPTED_DATA_OFFSET, HEADER_ENCRYPTED_DATA_SIZE, pCryptoInfo);
 
-		if (GetHeaderField32 (header, TC_HEADER_OFFSET_MAGIC) != 0x56455241)
+		if (GetHeaderField32 (header, TC_HEADER_OFFSET_MAGIC) != TC_HEADER_MAGIC_NUMBER)
 		{
 			Dump ("Header not decrypted");
 			status = STATUS_UNKNOWN_REVISION;

--- a/src/Driver/DriveFilter.h
+++ b/src/Driver/DriveFilter.h
@@ -49,8 +49,6 @@ typedef struct _DriveFilterExtension
 
 } DriveFilterExtension;
 
-#define TC_BOOT_DRIVE_FILTER_EXTENSION_MAGIC_NUMBER 0x5645524142455854
-
 extern BOOL BootArgsValid;
 extern BootArguments BootArgs;
 extern PKTHREAD EncryptionSetupThread;

--- a/src/Format/InPlace.c
+++ b/src/Format/InPlace.c
@@ -1870,7 +1870,7 @@ int FastVolumeHeaderUpdate (HANDLE dev, CRYPTO_INFO *headerCryptoInfo, CRYPTO_IN
 
 	DecryptBuffer (header + HEADER_ENCRYPTED_DATA_OFFSET, HEADER_ENCRYPTED_DATA_SIZE, pCryptoInfo);
 
-	if (GetHeaderField32 (header, TC_HEADER_OFFSET_MAGIC) != 0x56455241)
+	if (GetHeaderField32 (header, TC_HEADER_OFFSET_MAGIC) != TC_HEADER_MAGIC_NUMBER)
 	{
 		nStatus = ERR_PARAMETER_INCORRECT;
 		goto closing_seq;


### PR DESCRIPTION
### Changes
- Replaced hardcoded `0x56455241` (`'VERA'`) with `TC_HEADER_MAGIC` for improved readability and maintainability.
- Moved existing constant `TC_BOOT_DRIVE_FILTER_EXTENSION_MAGIC_NUMBER` (64-bit `"VERABEXT"`).
- Ensured usage of `ULL` suffix for 64-bit constant correctness.