### PR TITLE
Update Corsican translation on 2026-06 (2nd)

### DIFF
--- a/Translations/Language.co.xml
+++ b/Translations/Language.co.xml
@@ -7,7 +7,7 @@ Information about Corsican localization:
 
 2. History of Corsican translation for VeraCrypt:
 	- Updated in 2026 by Patriccollu di Santa Maria è Sichè: May 2nd (1.26.28), May 9th (1.26.28), May 13th (1.26.28),
-	          May 27th (1.26.29), June 15th (1.26.30)
+	          May 27th (1.26.29), June 15th (1.26.30), June 18th (1.26.30)
 	- Updated in 2025 by Patriccollu di Santa Maria è Sichè: May 5th (1.26.21), May 25th (1.26.24), June 26th (1.26.27),
 	          Aug. 31st (1.26.27), Sep. 27th (1.26.27)
 	- Updated in 2024 by Patriccollu di Santa Maria è Sichè: Aug. 2nd (1.26.13), Aug. 10th (1.26.13)
@@ -23,7 +23,7 @@ Information about Corsican localization:
 -->
 <VeraCrypt>
 	<localization prog-version="1.26.30">
-		<language langid="co" name="Corsu" en-name="Corsican" version="1.5.6" translators="Patriccollu di Santa Maria è Sichè"/>
+		<language langid="co" name="Corsu" en-name="Corsican" version="1.5.7" translators="Patriccollu di Santa Maria è Sichè"/>
 		<font lang="co" class="normal" size="11" face="default"/>
 		<font lang="co" class="bold" size="13" face="Arial"/>
 		<font lang="co" class="fixed" size="12" face="Lucida Console"/>
@@ -869,7 +869,7 @@ Information about Corsican localization:
 	    <entry lang="co" key="AFTER_UPGRADE_RELEASE_NOTES">Vulete leghje l’annutazioni nant’à a versione attuale (l’ultima versione stabule) di VeraCrypt ?</entry>
 	    <entry lang="co" key="AFTER_INSTALL_TUTORIAL">S’è ùn avete mai impiegatu VeraCrypt, vi ricumandemu di leghje u capitulu « Beginner&apos;s Tutorial » in a guida di l’utilizatore VeraCrypt. Vulete fighjà a furmazione autonoma ?</entry>
 	    <entry lang="co" key="SELECT_AN_ACTION">Selezziunate un azzione à fà :</entry>
-	    <entry lang="co" key="REPAIR_REINSTALL">Riparà/Riinstallà</entry>
+	    <entry lang="co" key="REPAIR_REINSTALL">Riparà o riinstallà</entry>
 	    <entry lang="co" key="UPGRADE">Mudernizà</entry>
 	    <entry lang="co" key="UNINSTALL">Disinstallà</entry>
 	    <entry lang="co" key="SETUP_ADMIN">Per installà o disinstallà currettamente VeraCrypt, ci vole à avè privileghji d’amministratore. Vulete cuntinuà ?</entry>
@@ -1707,7 +1707,7 @@ Information about Corsican localization:
 	    <entry lang="co" key="MACOSX_APFS_EROFS_HINT">macOS hà signalatu l’apparechju selezziunatu cum’è essendu in lettura sola. S’ellu hè un discu APFS, assicuratevi chì ghjè a partizione d’allucamentu APFS fisica chì hè selezziunata, è micca un vulume APFS sintetizatu. Impiegate l’attrezzu di discu o « diskutil list » per identificà a partizione fisica eppò pruvate torna.</entry>
 	    <entry lang="co" key="FAVORITE_PIM_OR_KDF_CHANGED">Stu vulume hè arregistratu cum’è un favuritu di u sistema è u so PIM è/o i so parametri KDF sò stati cambiati.\nVulete chì VeraCrypt mudificheghji autumaticamente a cunfigurazione di i favuriti di u sistema (i privileghji d’amministratore sò richiesti) ?\n\nSappiate chì, s’è vò rispundite nò, tuccherà à voi di fallu manualmente.</entry>
 	    <entry lang="co" key="PIM_RESET_ON_KDF_CHANGE_CONFIRM">U KDF selezziunatu impiegheghja parametri PIM sfarenti, dunque VeraCrypt ùn rimpiegherà micca u PIM persunalizatu attuale. A nova intestatura di u vulume impiegherà u PIM predefinitu per u KDF selezziunatu fora s’è vo selezziunate « Impiegà un PIM » in a sezzione « Novu » è s’è vo stampittate un valore persunalizatu.\n\nVulete cuntinuà ?</entry>
-	    <entry lang="en" key="SYSENC_EFI_UNSUPPORTED_SECUREBOOT_CA">Secure Boot is enabled, but the firmware Secure Boot database does not trust any Microsoft UEFI CA set supported by VeraCrypt's EFI bootloader. Enable either Microsoft Corporation UEFI CA 2011, or both Microsoft UEFI CA 2023 and Microsoft Option ROM UEFI CA 2023, then run VeraCrypt Repair/Reinstall. Alternatively, disable Secure Boot.</entry>
+	    <entry lang="co" key="SYSENC_EFI_UNSUPPORTED_SECUREBOOT_CA">A piccera sicurizata hè attiva ma a basa di dati di a piccera sicurizata di u microprugramma ùn face micca cunfidenza à alcunu inseme d’auturità di certificazione UEFI di Microsoft accettatu da u caricadore di piccera EFI di VeraCrypt. Attivà, sia Microsoft Corporation UEFI CA 2011, sia Microsoft UEFI CA 2023 è Microsoft Option ROM UEFI CA 2023 tremindui, eppò lancià « Riparà o riinstallà » di VeraCrypt. Osinnò, disattivà a piccera sicurizata.</entry>
 	</localization>
 	<xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
 		<xs:element name="VeraCrypt">


### PR DESCRIPTION
Hello,

This is an update of **Corsican** (co) localization to take this commit into account:

 * https://github.com/veracrypt/VeraCrypt/commit/8bfe53b20fef10e7dacc037346a4800998487bba Windows: prevent unsupported EFI Secure Boot fallback

Cheers,
Patriccollu.