### PR TITLE
Fix: Incorrect tooltip on mouseover due to bad translation key (fix #1635)

### DIFF
--- a/src/Setup/Wizard.c
+++ b/src/Setup/Wizard.c
@@ -447,7 +447,7 @@ BOOL CALLBACK PageDialogProc (HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lPa
 				// make the help button adjacent to the checkbox
 				MakeControlsContiguous(hwndDlg, IDC_DISABLE_MEMORY_PROTECTION, IDC_DISABLE_MEMORY_PROTECTION_HELP);
 
-				hDisableScreenProtectionTooltipWnd = CreateToolTip (IDC_DISABLE_SCREEN_PROTECTION, hwndDlg, "DISABLE_SCREEN_PROTECTION_HELP");
+				hDisableScreenProtectionTooltipWnd = CreateToolTip (IDC_DISABLE_SCREEN_PROTECTION, hwndDlg, "DISABLE_SCREEN_PROTECTION_WARNING");
 				// make the help button adjacent to the checkbox
 				AccommodateCheckBoxTextWidth(hwndDlg, IDC_DISABLE_SCREEN_PROTECTION);
 


### PR DESCRIPTION
The commit 9ea5ccc4aa35dc3d11863571fe9419f2950c7eef introduced this bug by creating a translation key named "DISABLE_SCREEN_PROTECTION_WARNING" but used the key "DISABLE_SCREEN_PROTECTION_HELP" into the installation wizard.