### PR TITLE
macOS: search system directories before /usr/local/bin for binaries

### DIFF
--- a/src/Platform/Unix/Process.cpp
+++ b/src/Platform/Unix/Process.cpp
@@ -44,9 +44,15 @@ namespace VeraCrypt
 			return "";
 		}
 
-		// Default system directories to search for executables
+		// Default system directories to search for executables.
+		// On macOS, system locations are searched before /usr/local/bin so that
+		// a user-writable /usr/local/bin (the default on Homebrew installs)
+		// cannot shadow system tools. This matters because this resolver is
+		// also used for privileged binaries such as sudo during elevation
+		// (see CoreService.cpp); a planted /usr/local/bin/sudo would otherwise
+		// receive the admin password.
 #ifdef TC_MACOSX
-		const char* defaultDirs[] = {"/usr/local/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin"};
+		const char* defaultDirs[] = {"/usr/bin", "/bin", "/usr/sbin", "/sbin", "/usr/local/bin"};
 #elif TC_FREEBSD
 		const char* defaultDirs[] = {"/sbin", "/bin", "/usr/sbin", "/usr/bin", "/usr/local/sbin", "/usr/local/bin"};
 #elif TC_OPENBSD


### PR DESCRIPTION
### Summary

On macOS, `Process::FindSystemBinary()` searched `/usr/local/bin` **first**, so a user-writable `/usr/local/bin` (the default on Homebrew installs) could shadow tools in the system directories.

This resolver is also used to locate privileged binaries during privilege elevation. `CoreService.cpp` resolves `sudo` (and `true`) through it both when probing for an active sudo session and when launching the elevated helper, and the admin password is written to that sudo process's stdin.

On a typical Homebrew install `/usr/local` is owned by the (non-root) user, so a planted `/usr/local/bin/sudo` would be selected ahead of `/usr/bin/sudo` and could capture the admin password, leading to privilege escalation.

### Fix

Reorder the macOS search list so system locations always win:

```diff
-const char* defaultDirs[] = {"/usr/local/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin"};
+const char* defaultDirs[] = {"/usr/bin", "/bin", "/usr/sbin", "/sbin", "/usr/local/bin"};
```

`/usr/local/bin` is kept only as a last-resort fallback and can no longer shadow the system tools.

### Affected resolver users

The binaries actually resolved through `FindSystemBinary()` on macOS are `sudo`, `true`, `fsck`, the terminal helper used for filesystem checks (and its dependencies), and non-APFS formatters — all of which live in system directories.

`diskutil`, `hdiutil`, and `newfs_apfs` are invoked via absolute paths and were never affected by the search order; they're mentioned only as context for what VeraCrypt runs on macOS.

### Notes

- Single-file change, no behavioral effect on normal installs (the system binaries are found in the same locations, just searched in a safer order).
- Builds cleanly on Apple Silicon via `Build/build_veracrypt_macosx.sh -b -f`.
- Related to the macOS elevation hardening in #1758.
