### PR TITLE
Linux: Update Ubuntu 25.04 Plucky dependencies

### DIFF
--- a/src/Build/CMakeLists.txt
+++ b/src/Build/CMakeLists.txt
@@ -280,10 +280,14 @@ if ( ( PLATFORM STREQUAL "Debian" ) OR ( PLATFORM STREQUAL "Ubuntu" ) )
 	else ()
 		# Link against gtk3 version of wxWidgets if >= Debian 10 or >= Ubuntu 18.04
 		# Otherwise, link against gtk2 version of wxWidgets
+		if (   ( ( PLATFORM STREQUAL "Debian" ) AND ( PLATFORM_VERSION VERSION_GREATER_EQUAL "13" ) )
+			OR ( ( PLATFORM STREQUAL "Ubuntu" ) AND ( PLATFORM_VERSION VERSION_GREATER_EQUAL "25.04" ) ) )
+
+			set( CPACK_DEBIAN_PACKAGE_DEPENDS 		"libwxgtk3.2-1t64, libayatana-appindicator3-1, libfuse2t64, dmsetup, sudo" )
+
 		# In case of Ubuntu 24.04, we depend on libfuse2t64 instead of libfuse2 and we link statically against wxWidgets
 		# because there is a bug in wxWidgets that ships with Ubuntu 24.04 and which was fixed in wxWidgets 3.2.5
-		if (   ( ( PLATFORM STREQUAL "Debian" ) AND ( PLATFORM_VERSION VERSION_GREATER_EQUAL "13" ) ) 
-			OR ( ( PLATFORM STREQUAL "Ubuntu" ) AND ( PLATFORM_VERSION VERSION_GREATER_EQUAL "24.04" ) ) )
+		elseif ( ( PLATFORM STREQUAL "Ubuntu" ) AND ( PLATFORM_VERSION VERSION_GREATER_EQUAL "24.04" ) )
 			
 			set( CPACK_DEBIAN_PACKAGE_DEPENDS 		"libgtk-3-0t64, libayatana-appindicator3-1, libfuse2t64, dmsetup, sudo" )										
 

--- a/src/Main/Main.make
+++ b/src/Main/Main.make
@@ -327,7 +327,7 @@ ifndef TC_NO_GUI
 
 	rm -fr $(BASE_DIR)/Setup/Linux/veracrypt.AppDir/usr
 	cp -r $(BASE_DIR)/Setup/Linux/usr $(BASE_DIR)/Setup/Linux/veracrypt.AppDir/.
-	ln -s usr/share/icons/hicolor/1024x1024/apps/$(APPNAME).png $(BASE_DIR)/Setup/Linux/veracrypt.AppDir/$(APPNAME).png
+	ln -sf usr/share/icons/hicolor/1024x1024/apps/$(APPNAME).png $(BASE_DIR)/Setup/Linux/veracrypt.AppDir/$(APPNAME).png
 endif
 
 


### PR DESCRIPTION
Update Ubuntu 25.04 .deb dependency to require libwxgtk3.2-1t64 package. This is same in Debian 13 Trixie at least in testing currently. Requires recreating .deb files for downloads distribution.

Also ensures symbolic link already existing does not fail the make build.

Fixes: #1555 