### PR TITLE
macOS: validate target of privileged SetFileOwner (restrict to disk device nodes)

### DIFF
--- a/src/Core/Unix/CoreService.cpp
+++ b/src/Core/Unix/CoreService.cpp
@@ -12,6 +12,7 @@
 
 #include "CoreService.h"
 #include <fcntl.h>
+#include <sys/stat.h>
 #include <sys/wait.h>
 #include <stdio.h>
 #include "Platform/FileStream.h"
@@ -58,6 +59,27 @@ namespace VeraCrypt
 	{
 		return IsMacOSXDevicePathWithPrefix (path, "/dev/disk")
 			|| IsMacOSXDevicePathWithPrefix (path, "/dev/rdisk");
+	}
+
+	// The elevated service runs as root, so it must not be tricked into changing
+	// ownership of an arbitrary path. Every legitimate macOS caller of the
+	// elevated SetFileOwner targets a real disk device node (/dev/[r]diskN[sM]),
+	// so restrict the operation to that. lstat() (not stat) is used so a symlink
+	// is rejected outright rather than followed, and the st_mode check confirms an
+	// actual block/character device before the chown.
+	static void ValidateMacOSXSetFileOwnerTarget (const FilesystemPath &path)
+	{
+		const string pathStr = path;
+
+		if (!IsMacOSXFormatterDevicePath (pathStr))
+			throw ParameterIncorrect (SRC_POS);
+
+		struct stat sb;
+		if (lstat (pathStr.c_str(), &sb) != 0)
+			throw ParameterIncorrect (SRC_POS);
+
+		if (!S_ISBLK (sb.st_mode) && !S_ISCHR (sb.st_mode))
+			throw ParameterIncorrect (SRC_POS);
 	}
 
 	static list <string> BuildMacOSXAPFSFormatterArguments (const ExecuteMacOSXAPFSFormatterRequest &request)
@@ -292,6 +314,10 @@ namespace VeraCrypt
 						if (!coreUnix)
 							throw ParameterIncorrect (SRC_POS);
 
+#ifdef TC_MACOSX
+						// Restrict the root-privileged chown to real disk device nodes.
+						ValidateMacOSXSetFileOwnerTarget (setFileOwnerRequest->Path);
+#endif
 						coreUnix->SetFileOwner (setFileOwnerRequest->Path, setFileOwnerRequest->Owner);
 						SetFileOwnerResponse().Serialize (outputStream);
 						continue;


### PR DESCRIPTION
## Summary

Defense-in-depth hardening for the macOS privileged helper. The elevated `CoreService` handler for `SetFileOwnerRequest` passed the client-supplied path straight to `chown()` running as root, with no validation — unlike the adjacent `ExecuteMacOSXAPFSFormatterRequest` handler, which strictly validates its device argument via `IsMacOSXFormatterDevicePath()`.

## Background

On macOS, when the user is not an administrator, the volume creation / format flows temporarily transfer ownership of the target **disk device node** to the invoking user through the root-elevated service (`VolumeCreator`, `GraphicUserInterface`, `TextUserInterface`, `MacOSXFormatterDevice.h`). Every legitimate caller of the elevated `SetFileOwner` targets a `/dev/[r]diskN[sM]` device.

The service side, however, performed no validation — it would `chown()` any path to any uid as root. Because `chown()` follows symlinks, a symlink planted at the target (or a crafted IPC request) could redirect the root-owned chown to an arbitrary path.

Reachability is limited (the service channel is private to the authenticated session, and the real callers only ever target devices), so this is hardening rather than a directly weaponizable issue. But the asymmetry with the already-validated formatter handler is worth closing.

## Change

Add `ValidateMacOSXSetFileOwnerTarget()` in `CoreService.cpp`, invoked before the elevated chown:

- Require the strict device-path form already used by the formatter (`IsMacOSXFormatterDevicePath`: exactly `/dev/disk<N>` or `/dev/disk<N>s<M>`, plus the `rdisk` variants, with no trailing characters).
- `lstat()` the path (not `stat`) and require `S_ISBLK` or `S_ISCHR`, so a symlink is rejected outright rather than followed.

No behavior change for legitimate flows — all macOS callers already target device nodes. Other platforms are unaffected (`#ifdef TC_MACOSX`).

## Testing

Built on Apple Silicon (arm64, macOS); volume create + mount still succeed. The validator accepts `/dev/diskN` (block) and `/dev/rdiskN` (character) device nodes and rejects non-device paths and symlinks.
