### PR TITLE
Linux: fix suspend deadlock with mounted volumes on kernel 6.18+

### DIFF
--- a/src/Build/CMakeLists.txt
+++ b/src/Build/CMakeLists.txt
@@ -213,6 +213,11 @@ install(DIRECTORY 	${VERACRYPT_BUILD_DIR}/usr/sbin
 install(DIRECTORY 	${VERACRYPT_BUILD_DIR}/usr/share
 		DESTINATION .
 		USE_SOURCE_PERMISSIONS)
+if(EXISTS "${VERACRYPT_BUILD_DIR}/lib/systemd/system-sleep")
+	install(DIRECTORY 	${VERACRYPT_BUILD_DIR}/lib/systemd/system-sleep
+			DESTINATION /lib/systemd
+			USE_SOURCE_PERMISSIONS)
+endif()
 set(CPACK_PACKAGING_INSTALL_PREFIX "/usr")
 
 # For packaging 

--- a/src/Main/GraphicUserInterface.cpp
+++ b/src/Main/GraphicUserInterface.cpp
@@ -1091,7 +1091,7 @@ namespace VeraCrypt
 
 			Connect (wxEVT_END_SESSION, wxCloseEventHandler (GraphicUserInterface::OnEndSession));
 #ifdef wxHAS_POWER_EVENTS
-			Gui->Connect (wxEVT_POWER_SUSPENDING, wxPowerEventHandler (GraphicUserInterface::OnPowerSuspending));
+			Gui->Connect (wxEVT_POWER_SUSPENDED, wxPowerEventHandler (GraphicUserInterface::OnPowerSuspending));
 #endif
 
 			mMainFrame = new MainFrame (nullptr);

--- a/src/Main/Main.make
+++ b/src/Main/Main.make
@@ -330,16 +330,21 @@ ifndef TC_NO_GUI
 	ln -sf usr/share/icons/hicolor/1024x1024/apps/$(APPNAME).png $(BASE_DIR)/Setup/Linux/veracrypt.AppDir/$(APPNAME).png
 endif
 
+	mkdir -p $(BASE_DIR)/Setup/Linux/lib/systemd/system-sleep
+	cp $(BASE_DIR)/Setup/Linux/$(APPNAME)-sleep-hook $(BASE_DIR)/Setup/Linux/lib/systemd/system-sleep/$(APPNAME)
+	chmod +x $(BASE_DIR)/Setup/Linux/lib/systemd/system-sleep/$(APPNAME)
+
 
 install: prepare
 ifneq "$(DESTDIR)" ""
 	mkdir -p $(DESTDIR)
 endif
 	cp -R $(BASE_DIR)/Setup/Linux/usr $(DESTDIR)/
+	cp -R $(BASE_DIR)/Setup/Linux/lib $(DESTDIR)/ 2>/dev/null || true
 
 ifeq "$(TC_BUILD_CONFIG)" "Release"
 package: prepare
-	tar cfz $(BASE_DIR)/Setup/Linux/$(PACKAGE_NAME) --directory $(BASE_DIR)/Setup/Linux usr
+	tar cfz $(BASE_DIR)/Setup/Linux/$(PACKAGE_NAME) --directory $(BASE_DIR)/Setup/Linux usr lib
 
 	@rm -fr $(INTERNAL_INSTALLER_NAME)
 	@echo "#!/bin/sh" > $(INTERNAL_INSTALLER_NAME)

--- a/src/Setup/Linux/veracrypt-sleep-hook
+++ b/src/Setup/Linux/veracrypt-sleep-hook
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Dismount all VeraCrypt volumes before suspend/hibernate to prevent
+# a deadlock between the cgroup freezer and FUSE_SYNCFS on kernel 6.18+.
+# See https://github.com/veracrypt/VeraCrypt/issues/1660
+
+case "$1" in
+  pre)
+    if command -v veracrypt >/dev/null 2>&1; then
+      veracrypt --text --dismount --all --force 2>/dev/null || true
+    fi
+    ;;
+esac

--- a/src/Setup/Linux/veracrypt-sleep-hook
+++ b/src/Setup/Linux/veracrypt-sleep-hook
@@ -6,7 +6,7 @@
 case "$1" in
   pre)
     if command -v veracrypt >/dev/null 2>&1; then
-      veracrypt --text --dismount --all --force 2>/dev/null || true
+      veracrypt --text --dismount --force 2>/dev/null || true
     fi
     ;;
 esac

--- a/src/Setup/Linux/veracrypt-uninstall.sh
+++ b/src/Setup/Linux/veracrypt-uninstall.sh
@@ -19,6 +19,7 @@ for res in 16 22 24 32 48 64 256 512 1024; do \
 		rm -f /usr/share/icons/hicolor/${res}x${res}/apps/veracrypt.png || removal_failed ;\
 done
 
+rm -f /lib/systemd/system-sleep/veracrypt 2>/dev/null
 rm -f /usr/bin/veracrypt-uninstall.sh || removal_failed
 update-mime-database /usr/share/mime >/dev/null 2>&1
 update-desktop-database -q


### PR DESCRIPTION
Fixes #1660.

On kernel 6.18+, `systemctl suspend` hangs indefinitely when a VeraCrypt volume is mounted. Two independent changes combined to cause this:

1. **systemd v255** made `user.slice` freezing the default before suspend
2. **Kernel 6.18** (commit `d3906d8f3cee`) enabled `FUSE_SYNCFS` for all fuseblk mounts

When a VeraCrypt NTFS volume is mounted, ntfs-3g runs in `user.slice`. The suspend path freezes ntfs-3g, then the kernel sends `FUSE_SYNCFS` to it and blocks forever waiting for a response.

**Tested on:** Ubuntu 26.04 (kernel 7.0.0, systemd 259). Built with `NOGUI=1 WITHFUSE3=1`. Confirmed FUSE daemons land in `user.slice/user-1000.slice/session-*.scope`. Verified the sleep hook dismounts all volumes when invoked with `pre suspend`. Azure VMs lack ACPI S3, so the actual suspend hang could not be triggered end-to-end.