### PR TITLE
Honor --no-size-check in CLI volume creation

### DIFF
--- a/src/Main/TextUserInterface.cpp
+++ b/src/Main/TextUserInterface.cpp
@@ -766,7 +766,10 @@ namespace VeraCrypt
 				if (options->Type == VolumeType::Normal && wxDirExists(parentDir) && wxGetDiskSpace (parentDir, nullptr, &diskSpace))
 				{
 					AvailableDiskSpace = (uint64) diskSpace.GetValue ();
-					if (maxVolumeSize > AvailableDiskSpace)
+					// Honor --no-size-check so a (sparse) file container larger than the
+					// current free space can be created from the command line, mirroring
+					// the GUI wizard behavior (see VolumeSizeWizardPage.cpp).
+					if (maxVolumeSize > AvailableDiskSpace && !CmdLine->ArgDisableFileSizeCheck)
 						maxVolumeSize = AvailableDiskSpace;
 				}
 			}

--- a/src/Main/TextUserInterface.cpp
+++ b/src/Main/TextUserInterface.cpp
@@ -782,8 +782,8 @@ namespace VeraCrypt
 				else if (AvailableDiskSpace)
 				{
 					// caller requesting maximum size
-					// we use maxVolumeSize because it is guaranteed to be less or equal to AvailableDiskSpace for outer volumes
-					options->Size = maxVolumeSize;
+					// Limit "max" to available disk space even when --no-size-check allows explicit sparse sizes beyond it.
+					options->Size = VC_MIN (maxVolumeSize, AvailableDiskSpace);
 				}
 				else
 				{
@@ -811,8 +811,8 @@ namespace VeraCrypt
 					else if (AvailableDiskSpace)
 					{
 						// caller requesting maximum size
-						// we use maxVolumeSize because it is guaranteed to be less or equal to AvailableDiskSpace for outer volumes
-						options->Size = maxVolumeSize;
+						// Limit "max" to available disk space even when --no-size-check allows explicit sparse sizes beyond it.
+						options->Size = VC_MIN (maxVolumeSize, AvailableDiskSpace);
 					}
 					else
 					{


### PR DESCRIPTION
## Problem

The documented `--no-size-check` switch ("Disable check of container size against disk free space") has **no effect** when creating a file-hosted container via `--text --create`. Creating a container larger than current free space fails with `Error: Incorrect volume size`, even though that's a valid request on sparse-capable filesystems (APFS, ext4, NTFS) and is exactly what the flag exists to permit.

## Root cause

In `TextUserInterface.cpp`, the volume-creation path clamps `maxVolumeSize` to available free disk space and never consults `CmdLine->ArgDisableFileSizeCheck`. The flag *is* honored by the GUI wizard (`Forms/VolumeSizeWizardPage.cpp`) but was never wired into the text UI.

## Fix

Skip the free-space clamp when `--no-size-check` is set, mirroring the GUI behavior. One-line guard; no change to default behavior.

## Verification

Built on macOS arm64; `--text --create --size 3500G --quick --no-size-check ...` now succeeds, producing a sparse 3.42 TiB container (256 KB physical on APFS). Without the flag, the free-space check still applies as before.
