### PR TITLE
Update Corsican translation on 2025-06

### DIFF
--- a/Translations/Language.co.xml
+++ b/Translations/Language.co.xml
@@ -6,7 +6,7 @@ Information about Corsican localization:
 	https://github.com/veracrypt/VeraCrypt/blob/master/Translations/Language.co.xml
 
 2. History of Corsican translation for VeraCrypt:
-	- Updated in 2025 by Patriccollu di Santa Maria è Sichè: May 5th (1.26.21), May 25th (1.26.24)
+	- Updated in 2025 by Patriccollu di Santa Maria è Sichè: May 5th (1.26.21), May 25th (1.26.24), June 26th (1.26.25)
 	- Updated in 2024 by Patriccollu di Santa Maria è Sichè: Aug. 2nd (1.26.13), Aug. 10th (1.26.13)
 	- Updated in 2023 by Patriccollu di Santa Maria è Sichè: May 29th (1.26), May 30th (1.26), June 1st (1.26),
 	          June 2nd (1.26), June 5th (1.26.2), June 21st (1.26.2), June 23rd (1.26.2), June 25th (1.26.2),
@@ -20,7 +20,7 @@ Information about Corsican localization:
 -->
 <VeraCrypt>
 	<localization prog-version="1.26.25">
-		<language langid="co" name="Corsu" en-name="Corsican" version="1.4.8" translators="Patriccollu di Santa Maria è Sichè"/>
+		<language langid="co" name="Corsu" en-name="Corsican" version="1.4.9" translators="Patriccollu di Santa Maria è Sichè"/>
 		<font lang="co" class="normal" size="11" face="default"/>
 		<font lang="co" class="bold" size="13" face="Arial"/>
 		<font lang="co" class="fixed" size="12" face="Lucida Console"/>
@@ -1665,7 +1665,7 @@ Information about Corsican localization:
 	    <entry lang="co" key="INSECURE_MODE">[MODU NONSICURU]</entry>
 	    <entry lang="co" key="IDC_DISABLE_SCREEN_PROTECTION">Disattivà a prutezzione contr’à e catture di screnu è l’arregistramentu di screnu</entry>
 	    <entry lang="co" key="DISABLE_SCREEN_PROTECTION_WARNING">AVERTIMENTU : A disattivazione di a prutezzione di screnu riduce forte a sicurità. Attivà st’ozzione SOLU s’è vo avete un bisognu specificu di catturà l’interfaccia di VeraCrypt. Què pò palisà i dati sensibile à l’attrezzi di screnu è à e funzioni d’arregistramentu di screnu cum’è Windows 11 Recall.</entry>
-	    <entry lang="en" key="MEMORY_COST">Memory Cost</entry>
+	    <entry lang="co" key="MEMORY_COST">Costu di a memoria</entry>
 	</localization>
 	<xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
 		<xs:element name="VeraCrypt">


### PR DESCRIPTION
Hello,

This is an update of **Corsican** (co) localization to take this commit into account:

 * https://github.com/veracrypt/VeraCrypt/commit/ab2937c8895bdb74f2505a657d29733048d83119 Add new entry in XML files for Argon2 memory cost. Increment version to 1.26.25

Cheers,
Patriccollu.