### PR TITLE
Use “unmount” instead of “dismount” in scripts and in text shown to the user

### DIFF
--- a/Tests/bench.bat
+++ b/Tests/bench.bat
@@ -61,7 +61,7 @@ if not exist !mydriveletter!:\ (
     goto :exit
 )
 
-"!VERACRYPT_PATH!" /dismount !mydriveletter! /silent /q
+"!VERACRYPT_PATH!" /unmount !mydriveletter! /silent /q
 exit /b
 
 :: Subroutine to measure the time taken for a command to execute

--- a/contrib/EncryptData.ps1
+++ b/contrib/EncryptData.ps1
@@ -6,7 +6,7 @@
 .DESCRIPTION
     • Chooses an exFAT cluster size (auto or explicit).
     • Calculates the minimum container size using an iterative approach for FAT/Bitmap sizing, plus safety margin.
-    • Creates, mounts, copies, verifies, and dismounts – all guarded by -WhatIf/-Confirm (SupportsShouldProcess).
+    • Creates, mounts, copies, verifies, and unmounts – all guarded by -WhatIf/-Confirm (SupportsShouldProcess).
     • Finds VeraCrypt automatically or takes a -VeraCryptDir override.
     • Encryption and hash algorithms are parameters.
     • Password can be passed via SecureString prompt or pipeline.
@@ -420,13 +420,13 @@ try {
 } finally {
     if (Test-Path variable:plainPassword) { Clear-Variable plainPassword -ErrorAction SilentlyContinue }
     if ($mounted) {
-        if ($PSCmdlet.ShouldProcess("Drive $driveLetter", "Dismount VeraCrypt volume")) {
-            Write-Verbose "Dismounting drive $driveLetter..."
-            $dismountArgs = @('/dismount', $driveLetter, '/force', '/quit', '/silent')
-            Start-Process -FilePath $VeraCryptExe -ArgumentList $dismountArgs -NoNewWindow -Wait -ErrorAction SilentlyContinue
-            Write-Verbose "Dismount command issued."
+        if ($PSCmdlet.ShouldProcess("Drive $driveLetter", "Unmount VeraCrypt volume")) {
+            Write-Verbose "Unmounting drive $driveLetter..."
+            $unmountArgs = @('/unmount', $driveLetter, '/force', '/quit', '/silent')
+            Start-Process -FilePath $VeraCryptExe -ArgumentList $unmountArgs -NoNewWindow -Wait -ErrorAction SilentlyContinue
+            Write-Verbose "Unmount command issued."
         } else {
-            Write-Host "Dismount skipped due to -WhatIf."
+            Write-Host "Unmount skipped due to -WhatIf."
         }
     }
     foreach($f in @($errFile,$mountFile) | Where-Object { $_ }) {  

--- a/src/Build/Packaging/debian-control/prerm
+++ b/src/Build/Packaging/debian-control/prerm
@@ -2,7 +2,7 @@
 V="$(mount | grep veracrypt_aux_mnt)"
 if [ ! -z "$V" ]
 then
-	echo "Error: All VeraCrypt volumes must be dismounted first." >&2
+	echo "Error: All VeraCrypt volumes must be unmounted first." >&2
 	exit 1
 else
 	exit 0

--- a/src/Build/Packaging/rpm-control/prerm.sh
+++ b/src/Build/Packaging/rpm-control/prerm.sh
@@ -2,7 +2,7 @@
 V="$(mount | grep veracrypt_aux_mnt)"
 if [ ! -z "$V" ]
 then
-	echo "Error: All VeraCrypt volumes must be dismounted first." >&2
+	echo "Error: All VeraCrypt volumes must be unmounted first." >&2
 	exit 1
 else
 	exit 0


### PR DESCRIPTION
This is for consistency with the rest of #1478.