### PR TITLE
Fix erroneous 2 TiB limit for hidden file containers in GUI wizard

### DIFF
--- a/src/Main/Forms/VolumeCreationWizard.cpp
+++ b/src/Main/Forms/VolumeCreationWizard.cpp
@@ -973,7 +973,7 @@ namespace VeraCrypt
 				{
 					if (SelectedVolumeType != VolumeType::Hidden || OuterVolume)
 					{
-						if (OuterVolume && VolumeSize > TC_MAX_FAT_SECTOR_COUNT * SectorSize)
+						if (SelectedVolumePath.IsDevice() && OuterVolume && VolumeSize > TC_MAX_FAT_SECTOR_COUNT * SectorSize)
 						{
 							uint64 limit = TC_MAX_FAT_SECTOR_COUNT * SectorSize / BYTES_PER_TB;
 							wstring err = static_cast<wstring>(StringFormatter (LangString["LINUX_ERROR_SIZE_HIDDEN_VOL"], limit, limit * 1024));


### PR DESCRIPTION
This PR fixes: https://github.com/veracrypt/VeraCrypt/issues/1560

## Summary

Fix the GUI wizard incorrectly rejecting hidden file containers larger than 2 TiB.

Currently the outer hidden-volume size check is applied even when the selected target is a normal file. In that case the wizard uses the file-hosted sector size constant, so the FAT sector-count check incorrectly caps the GUI flow at 2 TiB.

This change restricts that check to device-hosted paths only:

```cpp
if (SelectedVolumePath.IsDevice() && OuterVolume && VolumeSize > TC_MAX_FAT_SECTOR_COUNT * SectorSize)
```

This has been tested on Linux using a 3 TiB file.