### PR TITLE
Fix ghost drive letter after CLI dismount (Silent mode)

### DIFF
--- a/src/Common/Dlgcode.c
+++ b/src/Common/Dlgcode.c
@@ -9357,6 +9357,18 @@ retry:
 
 	BroadcastDeviceChange (DBT_DEVICEREMOVECOMPLETE, nDosDriveNo, 0);
 
+	/* GH #337, GH #1426: When running in silent/CLI mode, the process may
+	   exit immediately after unmount. BroadcastDeviceChange sends
+	   SHChangeNotify asynchronously, so Explorer may not process the drive
+	   removal before the process exits, leaving a ghost drive letter.
+	   Re-send the notification with SHCNF_FLUSH to force synchronous
+	   processing by Explorer before we return. */
+	if (Silent)
+	{
+		wchar_t root[] = { (wchar_t) (nDosDriveNo + L'A'), L':', L'\\', 0 };
+		SHChangeNotify (SHCNE_DRIVEREMOVED, SHCNF_PATH | SHCNF_FLUSH, root, NULL);
+	}
+
 	return TRUE;
 }
 

--- a/src/Mount/Mount.c
+++ b/src/Mount/Mount.c
@@ -5763,6 +5763,22 @@ retry:
 
 	BroadcastDeviceChange (DBT_DEVICEREMOVECOMPLETE, 0, prevMountList.ulMountedDrives & ~mountList.ulMountedDrives);
 
+	/* GH #337, GH #1426: Flush shell notifications synchronously in
+	   silent/CLI mode to prevent ghost drive letters when the process
+	   exits immediately after dismount. */
+	if (Silent)
+	{
+		DWORD removedDrives = prevMountList.ulMountedDrives & ~mountList.ulMountedDrives;
+		for (i = 0; i < 26; i++)
+		{
+			if (removedDrives & (1 << i))
+			{
+				wchar_t root[] = { (wchar_t) (i + L'A'), L':', L'\\', 0 };
+				SHChangeNotify (SHCNE_DRIVEREMOVED, SHCNF_PATH | SHCNF_FLUSH, root, NULL);
+			}
+		}
+	}
+
 	RefreshMainDlg (hwndDlg);
 
 	NormalCursor();


### PR DESCRIPTION
### Problem

When dismounting volumes via CLI (`VeraCrypt.exe /d X /q /s`), the drive letter remains visible in Windows Explorer as an inaccessible "Local Disk" until reboot. GUI dismount works correctly.

This has been reported multiple times over the past 8 years:

- #337 (2018) — "phantom disk" after Task Scheduler dismount
- #1426 (2024) — CLI dismount doesn't release drive letter

### Root Cause

`BroadcastDeviceChange()` in `Dlgcode.c` calls `SHChangeNotify(SHCNE_DRIVEREMOVED, SHCNF_PATH, ...)` which is **asynchronous** by default. The notification is queued for Explorer to process later.

In GUI mode this works fine — the process stays alive and Explorer eventually processes the notification.

In CLI mode with `/q` (Silent), the process calls `exit()` immediately after dismount (`Mount.c:7575`). Explorer never gets a chance to process the queued notification. The drive letter remains in the shell namespace cache indefinitely.

### Fix

Add `SHCNF_FLUSH` flag to `SHChangeNotify` when operating in Silent (CLI) mode. This forces synchronous processing — the function blocks until Explorer updates its drive list, before the process exits.

Two locations are patched:

- `src/Common/Dlgcode.c` — `UnmountVolumeBase()` (single volume dismount)
- `src/Mount/Mount.c` — `DismountAll()` (dismount all volumes)

The flush is **only added in Silent mode** to avoid introducing latency in interactive GUI operations.

### Testing

This fix should be tested with:

1. `VeraCrypt.exe /d X /q /s` — single volume CLI dismount
2. `VeraCrypt.exe /d /q /s` — dismount all via CLI
3. Task Scheduler automated dismount
4. Verify GUI dismount is unaffected