### PR TITLE
Linux/FreeBSD/macOS: Column widths correct initially and on update

### DIFF
--- a/src/Main/Forms/MainFrame.cpp
+++ b/src/Main/Forms/MainFrame.cpp
@@ -1687,7 +1687,6 @@ namespace VeraCrypt
 		}
 
 		VolumeInfoList protectionTriggeredVolumes;
-		SlotListCtrl->SetColumnWidth(0, wxLIST_AUTOSIZE);
 
 		// Update list
 		long prevItemIndex = -1;
@@ -1773,8 +1772,10 @@ namespace VeraCrypt
 			}
 		}
 
-		if (listChanged)
+		if (listChanged) {
+			SlotListCtrl->SetColumnWidth(0, wxLIST_AUTOSIZE);
 			OnListChanged();
+		}
 
 		foreach (shared_ptr <VolumeInfo> volume, protectionTriggeredVolumes)
 			OnHiddenVolumeProtectionTriggered (volume);

--- a/src/Main/GraphicUserInterface.cpp
+++ b/src/Main/GraphicUserInterface.cpp
@@ -2072,8 +2072,12 @@ namespace VeraCrypt
 			{
 				item.SetText (field);
 				listCtrl->SetItem (item);
-				if (item.GetColumn() == 3 || item.GetColumn() == 4)
+				if ((item.GetColumn() == 3 || item.GetColumn() == 4) && !item.GetText().IsEmpty())
 					listCtrl->SetColumnWidth(item.GetColumn(), wxLIST_AUTOSIZE);
+					// SlotListCtrl headers do not automatically move with column widths changing on macOS
+#ifdef TC_MACOSX
+					listCtrl->Update();
+#endif
 				changed = true;
 			}
 		}


### PR DESCRIPTION
The sizing of column width was set before the column itself is filled with the slot values, which caused the column width to be incorrect until the OnTimer runs to update it in a few seconds from launch. Changing the order ensures the column width is correct on program launch. Also ensure that we do not autosize columns 3 and 4 to fit empty content, this caused the column to go minimum width in some unmount cases.

Fixes: #1551 