### PR TITLE
Linux/FUSE: tune FUSE 3 init config and fix error mapping

### DIFF
--- a/src/Driver/Fuse/FuseService.cpp
+++ b/src/Driver/Fuse/FuseService.cpp
@@ -125,6 +125,19 @@ namespace VeraCrypt
 			cfg->set_gid = 1;
 			cfg->uid = FuseService::GetUserId();
 			cfg->gid = FuseService::GetGroupId();
+
+			// Honor the inode numbers assigned in getattr/readdir responses.
+			// Without this the kernel may synthesize its own, making the
+			// explicit VC_FUSE_INODE_* values unused.
+			cfg->use_ino = 1;
+
+			// VeraCrypt exposes a fixed three-entry filesystem ("/",
+			// "/volume", "/control") whose structure never changes for the
+			// lifetime of the mount.  Cache lookups aggressively so the
+			// kernel does not round-trip to userspace for every stat/lookup.
+			cfg->entry_timeout = 86400;
+			cfg->negative_timeout = 86400;
+			cfg->attr_timeout = 1;
 		}
 
 		return fuse_service_init_common ();

--- a/src/Driver/Fuse/FuseService.cpp
+++ b/src/Driver/Fuse/FuseService.cpp
@@ -126,18 +126,9 @@ namespace VeraCrypt
 			cfg->uid = FuseService::GetUserId();
 			cfg->gid = FuseService::GetGroupId();
 
-			// Honor the inode numbers assigned in getattr/readdir responses.
-			// Without this the kernel may synthesize its own, making the
-			// explicit VC_FUSE_INODE_* values unused.
 			cfg->use_ino = 1;
-
-			// VeraCrypt exposes a fixed three-entry filesystem ("/",
-			// "/volume", "/control") whose structure never changes for the
-			// lifetime of the mount.  Cache lookups aggressively so the
-			// kernel does not round-trip to userspace for every stat/lookup.
-			cfg->entry_timeout = 86400;
-			cfg->negative_timeout = 86400;
-			cfg->attr_timeout = 1;
+			cfg->entry_timeout = 86400.0;
+			cfg->attr_timeout = 1.0;
 		}
 
 		return fuse_service_init_common ();
@@ -488,12 +479,12 @@ namespace VeraCrypt
 		catch (std::exception &e)
 		{
 			SystemLog::WriteException (e);
-			return -EINTR;
+			return -EIO;
 		}
 		catch (...)
 		{
 			SystemLog::WriteException (UnknownException (SRC_POS));
-			return -EINTR;
+			return -EIO;
 		}
 	}
 


### PR DESCRIPTION
Two small fixes for the FUSE layer, building on cdc00dc4.

1. Configure FUSE 3 caching in init

VeraCrypt exposes a fixed three-entry filesystem (`/`, `/volume`, `/control`) that never changes during a mount. With the default 1s `entry_timeout`, the kernel revalidates every dentry once per second — unnecessary round-trips to userspace that add up since the loop device and upper filesystem trigger frequent lookups.

2. Return EIO instead of EINTR for unhandled exceptions

`ExceptionToErrorCode()` was returning EINTR for unknown exceptions. EINTR means "interrupted by signal, retry".