### PR TITLE
macOS: honor the CheckFilesystem repair flag

### DIFF
--- a/Translations/Language.ar.xml
+++ b/Translations/Language.ar.xml
@@ -1498,6 +1498,8 @@
     <entry lang="ar" key="LINUX_REMOUNT_BECAUSEOF_SETTING">يرجى ملاحظة أن أي أحجام مثبتة حاليًا تحتاج إلى إعادة تثبيتها قبل أن تتمكن من استخدام هذا الإعداد.</entry>
     <entry lang="ar" key="LINUX_UNKNOWN_EXC_OCCURRED">حدث استثناء غير معروف.</entry>
     <entry lang="ar" key="LINUX_FIRST_AID">"سيتم تشغيل “أداة القرص” بعد الضغط على "موافق".\n\nيرجى تحديد حجمك في نافذة أداة الأقراص والضغط على "التحقق من القرص" أو زر "إصلاح القرص" على صفحة "الإسعافات الأولية".</entry>
+    <entry lang="en" key="MACOSX_CHECK_FILESYS">A Terminal window will open after you press 'OK' and check the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the check cannot be started, Disk Utility will be launched instead.</entry>
+    <entry lang="en" key="MACOSX_REPAIR_FILESYS">A Terminal window will open after you press 'OK' and attempt to repair the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the repair cannot be started, Disk Utility will be launched instead.</entry>
     <entry lang="ar" key="LINUX_MOUNT_ALL_DEV">تركيب جميع الأجهزة</entry>
     <entry lang="ar" key="LINUX_ERROR_LOADING_CONFIG">خطأ أثناء تحميل ملفات التكوين الموجودة في </entry>
     <entry lang="ar" key="LINUX_SELECT_FREE_SLOT">يرجى اختيار فتحة محرك مجانية من القائمة.</entry>

--- a/Translations/Language.be.xml
+++ b/Translations/Language.be.xml
@@ -1498,6 +1498,8 @@
     <entry lang="be" key="LINUX_REMOUNT_BECAUSEOF_SETTING">Калі ласка, звярніце ўвагу, што любыя змантаваныя ў цяперашні час тамы неабходна перамантаваць, перш чым яны змогуць выкарыстоўваць гэты параметр.</entry>
     <entry lang="be" key="LINUX_UNKNOWN_EXC_OCCURRED">Адбылося невядомае выключэнне.</entry>
     <entry lang="be" key="LINUX_FIRST_AID">«Дыскавая ўтыліта будзе запушчана пасля націску «ОК».\n\nВыберыце свой том у акне Disk Utility і націсніце кнопку «Праверыць дыск» або «Адрамантаваць дыск» на старонцы «Першая дапамога».</entry>
+    <entry lang="en" key="MACOSX_CHECK_FILESYS">A Terminal window will open after you press 'OK' and check the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the check cannot be started, Disk Utility will be launched instead.</entry>
+    <entry lang="en" key="MACOSX_REPAIR_FILESYS">A Terminal window will open after you press 'OK' and attempt to repair the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the repair cannot be started, Disk Utility will be launched instead.</entry>
     <entry lang="be" key="LINUX_MOUNT_ALL_DEV">Змантаваць усе прылады</entry>
     <entry lang="be" key="LINUX_ERROR_LOADING_CONFIG">Памылка пры загрузцы файлаў канфігурацыі, размешчаных у </entry>
     <entry lang="be" key="LINUX_SELECT_FREE_SLOT">Калі ласка, абярыце свабодны слот для дыскавода са спісу.</entry>

--- a/Translations/Language.bg.xml
+++ b/Translations/Language.bg.xml
@@ -1498,6 +1498,8 @@
     <entry lang="bg" key="LINUX_REMOUNT_BECAUSEOF_SETTING">Моля, обърнете внимание, че всички монтирани в момента томове трябва да бъдат монтирани отново, преди да могат да използват тази настройка.</entry>
     <entry lang="bg" key="LINUX_UNKNOWN_EXC_OCCURRED">Възникна неизвестно изключение.</entry>
     <entry lang="bg" key="LINUX_FIRST_AID">„Disk Utility ще се стартира, след като натиснете „OK“.\n\nМоля, изберете своя том в прозореца на Disk Utility и натиснете бутона „Проверете диска“ или „Поправете диска“ на страницата „Първа помощ“.</entry>
+    <entry lang="en" key="MACOSX_CHECK_FILESYS">A Terminal window will open after you press 'OK' and check the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the check cannot be started, Disk Utility will be launched instead.</entry>
+    <entry lang="en" key="MACOSX_REPAIR_FILESYS">A Terminal window will open after you press 'OK' and attempt to repair the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the repair cannot be started, Disk Utility will be launched instead.</entry>
     <entry lang="bg" key="LINUX_MOUNT_ALL_DEV">Монтирайте всички устройства</entry>
     <entry lang="bg" key="LINUX_ERROR_LOADING_CONFIG">Грешка при зареждане на конфигурационните файлове, намиращи се в </entry>
     <entry lang="bg" key="LINUX_SELECT_FREE_SLOT">Моля, изберете свободен слот за устройство от списъка.</entry>

--- a/Translations/Language.ca.xml
+++ b/Translations/Language.ca.xml
@@ -1498,6 +1498,8 @@
     <entry lang="ca" key="LINUX_REMOUNT_BECAUSEOF_SETTING">Tingueu en compte que els volums muntats actualment s'han de tornar a muntar abans que puguin utilitzar aquesta configuració.</entry>
     <entry lang="ca" key="LINUX_UNKNOWN_EXC_OCCURRED">S'ha produït una excepció desconeguda.</entry>
     <entry lang="ca" key="LINUX_FIRST_AID">"La Utilitat de disc s'iniciarà després de prémer "D'acord".\n\nSeleccioneu el vostre volum a la finestra Utilitat de disc i premeu el botó "Verifica el disc" o "Repara el disc" a la pàgina "Primers auxilis".</entry>
+    <entry lang="en" key="MACOSX_CHECK_FILESYS">A Terminal window will open after you press 'OK' and check the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the check cannot be started, Disk Utility will be launched instead.</entry>
+    <entry lang="en" key="MACOSX_REPAIR_FILESYS">A Terminal window will open after you press 'OK' and attempt to repair the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the repair cannot be started, Disk Utility will be launched instead.</entry>
     <entry lang="ca" key="LINUX_MOUNT_ALL_DEV">Munta tots els dispositius</entry>
     <entry lang="ca" key="LINUX_ERROR_LOADING_CONFIG">S'ha produït un error en carregar els fitxers de configuració que es troben a </entry>
     <entry lang="ca" key="LINUX_SELECT_FREE_SLOT">Seleccioneu una ranura d'unitat lliure de la llista.</entry>

--- a/Translations/Language.co.xml
+++ b/Translations/Language.co.xml
@@ -1520,6 +1520,8 @@ Information about Corsican localization:
 	    <entry lang="co" key="LINUX_REMOUNT_BECAUSEOF_SETTING">Sappiate chì, prima di pudè impiegà stu parametru, tutti i vulumi muntati attualmente devenu esse smuntati è muntati torna.</entry>
 	    <entry lang="co" key="LINUX_UNKNOWN_EXC_OCCURRED">Un’anumalia scunnisciuta hè accaduta.</entry>
 	    <entry lang="co" key="LINUX_FIRST_AID">L’utilitariu di discu serà lanciatu dopu à un cliccu nant’à « Vai ».\n\nSelezziunate u vostru vulume in a finestra di l’utilitariu di discu è appughjate nant’à u buttone « Verificà u discu » o « Riparà u discu » di a pagina« Prontu Succorsu ».</entry>
+    <entry lang="en" key="MACOSX_CHECK_FILESYS">A Terminal window will open after you press 'OK' and check the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the check cannot be started, Disk Utility will be launched instead.</entry>
+    <entry lang="en" key="MACOSX_REPAIR_FILESYS">A Terminal window will open after you press 'OK' and attempt to repair the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the repair cannot be started, Disk Utility will be launched instead.</entry>
 	    <entry lang="co" key="LINUX_MOUNT_ALL_DEV">Muntà tutti l’apparechji</entry>
 	    <entry lang="co" key="LINUX_ERROR_LOADING_CONFIG">Sbagliu durante u caricamentu di i schedarii di cunfigurazione lucalizati in</entry>
 	    <entry lang="co" key="LINUX_SELECT_FREE_SLOT">Ci vole à selezziunà una lettera di lettore libera nant’à a lista.</entry>

--- a/Translations/Language.cs.xml
+++ b/Translations/Language.cs.xml
@@ -1498,6 +1498,8 @@
     <entry lang="cs" key="LINUX_REMOUNT_BECAUSEOF_SETTING">Berte v potaz, že před použitím tohoto nastavení je třeba znovu připojit všechny aktuálně připojené svazky.</entry>
     <entry lang="cs" key="LINUX_UNKNOWN_EXC_OCCURRED">Vyskytla se neznámá výjimka.</entry>
     <entry lang="cs" key="LINUX_FIRST_AID">"Po stisknutí tlačítka „OK” se spustí nástroj „Disk Utility”.\n\nV okně nástroje „Disk Utility” vyberte svazek a na stránce „První pomoc” stiskněte tlačítko „Ověřit disk” nebo „Opravit disk”.</entry>
+    <entry lang="en" key="MACOSX_CHECK_FILESYS">A Terminal window will open after you press 'OK' and check the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the check cannot be started, Disk Utility will be launched instead.</entry>
+    <entry lang="en" key="MACOSX_REPAIR_FILESYS">A Terminal window will open after you press 'OK' and attempt to repair the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the repair cannot be started, Disk Utility will be launched instead.</entry>
     <entry lang="cs" key="LINUX_MOUNT_ALL_DEV">Připojit všechna zařízení</entry>
     <entry lang="cs" key="LINUX_ERROR_LOADING_CONFIG">Chyba při načítání konfiguračních souborů umístěných v </entry>
     <entry lang="cs" key="LINUX_SELECT_FREE_SLOT">Vyberte ze seznamu volný slot pro jednotku.</entry>

--- a/Translations/Language.da.xml
+++ b/Translations/Language.da.xml
@@ -1498,6 +1498,8 @@
     <entry lang="da" key="LINUX_REMOUNT_BECAUSEOF_SETTING">Bemærk venligst, at alle aktuelt monterede volumener skal genmonteres, før de kan bruge denne indstilling.</entry>
     <entry lang="da" key="LINUX_UNKNOWN_EXC_OCCURRED">Ukendt undtagelse opstod.</entry>
     <entry lang="da" key="LINUX_FIRST_AID">"Diskværktøj vil blive lanceret, når du trykker på 'OK'.\n\nVælg venligst din volumen i vinduet Diskværktøj, og tryk på knappen 'Verify Disk' eller 'Repair Disk' på 'First Aid'-siden.</entry>
+    <entry lang="en" key="MACOSX_CHECK_FILESYS">A Terminal window will open after you press 'OK' and check the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the check cannot be started, Disk Utility will be launched instead.</entry>
+    <entry lang="en" key="MACOSX_REPAIR_FILESYS">A Terminal window will open after you press 'OK' and attempt to repair the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the repair cannot be started, Disk Utility will be launched instead.</entry>
     <entry lang="da" key="LINUX_MOUNT_ALL_DEV">Monter alle enheder</entry>
     <entry lang="da" key="LINUX_ERROR_LOADING_CONFIG">Fejl under indlæsning af konfigurationsfiler placeret i </entry>
     <entry lang="da" key="LINUX_SELECT_FREE_SLOT">Vælg venligst en gratis drevplads fra listen.</entry>

--- a/Translations/Language.de.xml
+++ b/Translations/Language.de.xml
@@ -1501,6 +1501,8 @@
     <entry lang="de" key="LINUX_REMOUNT_BECAUSEOF_SETTING">Bitte beachten Sie, dass alle eingehängten Volumes neu eingehängt werden müssen, bevor diese Einstellungen genutzt werden können.</entry>
     <entry lang="de" key="LINUX_UNKNOWN_EXC_OCCURRED">Unbekannte Ausnahme aufgetreten.</entry>
     <entry lang="de" key="LINUX_FIRST_AID">Das Laufwerkswerkzeug wird nach dem Klicken von „OK“ gestartet.\n\nBitte wählen Sie das Volume im Werkzeug aus und klicken „Laufwerk überprüfen“ oder „Laufwerk reparieren“ auf der Seite „Erste Hilfe“.</entry>
+    <entry lang="en" key="MACOSX_CHECK_FILESYS">A Terminal window will open after you press 'OK' and check the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the check cannot be started, Disk Utility will be launched instead.</entry>
+    <entry lang="en" key="MACOSX_REPAIR_FILESYS">A Terminal window will open after you press 'OK' and attempt to repair the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the repair cannot be started, Disk Utility will be launched instead.</entry>
     <entry lang="de" key="LINUX_MOUNT_ALL_DEV">Alle Geräte einhängen</entry>
     <entry lang="de" key="LINUX_ERROR_LOADING_CONFIG">Fehler beim Laden der Konfigurationsdateien aus </entry>
     <entry lang="de" key="LINUX_SELECT_FREE_SLOT">Bitte einen freien Laufwerksplatz aus der Liste wählen.</entry>

--- a/Translations/Language.el.xml
+++ b/Translations/Language.el.xml
@@ -1498,6 +1498,8 @@
     <entry lang="el" key="LINUX_REMOUNT_BECAUSEOF_SETTING">Λάβετε υπόψη ότι τυχόν τόμοι που έχουν τοποθετηθεί αυτήν τη στιγμή πρέπει να επανατοποθετηθούν για να μπορέσουν να χρησιμοποιήσουν αυτήν τη ρύθμιση.</entry>
     <entry lang="el" key="LINUX_UNKNOWN_EXC_OCCURRED">Παρουσιάστηκε άγνωστη εξαίρεση.</entry>
     <entry lang="el" key="LINUX_FIRST_AID">"Το Disk Utility θα ξεκινήσει αφού πατήσετε "OK".\n\nΕπιλέξτε τον τόμο σας στο παράθυρο Disk Utility και πατήστε το κουμπί "Verify Disk" ή "Repair Disk" στη σελίδα "First Aid".</entry>
+    <entry lang="en" key="MACOSX_CHECK_FILESYS">A Terminal window will open after you press 'OK' and check the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the check cannot be started, Disk Utility will be launched instead.</entry>
+    <entry lang="en" key="MACOSX_REPAIR_FILESYS">A Terminal window will open after you press 'OK' and attempt to repair the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the repair cannot be started, Disk Utility will be launched instead.</entry>
     <entry lang="el" key="LINUX_MOUNT_ALL_DEV">Τοποθέτηση όλων των συσκευών</entry>
     <entry lang="el" key="LINUX_ERROR_LOADING_CONFIG">Σφάλμα κατά τη φόρτωση των αρχείων διαμόρφωσης που βρίσκονται στο </entry>
     <entry lang="el" key="LINUX_SELECT_FREE_SLOT">Επιλέξτε μια δωρεάν υποδοχή μονάδας δίσκου από τη λίστα.</entry>

--- a/Translations/Language.es.xml
+++ b/Translations/Language.es.xml
@@ -1498,6 +1498,8 @@
     <entry lang="es" key="LINUX_REMOUNT_BECAUSEOF_SETTING">Tenga en cuenta que cualquier volumen actualmente montado necesita ser remontado antes de que pueda usar esta configuración.</entry>
     <entry lang="es" key="LINUX_UNKNOWN_EXC_OCCURRED">Se produjo una excepción desconocida.</entry>
     <entry lang="es" key="LINUX_FIRST_AID">"La Utilidad de Discos se lanzará después de que presione 'OK'.\n\nPor favor seleccione su volumen en la ventana de Utilidad de Discos y presione el botón 'Verificar Disco' o 'Reparar Disco' en la página de 'Primeros Auxilios'.</entry>
+    <entry lang="en" key="MACOSX_CHECK_FILESYS">A Terminal window will open after you press 'OK' and check the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the check cannot be started, Disk Utility will be launched instead.</entry>
+    <entry lang="en" key="MACOSX_REPAIR_FILESYS">A Terminal window will open after you press 'OK' and attempt to repair the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the repair cannot be started, Disk Utility will be launched instead.</entry>
     <entry lang="es" key="LINUX_MOUNT_ALL_DEV">Montar Todos los Dispositivos</entry>
     <entry lang="es" key="LINUX_ERROR_LOADING_CONFIG">Error al cargar los archivos de configuración ubicados en </entry>
     <entry lang="es" key="LINUX_SELECT_FREE_SLOT">Por favor, seleccione un espacio libre de unidad de la lista.</entry>

--- a/Translations/Language.et.xml
+++ b/Translations/Language.et.xml
@@ -1498,6 +1498,8 @@
     <entry lang="et" key="LINUX_REMOUNT_BECAUSEOF_SETTING">Pange tähele, et kõik praegu ühendatud köited tuleb enne selle sätte kasutamist uuesti ühendada.</entry>
     <entry lang="et" key="LINUX_UNKNOWN_EXC_OCCURRED">Tekkis tundmatu erand.</entry>
     <entry lang="et" key="LINUX_FIRST_AID">"Disk Utility käivitatakse pärast "OK" vajutamist.\n\nValige aknas Disk Utility oma köide ja vajutage lehel "Esmaabi" nuppu "Kinnita ketas" või "Paranda ketas".</entry>
+    <entry lang="en" key="MACOSX_CHECK_FILESYS">A Terminal window will open after you press 'OK' and check the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the check cannot be started, Disk Utility will be launched instead.</entry>
+    <entry lang="en" key="MACOSX_REPAIR_FILESYS">A Terminal window will open after you press 'OK' and attempt to repair the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the repair cannot be started, Disk Utility will be launched instead.</entry>
     <entry lang="et" key="LINUX_MOUNT_ALL_DEV">Ühendage kõik seadmed</entry>
     <entry lang="et" key="LINUX_ERROR_LOADING_CONFIG">Viga asukohas asuvate konfiguratsioonifailide laadimisel </entry>
     <entry lang="et" key="LINUX_SELECT_FREE_SLOT">Valige loendist vaba draivipesa.</entry>

--- a/Translations/Language.eu.xml
+++ b/Translations/Language.eu.xml
@@ -1498,6 +1498,8 @@
     <entry lang="eu" key="LINUX_REMOUNT_BECAUSEOF_SETTING">Kontuan izan unean muntatutako bolumenak berriro muntatu behar direla ezarpen hau erabili ahal izateko.</entry>
     <entry lang="eu" key="LINUX_UNKNOWN_EXC_OCCURRED">Salbuespen ezezaguna gertatu da.</entry>
     <entry lang="eu" key="LINUX_FIRST_AID">"Disko erabilgarritasuna abiaraziko da 'Ados' sakatu ondoren.\n\nMesedez, hautatu zure bolumena Disk Utility leihoan eta sakatu 'Egiaztatu diskoa' edo 'Konpon ezazu diskoa' botoia 'Lehen Laguntzak' orrian.</entry>
+    <entry lang="en" key="MACOSX_CHECK_FILESYS">A Terminal window will open after you press 'OK' and check the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the check cannot be started, Disk Utility will be launched instead.</entry>
+    <entry lang="en" key="MACOSX_REPAIR_FILESYS">A Terminal window will open after you press 'OK' and attempt to repair the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the repair cannot be started, Disk Utility will be launched instead.</entry>
     <entry lang="eu" key="LINUX_MOUNT_ALL_DEV">Muntatu gailu guztiak</entry>
     <entry lang="eu" key="LINUX_ERROR_LOADING_CONFIG">Errore bat gertatu da hemen kokatutako konfigurazio-fitxategiak kargatzean </entry>
     <entry lang="eu" key="LINUX_SELECT_FREE_SLOT">Mesedez, hautatu doako disko zirrikitua zerrendatik.</entry>

--- a/Translations/Language.fa.xml
+++ b/Translations/Language.fa.xml
@@ -1498,6 +1498,8 @@
     <entry lang="fa" key="LINUX_REMOUNT_BECAUSEOF_SETTING">لطفاً توجه داشته باشید که هر حجمی که در حال حاضر نصب شده است باید قبل از استفاده از این تنظیم مجدداً نصب شود.</entry>
     <entry lang="fa" key="LINUX_UNKNOWN_EXC_OCCURRED">استثنا ناشناخته رخ داد.</entry>
     <entry lang="fa" key="LINUX_FIRST_AID">پس از فشار دادن «قبول»، Disk Utility راه اندازی می شود.\n\nلطفاً حجم خود را در پنجره Disk Utility انتخاب کنید و دکمه "Verify Disk" یا "Repair Disk" را در صفحه "First Aid" فشار دهید.</entry>
+    <entry lang="en" key="MACOSX_CHECK_FILESYS">A Terminal window will open after you press 'OK' and check the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the check cannot be started, Disk Utility will be launched instead.</entry>
+    <entry lang="en" key="MACOSX_REPAIR_FILESYS">A Terminal window will open after you press 'OK' and attempt to repair the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the repair cannot be started, Disk Utility will be launched instead.</entry>
     <entry lang="fa" key="LINUX_MOUNT_ALL_DEV">نصب همه دستگاه ها</entry>
     <entry lang="fa" key="LINUX_ERROR_LOADING_CONFIG">خطا هنگام بارگیری فایل های پیکربندی واقع در </entry>
     <entry lang="fa" key="LINUX_SELECT_FREE_SLOT">لطفاً یک اسلات درایو رایگان از لیست انتخاب کنید.</entry>

--- a/Translations/Language.fi.xml
+++ b/Translations/Language.fi.xml
@@ -1498,6 +1498,8 @@
     <entry lang="fi" key="LINUX_REMOUNT_BECAUSEOF_SETTING">Ota huomioon, että jo liitettynä olevat taltiot tulee liittää uudelleen ennen kuin ne voivat käyttää tätä asetusta.</entry>
     <entry lang="fi" key="LINUX_UNKNOWN_EXC_OCCURRED">Tuntematon poikkeus tapahtui.</entry>
     <entry lang="fi" key="LINUX_FIRST_AID">Levytyökalu käynnistetään kun painat 'OK'.\n\nValitse ensin taltiosi Levytyökalussa ja paina 'Tarkista Levy' tai 'Korjaa Levy' nappulaa 'Korjaus' sivulla.</entry>
+    <entry lang="en" key="MACOSX_CHECK_FILESYS">A Terminal window will open after you press 'OK' and check the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the check cannot be started, Disk Utility will be launched instead.</entry>
+    <entry lang="en" key="MACOSX_REPAIR_FILESYS">A Terminal window will open after you press 'OK' and attempt to repair the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the repair cannot be started, Disk Utility will be launched instead.</entry>
     <entry lang="fi" key="LINUX_MOUNT_ALL_DEV">Liitä kaikki laitteet</entry>
     <entry lang="fi" key="LINUX_ERROR_LOADING_CONFIG">Virhe ladattaessa määritystiedostoa sijainnista </entry>
     <entry lang="fi" key="LINUX_SELECT_FREE_SLOT">Valitse vapaa paikka taltiolle listasta.</entry>

--- a/Translations/Language.fr.xml
+++ b/Translations/Language.fr.xml
@@ -1498,6 +1498,8 @@
     <entry lang="fr" key="LINUX_REMOUNT_BECAUSEOF_SETTING">Notez que tous les volumes actuellement montés doivent être démontés puis remontés avant que ce paramètre ne puisse être appliqué.</entry>
     <entry lang="fr" key="LINUX_UNKNOWN_EXC_OCCURRED">Une exception inconnue s'est produite.</entry>
     <entry lang="fr" key="LINUX_FIRST_AID">L'utilitaire de disque sera lancé après avoir appuyé sur 'OK'.\n\nVeuillez sélectionner votre volume dans la fenêtre de l'utilitaire de disque et cliquer sur le bouton 'Vérifier le disque' ou 'Réparer le disque' dans l'onglet 'Premiers secours'.</entry>
+    <entry lang="en" key="MACOSX_CHECK_FILESYS">A Terminal window will open after you press 'OK' and check the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the check cannot be started, Disk Utility will be launched instead.</entry>
+    <entry lang="en" key="MACOSX_REPAIR_FILESYS">A Terminal window will open after you press 'OK' and attempt to repair the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the repair cannot be started, Disk Utility will be launched instead.</entry>
     <entry lang="fr" key="LINUX_MOUNT_ALL_DEV">Tout Monter</entry>
     <entry lang="fr" key="LINUX_ERROR_LOADING_CONFIG">Erreur lors du chargement des fichiers de configuration situés dans </entry>
     <entry lang="fr" key="LINUX_SELECT_FREE_SLOT">Veuillez sélectionner un emplacement de lecteur libre dans la liste.</entry>

--- a/Translations/Language.he.xml
+++ b/Translations/Language.he.xml
@@ -1498,6 +1498,8 @@
     <entry lang="he" key="LINUX_REMOUNT_BECAUSEOF_SETTING">שים לב כי כל האמצעי אחסון המותקנים כרגע צריכים להיות מחוזרים לפני שהם יכולים להשתמש בהגדרה זו.</entry>
     <entry lang="he" key="LINUX_UNKNOWN_EXC_OCCURRED">חריג לא ידוע התרחש.</entry>
     <entry lang="he" key="LINUX_FIRST_AID">&amp;quot;תוכנית השירות לדיסק תושק לאחר שתלחץ על &amp;apos;אישור&amp;apos;. \n \n אנא בחר את אמצעי האחסון שלך בחלון כלי הדיסק ולחץ על &amp;apos;אמת דיסק&amp;apos; או &amp;apos;תיקון דיסק&amp;apos; בכפתור בעמוד &amp;apos;עזרה ראשונה&amp;apos;.</entry>
+    <entry lang="en" key="MACOSX_CHECK_FILESYS">A Terminal window will open after you press 'OK' and check the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the check cannot be started, Disk Utility will be launched instead.</entry>
+    <entry lang="en" key="MACOSX_REPAIR_FILESYS">A Terminal window will open after you press 'OK' and attempt to repair the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the repair cannot be started, Disk Utility will be launched instead.</entry>
     <entry lang="he" key="LINUX_MOUNT_ALL_DEV">טעינה את כל ההתקןים</entry>
     <entry lang="he" key="LINUX_ERROR_LOADING_CONFIG">שגיאה בעת טעינת קבצי תצורה הממוקמים ב</entry>
     <entry lang="he" key="LINUX_SELECT_FREE_SLOT">אנא בחר חריץ כונן חופשי מהרשימה.</entry>

--- a/Translations/Language.hu.xml
+++ b/Translations/Language.hu.xml
@@ -1498,6 +1498,8 @@
     <entry lang="hu" key="LINUX_REMOUNT_BECAUSEOF_SETTING">Felhívjuk figyelmét, hogy a beállítás használata előtt minden jelenleg csatlakoztatott kötetet újra kell csatlakoztatni.</entry>
     <entry lang="hu" key="LINUX_UNKNOWN_EXC_OCCURRED">Ismeretlen kivétel történt.</entry>
     <entry lang="hu" key="LINUX_FIRST_AID">"A lemezkezelő az 'OK' megnyomása után indul el.\n\nVálasszon kötetet a lemezkezelő ablakában, majd nyomja meg a 'Lemez ellenőrzése' vagy a 'Lemez javítása' gombot az 'Elsősegély' lapon.</entry>
+    <entry lang="en" key="MACOSX_CHECK_FILESYS">A Terminal window will open after you press 'OK' and check the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the check cannot be started, Disk Utility will be launched instead.</entry>
+    <entry lang="en" key="MACOSX_REPAIR_FILESYS">A Terminal window will open after you press 'OK' and attempt to repair the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the repair cannot be started, Disk Utility will be launched instead.</entry>
     <entry lang="hu" key="LINUX_MOUNT_ALL_DEV">Minden eszköz csatlakoztatása</entry>
     <entry lang="hu" key="LINUX_ERROR_LOADING_CONFIG">Hiba történt a következő helyen található konfigurációs fájlok betöltésekor: </entry>
     <entry lang="hu" key="LINUX_SELECT_FREE_SLOT">Válasszon egy szabad meghajtó nyílást a listából.</entry>

--- a/Translations/Language.id.xml
+++ b/Translations/Language.id.xml
@@ -1498,6 +1498,8 @@
     <entry lang="id" key="LINUX_REMOUNT_BECAUSEOF_SETTING">Harap dicatat bahwa setiap volume yang dipasang saat ini perlu dipasang ulang sebelum dapat menggunakan pengaturan ini.</entry>
     <entry lang="id" key="LINUX_UNKNOWN_EXC_OCCURRED">Pengecualian yang tidak diketahui terjadi.</entry>
     <entry lang="id" key="LINUX_FIRST_AID">Disk Utility akan diluncurkan setelah Anda menekan tombol 'OK'.\n\nPlease pilih volume Anda di jendela Disk Utility dan tekan tombol 'Verify Disk' atau 'Repair Disk' pada halaman 'Pertolongan Pertama'.</entry>
+    <entry lang="en" key="MACOSX_CHECK_FILESYS">A Terminal window will open after you press 'OK' and check the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the check cannot be started, Disk Utility will be launched instead.</entry>
+    <entry lang="en" key="MACOSX_REPAIR_FILESYS">A Terminal window will open after you press 'OK' and attempt to repair the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the repair cannot be started, Disk Utility will be launched instead.</entry>
     <entry lang="id" key="LINUX_MOUNT_ALL_DEV">Mount Semua Perangkat</entry>
     <entry lang="id" key="LINUX_ERROR_LOADING_CONFIG">Galat saat memuat file konfigurasi yang berada di </entry>
     <entry lang="id" key="LINUX_SELECT_FREE_SLOT">Silakan pilih slot drive gratis dari daftar.</entry>

--- a/Translations/Language.it.xml
+++ b/Translations/Language.it.xml
@@ -1498,6 +1498,8 @@
     <entry lang="it" key="LINUX_REMOUNT_BECAUSEOF_SETTING">Nota che prima di poter usare questa impostazione tutti i volumi attualmente montati devono essere rimontati.</entry>
     <entry lang="it" key="LINUX_UNKNOWN_EXC_OCCURRED">Si è verificata un'eccezione sconosciuta.</entry>
     <entry lang="it" key="LINUX_FIRST_AID">'Utilità disco' verrà avviata dopo aver selezionato 'OK'.\n\nSeleziona il volume nella finestra 'Utilità disco' e seleziona 'Verifica disco' o 'Ripara disco' nella pagina 'Pronto soccorso'.</entry>
+    <entry lang="en" key="MACOSX_CHECK_FILESYS">A Terminal window will open after you press 'OK' and check the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the check cannot be started, Disk Utility will be launched instead.</entry>
+    <entry lang="en" key="MACOSX_REPAIR_FILESYS">A Terminal window will open after you press 'OK' and attempt to repair the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the repair cannot be started, Disk Utility will be launched instead.</entry>
     <entry lang="it" key="LINUX_MOUNT_ALL_DEV">Monta tutti i dispositivi</entry>
     <entry lang="it" key="LINUX_ERROR_LOADING_CONFIG">Errore durante il caricamento dei file di configurazione situati in</entry>
     <entry lang="it" key="LINUX_SELECT_FREE_SLOT">Seleziona uno slot unità libero nell'elenco.</entry>

--- a/Translations/Language.ja.xml
+++ b/Translations/Language.ja.xml
@@ -1498,6 +1498,8 @@
     <entry lang="ja" key="LINUX_REMOUNT_BECAUSEOF_SETTING">現在マウントされているボリュームは、この設定を有効にする前に再マウントする必要があります。</entry>
     <entry lang="ja" key="LINUX_UNKNOWN_EXC_OCCURRED">不明な例外が発生しました。</entry>
     <entry lang="ja" key="LINUX_FIRST_AID">[OK] を押すと、ディスクユーティリティが起動します。\n\nディスクユーティリティウィンドウでボリュームを選択し、[First Aid] ページの [ディスクの検証] または [ディスクの修復] ボタンを押してください。</entry>
+    <entry lang="en" key="MACOSX_CHECK_FILESYS">A Terminal window will open after you press 'OK' and check the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the check cannot be started, Disk Utility will be launched instead.</entry>
+    <entry lang="en" key="MACOSX_REPAIR_FILESYS">A Terminal window will open after you press 'OK' and attempt to repair the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the repair cannot be started, Disk Utility will be launched instead.</entry>
     <entry lang="ja" key="LINUX_MOUNT_ALL_DEV">すべてのデバイスをマウントする</entry>
     <entry lang="ja" key="LINUX_ERROR_LOADING_CONFIG">にある構成ファイルの読み込み中にエラーが発生しました </entry>
     <entry lang="ja" key="LINUX_SELECT_FREE_SLOT">リストから空きドライブスロットを選択してください。</entry>

--- a/Translations/Language.ka.xml
+++ b/Translations/Language.ka.xml
@@ -1498,6 +1498,8 @@
     <entry lang="ka" key="LINUX_REMOUNT_BECAUSEOF_SETTING">გთხოვთ, გაითვალისწინოთ, რომ ამ პარამეტრის გამოყენებამდე ნებისმიერი ამჟამად დამონტაჟებული ტომი ხელახლა უნდა დამონტაჟდეს.</entry>
     <entry lang="ka" key="LINUX_UNKNOWN_EXC_OCCURRED">მოხდა უცნობი გამონაკლისი.</entry>
     <entry lang="ka" key="LINUX_FIRST_AID">"Disk Utility ამოქმედდება "OK"-ის დაჭერის შემდეგ.\n\nგთხოვთ, აირჩიოთ თქვენი ხმა Disk Utility ფანჯარაში და დააჭირეთ ღილაკს "Verify Disk" ან "Repair Disk" ღილაკზე "პირველი დახმარების" გვერდზე.</entry>
+    <entry lang="en" key="MACOSX_CHECK_FILESYS">A Terminal window will open after you press 'OK' and check the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the check cannot be started, Disk Utility will be launched instead.</entry>
+    <entry lang="en" key="MACOSX_REPAIR_FILESYS">A Terminal window will open after you press 'OK' and attempt to repair the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the repair cannot be started, Disk Utility will be launched instead.</entry>
     <entry lang="ka" key="LINUX_MOUNT_ALL_DEV">ყველა მოწყობილობის დამონტაჟება</entry>
     <entry lang="ka" key="LINUX_ERROR_LOADING_CONFIG">შეცდომა მდებარე კონფიგურაციის ფაილების ჩატვირთვისას </entry>
     <entry lang="ka" key="LINUX_SELECT_FREE_SLOT">გთხოვთ, აირჩიოთ დისკის უფასო სლოტი სიიდან.</entry>

--- a/Translations/Language.ko.xml
+++ b/Translations/Language.ko.xml
@@ -1498,6 +1498,8 @@
     <entry lang="ko" key="LINUX_REMOUNT_BECAUSEOF_SETTING">현재 설정을 적용하려면 현재 마운트된 볼륨들을 다시 마운트해야 합니다.</entry>
     <entry lang="ko" key="LINUX_UNKNOWN_EXC_OCCURRED">알 수 없는 오류가 발생했습니다.</entry>
     <entry lang="ko" key="LINUX_FIRST_AID">"'확인'을 누르면 디스크 유틸리티가 실행될 것입니다\n\n디스크 유틸리티 창에서 볼륨을 선택하고 '응급 처치' 페이지에서 '디스크 확인' 또는 '디스크 수리' 버튼을 누르십시오.</entry>
+    <entry lang="en" key="MACOSX_CHECK_FILESYS">A Terminal window will open after you press 'OK' and check the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the check cannot be started, Disk Utility will be launched instead.</entry>
+    <entry lang="en" key="MACOSX_REPAIR_FILESYS">A Terminal window will open after you press 'OK' and attempt to repair the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the repair cannot be started, Disk Utility will be launched instead.</entry>
     <entry lang="ko" key="LINUX_MOUNT_ALL_DEV">모든 장치 마운트</entry>
     <entry lang="ko" key="LINUX_ERROR_LOADING_CONFIG">특정 위치의 설정 파일 불러오기 실패: </entry>
     <entry lang="ko" key="LINUX_SELECT_FREE_SLOT">리스트에서 빈 드라이브 자리를 선택하세요.</entry>

--- a/Translations/Language.lv.xml
+++ b/Translations/Language.lv.xml
@@ -1498,6 +1498,8 @@
     <entry lang="lv" key="LINUX_REMOUNT_BECAUSEOF_SETTING">Lūdzu, ņemiet vērā, ka visi pašlaik pievienotie sējumi ir jāmontē atkārtoti, lai varētu izmantot šo iestatījumu.</entry>
     <entry lang="lv" key="LINUX_UNKNOWN_EXC_OCCURRED">Radās nezināms izņēmums.</entry>
     <entry lang="lv" key="LINUX_FIRST_AID">Diska utilīta tiks palaista pēc tam, kad būsit nospiedis OK.\n\nLūdzu, atlasiet savu sējumu diska utilīta logā un nospiediet pogu "Pārbaudīt disku" vai "Remontēt disku" lapā "Pirmā palīdzība".</entry>
+    <entry lang="en" key="MACOSX_CHECK_FILESYS">A Terminal window will open after you press 'OK' and check the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the check cannot be started, Disk Utility will be launched instead.</entry>
+    <entry lang="en" key="MACOSX_REPAIR_FILESYS">A Terminal window will open after you press 'OK' and attempt to repair the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the repair cannot be started, Disk Utility will be launched instead.</entry>
     <entry lang="lv" key="LINUX_MOUNT_ALL_DEV">Uzstādiet visas ierīces</entry>
     <entry lang="lv" key="LINUX_ERROR_LOADING_CONFIG">Kļūda, ielādējot konfigurācijas failus, kas atrodas </entry>
     <entry lang="lv" key="LINUX_SELECT_FREE_SLOT">Lūdzu, sarakstā atlasiet brīvu diska slotu.</entry>

--- a/Translations/Language.my.xml
+++ b/Translations/Language.my.xml
@@ -1500,6 +1500,8 @@
     <entry lang="my" key="LINUX_REMOUNT_BECAUSEOF_SETTING">ဤဆက်တင်ကို အသုံးမပြုမီ လတ်တလော အစပျိုးထားသော volume များကို ပြန်အစပျိုးရန် လိုအပ်ကြောင်း ကျေးဇူးပြု၍ သတိပြုပါ။</entry>
     <entry lang="my" key="LINUX_UNKNOWN_EXC_OCCURRED">အမည်မသိသော ခြွင်းချက် ဖြစ်ပေါ်ခဲ့သည်။</entry>
     <entry lang="my" key="LINUX_FIRST_AID">"သင် 'အိုကေ' ကို နှိပ်ပြီးနောက် Disk Utility ကို မိတ်ဆက်ပါမည်။\n\nကျေးဇူးပြု၍ Disk Utility ဝင်းဒိုးတွင် သင့် volume ကို ရွေးချယ်ပြီးနောက် 'First Aid' စာမျက်နှာရှိ 'ဒစ်(စ်)မှန်ကန်ကြောင်း စစ်ဆေးရန်' သို့မဟုတ် 'ဒစ်(စ်)ပြုပြင်ရန်' ခလုတ်ကို နှိပ်ပါ။</entry>
+    <entry lang="en" key="MACOSX_CHECK_FILESYS">A Terminal window will open after you press 'OK' and check the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the check cannot be started, Disk Utility will be launched instead.</entry>
+    <entry lang="en" key="MACOSX_REPAIR_FILESYS">A Terminal window will open after you press 'OK' and attempt to repair the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the repair cannot be started, Disk Utility will be launched instead.</entry>
     <entry lang="my" key="LINUX_MOUNT_ALL_DEV">စက်အားလုံးကို အစပျိုးရန်</entry>
     <entry lang="my" key="LINUX_ERROR_LOADING_CONFIG">ဤနေရာတွင် တည်ရှိသည့် အစိတ်အပိုင်းများဖွဲ့စည်းပုံဖိုင်များကို တင်နေစဉ် ပြဿနာ ဖြစ်ပေါ်ခဲ့သည်</entry>
     <entry lang="my" key="LINUX_SELECT_FREE_SLOT">ကျေးဇူးပြု၍ ဒရိုက်(ဗ်)အပေါက်လွတ်ကို စာရင်းမှ ရွေးချယ်ပါ။</entry>

--- a/Translations/Language.nb.xml
+++ b/Translations/Language.nb.xml
@@ -1498,6 +1498,8 @@
     <entry lang="nb" key="LINUX_REMOUNT_BECAUSEOF_SETTING">Vennligst merk at alle nåværende monterte volumer må monteres på nytt før de kan bruke denne innstillingen.</entry>
     <entry lang="nb" key="LINUX_UNKNOWN_EXC_OCCURRED">Ukjent unntak skjedde.</entry>
     <entry lang="nb" key="LINUX_FIRST_AID">Diskverktøy vil bli startet etter at du trykker «OK».\n\nVennligst velg volumet ditt i Diskverktøy-vinduet og trykk på «Verifiser Disk» eller «Reparer Disk»-knappen på «Førstehjelp»-siden.</entry>
+    <entry lang="en" key="MACOSX_CHECK_FILESYS">A Terminal window will open after you press 'OK' and check the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the check cannot be started, Disk Utility will be launched instead.</entry>
+    <entry lang="en" key="MACOSX_REPAIR_FILESYS">A Terminal window will open after you press 'OK' and attempt to repair the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the repair cannot be started, Disk Utility will be launched instead.</entry>
     <entry lang="nb" key="LINUX_MOUNT_ALL_DEV">Monter alle enheter</entry>
     <entry lang="nb" key="LINUX_ERROR_LOADING_CONFIG">Feil ved lasting av konfigurasjonsfiler lokalisert i</entry>
     <entry lang="nb" key="LINUX_SELECT_FREE_SLOT">Vennligst velg en ledig stasjonsbokstav fra listen.</entry>

--- a/Translations/Language.nl.xml
+++ b/Translations/Language.nl.xml
@@ -1498,6 +1498,8 @@
     <entry lang="nl" key="LINUX_REMOUNT_BECAUSEOF_SETTING">Merk op dat alle momenteel gekoppelde volumes opnieuw moeten worden gekoppeld vooraleer ze deze instelling kunnen gebruiken.</entry>
     <entry lang="nl" key="LINUX_UNKNOWN_EXC_OCCURRED">Er deed zich een onbekende uitzondering voor.</entry>
     <entry lang="nl" key="LINUX_FIRST_AID">Schijfhulp wordt gestart nadat u op "OK" hebt gedrukt.\n\nSelecteer uw volume in het venster van het schijfhulpprogramma en druk op de knop 'schijf controleren' of 'schijf herstellen' op de pagina 'eerste hulp'.</entry>
+    <entry lang="en" key="MACOSX_CHECK_FILESYS">A Terminal window will open after you press 'OK' and check the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the check cannot be started, Disk Utility will be launched instead.</entry>
+    <entry lang="en" key="MACOSX_REPAIR_FILESYS">A Terminal window will open after you press 'OK' and attempt to repair the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the repair cannot be started, Disk Utility will be launched instead.</entry>
     <entry lang="nl" key="LINUX_MOUNT_ALL_DEV">Alle apparaten koppelen</entry>
     <entry lang="nl" key="LINUX_ERROR_LOADING_CONFIG">Fout bij het laden van configuratiebestanden in </entry>
     <entry lang="nl" key="LINUX_SELECT_FREE_SLOT">Selecteer een vrij stationsslot uit de lijst.</entry>

--- a/Translations/Language.nn.xml
+++ b/Translations/Language.nn.xml
@@ -1498,6 +1498,8 @@
     <entry lang="nn" key="LINUX_REMOUNT_BECAUSEOF_SETTING">Ver merksam på at alle akkurat no monterte volum må monterast på nytt før dei kan bruka denne innstillinga.</entry>
     <entry lang="nn" key="LINUX_UNKNOWN_EXC_OCCURRED">Ukjent unntak skjedde.</entry>
     <entry lang="nn" key="LINUX_FIRST_AID">"Diskverktøy vil bli lansert etter at du trykkjer ’OK’.\n\nVel volumet ditt i Diskverktøy-vindauget og trykk på ’Bekreft disk’ eller ’Reparer disk’-knappen på ’Førstehjelp’-sidan.</entry>
+    <entry lang="en" key="MACOSX_CHECK_FILESYS">A Terminal window will open after you press 'OK' and check the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the check cannot be started, Disk Utility will be launched instead.</entry>
+    <entry lang="en" key="MACOSX_REPAIR_FILESYS">A Terminal window will open after you press 'OK' and attempt to repair the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the repair cannot be started, Disk Utility will be launched instead.</entry>
     <entry lang="nn" key="LINUX_MOUNT_ALL_DEV">Monter alle einingar</entry>
     <entry lang="nn" key="LINUX_ERROR_LOADING_CONFIG">Feil under innlasting av konfigurasjonsfiler som ligg i </entry>
     <entry lang="nn" key="LINUX_SELECT_FREE_SLOT">Vel ein gratis stasjonsplass frå lista.</entry>

--- a/Translations/Language.pl.xml
+++ b/Translations/Language.pl.xml
@@ -1498,6 +1498,8 @@
     <entry lang="pl" key="LINUX_REMOUNT_BECAUSEOF_SETTING">Należy pamiętać, że wszystkie aktualnie podłączone wolumeny muszą zostać ponownie podłączone, zanim będą mogły użyć tego ustawienia.</entry>
     <entry lang="pl" key="LINUX_UNKNOWN_EXC_OCCURRED">Wystąpił nieznany wyjątek.</entry>
     <entry lang="pl" key="LINUX_FIRST_AID">Narzędzie dyskowe zostanie uruchomione po naciśnięciu 'OK'.\n\nWybierz swój wolumen w oknie Narzędzia dyskowego i naciśnij przycisk 'Weryfikuj dysk' lub 'Napraw dysk' na stronie 'Pierwsza pomoc'.</entry>
+    <entry lang="en" key="MACOSX_CHECK_FILESYS">A Terminal window will open after you press 'OK' and check the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the check cannot be started, Disk Utility will be launched instead.</entry>
+    <entry lang="en" key="MACOSX_REPAIR_FILESYS">A Terminal window will open after you press 'OK' and attempt to repair the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the repair cannot be started, Disk Utility will be launched instead.</entry>
     <entry lang="pl" key="LINUX_MOUNT_ALL_DEV">Podłącz wszystkie urządzenia</entry>
     <entry lang="pl" key="LINUX_ERROR_LOADING_CONFIG">Błąd podczas ładowania plików konfiguracyjnych znajdujących się w </entry>
     <entry lang="pl" key="LINUX_SELECT_FREE_SLOT">Wybierz wolne miejsce na dysk z listy.</entry>

--- a/Translations/Language.pt-br.xml
+++ b/Translations/Language.pt-br.xml
@@ -1498,6 +1498,8 @@
     <entry lang="pt-br" key="LINUX_REMOUNT_BECAUSEOF_SETTING">Observe que qualquer volume atualmente montado precisará ser remontado para usar esta configuração.</entry>
     <entry lang="pt-br" key="LINUX_UNKNOWN_EXC_OCCURRED">Ocorreu uma exceção desconhecida.</entry>
     <entry lang="pt-br" key="LINUX_FIRST_AID">"O Utilitário de Disco será iniciado após você pressionar 'OK'.\n\nPor favor, selecione seu volume na janela do Utilitário de Disco e pressione o botão 'Verificar Disco' ou 'Reparar Disco' na página 'Primeiros Socorros'.</entry>
+    <entry lang="en" key="MACOSX_CHECK_FILESYS">A Terminal window will open after you press 'OK' and check the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the check cannot be started, Disk Utility will be launched instead.</entry>
+    <entry lang="en" key="MACOSX_REPAIR_FILESYS">A Terminal window will open after you press 'OK' and attempt to repair the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the repair cannot be started, Disk Utility will be launched instead.</entry>
     <entry lang="pt-br" key="LINUX_MOUNT_ALL_DEV">Montar Todos os Dispositivos</entry>
     <entry lang="pt-br" key="LINUX_ERROR_LOADING_CONFIG">Erro ao carregar os arquivos de configuração localizados em </entry>
     <entry lang="pt-br" key="LINUX_SELECT_FREE_SLOT">Por favor, selecione um slot de unidade livre da lista.</entry>

--- a/Translations/Language.ro.xml
+++ b/Translations/Language.ro.xml
@@ -1498,6 +1498,8 @@
     <entry lang="ro" key="LINUX_REMOUNT_BECAUSEOF_SETTING">Orice volum montat acum trebuie să fie remontat înainte de a folosi această setare.</entry>
     <entry lang="ro" key="LINUX_UNKNOWN_EXC_OCCURRED">A apărut o excepție necunoscută.</entry>
     <entry lang="ro" key="LINUX_FIRST_AID">„Utilitarul pentru discuri” va fi lansat după ce apăsați pe «OK».\n\nSelectați volumul în fereastra utilizatorului și apăsați butonul „Verificare disc” sau „Reparare disc” pe pagina „Primul ajutor”.</entry>
+    <entry lang="en" key="MACOSX_CHECK_FILESYS">A Terminal window will open after you press 'OK' and check the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the check cannot be started, Disk Utility will be launched instead.</entry>
+    <entry lang="en" key="MACOSX_REPAIR_FILESYS">A Terminal window will open after you press 'OK' and attempt to repair the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the repair cannot be started, Disk Utility will be launched instead.</entry>
     <entry lang="ro" key="LINUX_MOUNT_ALL_DEV">Montare toate dispozitivele</entry>
     <entry lang="ro" key="LINUX_ERROR_LOADING_CONFIG">Eroare la încărcarea fișierele de configurare aflate în </entry>
     <entry lang="ro" key="LINUX_SELECT_FREE_SLOT">Selectați o literă de unitate liberă din listă.</entry>

--- a/Translations/Language.ru.xml
+++ b/Translations/Language.ru.xml
@@ -1498,6 +1498,8 @@
     <entry lang="ru" key="LINUX_REMOUNT_BECAUSEOF_SETTING">Учтите, что все сейчас смонтированные тома нужно размонтировать, прежде чем они смогут использовать эту настройку.</entry>
     <entry lang="ru" key="LINUX_UNKNOWN_EXC_OCCURRED">Произошло неизвестное исключение.</entry>
     <entry lang="ru" key="LINUX_FIRST_AID">"При нажатии OK будет запущена утилита управления дисками (Disk Utility).\n\nВыберите в её окне ваш том и нажмите кнопку проверки или починки диска ("Verify Disk" или "Repair Disk") на странице первой помощи ("First Aid").</entry>
+    <entry lang="en" key="MACOSX_CHECK_FILESYS">A Terminal window will open after you press 'OK' and check the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the check cannot be started, Disk Utility will be launched instead.</entry>
+    <entry lang="en" key="MACOSX_REPAIR_FILESYS">A Terminal window will open after you press 'OK' and attempt to repair the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the repair cannot be started, Disk Utility will be launched instead.</entry>
     <entry lang="ru" key="LINUX_MOUNT_ALL_DEV">Смонтировать все устройства</entry>
     <entry lang="ru" key="LINUX_ERROR_LOADING_CONFIG">Ошибка при загрузке файлов конфигурации в </entry>
     <entry lang="ru" key="LINUX_SELECT_FREE_SLOT">Выберите в списке свободный слот диска.</entry>

--- a/Translations/Language.sk.xml
+++ b/Translations/Language.sk.xml
@@ -1498,6 +1498,8 @@
     <entry lang="sk" key="LINUX_REMOUNT_BECAUSEOF_SETTING">Upozorňujeme, že všetky aktuálne pripojené zväzky je potrebné pred použitím tohto nastavenia znova pripojiť.</entry>
     <entry lang="sk" key="LINUX_UNKNOWN_EXC_OCCURRED">Vyskytla sa neznáma výnimka.</entry>
     <entry lang="sk" key="LINUX_FIRST_AID">"Disk Utility sa spustí po stlačení 'OK'.\n\nV okne Disk Utility vyberte svoj zväzok a stlačte tlačidlo „Overiť disk“ alebo „Opraviť disk“ na stránke „Prvá pomoc“.</entry>
+    <entry lang="en" key="MACOSX_CHECK_FILESYS">A Terminal window will open after you press 'OK' and check the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the check cannot be started, Disk Utility will be launched instead.</entry>
+    <entry lang="en" key="MACOSX_REPAIR_FILESYS">A Terminal window will open after you press 'OK' and attempt to repair the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the repair cannot be started, Disk Utility will be launched instead.</entry>
     <entry lang="sk" key="LINUX_MOUNT_ALL_DEV">Namontujte všetky zariadenia</entry>
     <entry lang="sk" key="LINUX_ERROR_LOADING_CONFIG">Chyba pri načítavaní konfiguračných súborov umiestnených v </entry>
     <entry lang="sk" key="LINUX_SELECT_FREE_SLOT">Vyberte si zo zoznamu voľný diskový slot.</entry>

--- a/Translations/Language.sl.xml
+++ b/Translations/Language.sl.xml
@@ -1498,6 +1498,8 @@
     <entry lang="sl" key="LINUX_REMOUNT_BECAUSEOF_SETTING">Upoštevaj, da je treba vse trenutno nameščene nosilce znova namestiti, preden lahko uporabljajo to nastavitev.</entry>
     <entry lang="sl" key="LINUX_UNKNOWN_EXC_OCCURRED">Prišlo je do neznane izjeme.</entry>
     <entry lang="sl" key="LINUX_FIRST_AID">"Disk Utility se bo zagnal, ko pritisneš 'V redu'.\n\nIzberi svoj nosilec v oknu Disk Utility in pritisni gumb 'Preveri disk' ali 'Popravi disk' na strani 'Prva pomoč'.</entry>
+    <entry lang="en" key="MACOSX_CHECK_FILESYS">A Terminal window will open after you press 'OK' and check the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the check cannot be started, Disk Utility will be launched instead.</entry>
+    <entry lang="en" key="MACOSX_REPAIR_FILESYS">A Terminal window will open after you press 'OK' and attempt to repair the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the repair cannot be started, Disk Utility will be launched instead.</entry>
     <entry lang="sl" key="LINUX_MOUNT_ALL_DEV">Priklop vseh naprav</entry>
     <entry lang="sl" key="LINUX_ERROR_LOADING_CONFIG">Napaka pri nalaganju konfiguracijskih datotek, ki se nahajajo v</entry>
     <entry lang="sl" key="LINUX_SELECT_FREE_SLOT">Na seznamu izberi prosto režo za pogon.</entry>

--- a/Translations/Language.sv.xml
+++ b/Translations/Language.sv.xml
@@ -1498,6 +1498,8 @@
     <entry lang="sv" key="LINUX_REMOUNT_BECAUSEOF_SETTING">Observera att alla för närvarande monterade volymer måste monteras om innan de kan använda den här inställningen.</entry>
     <entry lang="sv" key="LINUX_UNKNOWN_EXC_OCCURRED">Okänt undantag inträffade.</entry>
     <entry lang="sv" key="LINUX_FIRST_AID">"Diskverktyget kommer att startas när du trycker på "OK".\n\nVälj din volym i fönstret Diskverktyget och tryck på "Verifiera disk" eller "Reparera disk"-knappen på "Första hjälp"-sidan.</entry>
+    <entry lang="en" key="MACOSX_CHECK_FILESYS">A Terminal window will open after you press 'OK' and check the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the check cannot be started, Disk Utility will be launched instead.</entry>
+    <entry lang="en" key="MACOSX_REPAIR_FILESYS">A Terminal window will open after you press 'OK' and attempt to repair the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the repair cannot be started, Disk Utility will be launched instead.</entry>
     <entry lang="sv" key="LINUX_MOUNT_ALL_DEV">Montera alla enheter</entry>
     <entry lang="sv" key="LINUX_ERROR_LOADING_CONFIG">Fel vid inläsning av konfigurationsfiler som finns i </entry>
     <entry lang="sv" key="LINUX_SELECT_FREE_SLOT">Välj en ledig enhetsplats från listan.</entry>

--- a/Translations/Language.th.xml
+++ b/Translations/Language.th.xml
@@ -1498,6 +1498,8 @@
     <entry lang="th" key="LINUX_REMOUNT_BECAUSEOF_SETTING">โปรดทราบว่าปริมาณที่ติดตั้งอยู่ในปัจจุบันต้องถูกติดตั้งใหม่ก่อนที่พวกมันจะสามารถใช้การตั้งค่านี้ได้.</entry>
     <entry lang="th" key="LINUX_UNKNOWN_EXC_OCCURRED">เกิดข้อผิดพลาดไม่ทราบ.</entry>
     <entry lang="th" key="LINUX_FIRST_AID">ยูทิลิตี้ดิสก์จะเปิดหลังจากที่คุณกด 'ตกลง'.\n\nโปรดเลือกปริมาณของคุณในหน้าต่างยูทิลิตี้ดิสก์และกดปุ่ม 'ตรวจสอบดิสก์' หรือ 'ซ่อมแซมดิสก์' ในหน้าความช่วยเหลือเบื้องต้น.</entry>
+    <entry lang="en" key="MACOSX_CHECK_FILESYS">A Terminal window will open after you press 'OK' and check the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the check cannot be started, Disk Utility will be launched instead.</entry>
+    <entry lang="en" key="MACOSX_REPAIR_FILESYS">A Terminal window will open after you press 'OK' and attempt to repair the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the repair cannot be started, Disk Utility will be launched instead.</entry>
     <entry lang="th" key="LINUX_MOUNT_ALL_DEV">ติดตั้งอุปกรณ์ทั้งหมด</entry>
     <entry lang="th" key="LINUX_ERROR_LOADING_CONFIG">ข้อผิดพลาดขณะโหลดไฟล์การตั้งค้าที่อยู่ใน</entry>
     <entry lang="th" key="LINUX_SELECT_FREE_SLOT">โปรดเลือกตัวอักษรไดรฟ์ที่ว่างจากรายการ.</entry>

--- a/Translations/Language.tr.xml
+++ b/Translations/Language.tr.xml
@@ -1498,6 +1498,8 @@
     <entry lang="tr" key="LINUX_REMOUNT_BECAUSEOF_SETTING">Şu anda bağlı olan birimlerin bu ayarı kullanabilmeleri için yeniden bağlanması gerektiğini lütfen unutmayın.</entry>
     <entry lang="tr" key="LINUX_UNKNOWN_EXC_OCCURRED">Bilinmeyen bir sorun çıktı.</entry>
     <entry lang="tr" key="LINUX_FIRST_AID">"'Tamam' üzerine tıkladığınızda Disk Aracı başlatılır.\n\nLütfen Disk Aracı penceresinden biriminizi seçin ve 'İlk yardım' sayfasında 'Diski doğrula' ya da 'Diski onar' üzerine tıklayın.</entry>
+    <entry lang="en" key="MACOSX_CHECK_FILESYS">A Terminal window will open after you press 'OK' and check the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the check cannot be started, Disk Utility will be launched instead.</entry>
+    <entry lang="en" key="MACOSX_REPAIR_FILESYS">A Terminal window will open after you press 'OK' and attempt to repair the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the repair cannot be started, Disk Utility will be launched instead.</entry>
     <entry lang="tr" key="LINUX_MOUNT_ALL_DEV">Tüm aygıtları bağla</entry>
     <entry lang="tr" key="LINUX_ERROR_LOADING_CONFIG">Şuradaki yapılandırma dosyaları yüklenirken sorun çıktı </entry>
     <entry lang="tr" key="LINUX_SELECT_FREE_SLOT">Lütfen listeden boştaki bir sürücü konumu seçin.</entry>

--- a/Translations/Language.uk.xml
+++ b/Translations/Language.uk.xml
@@ -1498,6 +1498,8 @@
     <entry lang="uk" key="LINUX_REMOUNT_BECAUSEOF_SETTING">Зверніть увагу, що всі томи, які зараз змонтовані, повинні бути перемонтовані перед тим, як вони зможуть використовувати цей параметр.</entry>
     <entry lang="uk" key="LINUX_UNKNOWN_EXC_OCCURRED">Сталася невідома помилка.</entry>
     <entry lang="uk" key="LINUX_FIRST_AID">"Утиліта Диска буде запущена після натискання 'OK'.\n\nБудь ласка, виберіть свій том у вікні Утиліти Диска та натисніть кнопку 'Перевірити диск' або 'Відновити диск' на сторінці 'Перша допомога'.</entry>
+    <entry lang="en" key="MACOSX_CHECK_FILESYS">A Terminal window will open after you press 'OK' and check the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the check cannot be started, Disk Utility will be launched instead.</entry>
+    <entry lang="en" key="MACOSX_REPAIR_FILESYS">A Terminal window will open after you press 'OK' and attempt to repair the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the repair cannot be started, Disk Utility will be launched instead.</entry>
     <entry lang="uk" key="LINUX_MOUNT_ALL_DEV">Монтувати всі пристрої</entry>
     <entry lang="uk" key="LINUX_ERROR_LOADING_CONFIG">Помилка під час завантаження файлів конфігурації, розташованих в </entry>
     <entry lang="uk" key="LINUX_SELECT_FREE_SLOT">Будь ласка, виберіть вільний слот для диска зі списку.</entry>

--- a/Translations/Language.uz.xml
+++ b/Translations/Language.uz.xml
@@ -1498,6 +1498,8 @@
     <entry lang="uz" key="LINUX_REMOUNT_BECAUSEOF_SETTING">Шуни есда тутингки, ҳозирда ўрнатилган жилдлар ушбу созламадан фойдаланишдан олдин қайта ўрнатилиши керак.</entry>
     <entry lang="uz" key="LINUX_UNKNOWN_EXC_OCCURRED">Нома'лум истисно юз берди.</entry>
     <entry lang="uz" key="LINUX_FIRST_AID">"Ок" тугмасини босганингиздан сўнг Диск Утилитй ишга тушади.\n\nИлтимос, Диск Утилитй ойнасида томни танланг ва "Биринчи ёрдам" саҳифасида "Дискни текшириш" ёки "Дискни тузатиш" тугмасини босинг.</entry>
+    <entry lang="en" key="MACOSX_CHECK_FILESYS">A Terminal window will open after you press 'OK' and check the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the check cannot be started, Disk Utility will be launched instead.</entry>
+    <entry lang="en" key="MACOSX_REPAIR_FILESYS">A Terminal window will open after you press 'OK' and attempt to repair the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the repair cannot be started, Disk Utility will be launched instead.</entry>
     <entry lang="uz" key="LINUX_MOUNT_ALL_DEV">Барча қурилмаларни ўрнатиш</entry>
     <entry lang="uz" key="LINUX_ERROR_LOADING_CONFIG">жойлашган конфигуратсия файлларини юклашда хатолик юз берди </entry>
     <entry lang="uz" key="LINUX_SELECT_FREE_SLOT">Илтимос, рўйхатдан бепул ҳайдовчи уйини танланг.</entry>

--- a/Translations/Language.vi.xml
+++ b/Translations/Language.vi.xml
@@ -1498,6 +1498,8 @@
     <entry lang="vi" key="LINUX_REMOUNT_BECAUSEOF_SETTING">Xin lưu ý rằng mọi tập đĩa hiện đang được gắn đều phải được gắn lại trước khi chúng có thể sử dụng cài đặt này.</entry>
     <entry lang="vi" key="LINUX_UNKNOWN_EXC_OCCURRED">Đã xảy ra ngoại lệ không xác định.</entry>
     <entry lang="vi" key="LINUX_FIRST_AID">"Disk Utility sẽ được khởi chạy sau khi bạn nhấn 'OK'.\n\nVui lòng chọn ổ đĩa của bạn trong cửa sổ Disk Utility và nhấn nút 'Xác minh đĩa' hoặc 'Sửa đĩa' trên trang 'Sơ cứu'.</entry>
+    <entry lang="en" key="MACOSX_CHECK_FILESYS">A Terminal window will open after you press 'OK' and check the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the check cannot be started, Disk Utility will be launched instead.</entry>
+    <entry lang="en" key="MACOSX_REPAIR_FILESYS">A Terminal window will open after you press 'OK' and attempt to repair the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the repair cannot be started, Disk Utility will be launched instead.</entry>
     <entry lang="vi" key="LINUX_MOUNT_ALL_DEV">Gắn tất cả các thiết bị</entry>
     <entry lang="vi" key="LINUX_ERROR_LOADING_CONFIG">Lỗi khi tải tập tin cấu hình nằm trong </entry>
     <entry lang="vi" key="LINUX_SELECT_FREE_SLOT">Vui lòng chọn một khe cắm ổ đĩa miễn phí từ danh sách.</entry>

--- a/Translations/Language.zh-cn.xml
+++ b/Translations/Language.zh-cn.xml
@@ -1499,6 +1499,8 @@
     <entry lang="zh-cn" key="LINUX_REMOUNT_BECAUSEOF_SETTING">请注意，任何当前已装载的卷都需要重新装载才能应用此设置。</entry>
     <entry lang="zh-cn" key="LINUX_UNKNOWN_EXC_OCCURRED">发生未知异常。</entry>
     <entry lang="zh-cn" key="LINUX_FIRST_AID">磁盘实用程序将在您按下“确定”后启动。\n\n请在“磁盘实用程序”窗口选择您的卷，然后按“急救”页上的“验证磁盘”或“修复磁盘”按钮。</entry>
+    <entry lang="en" key="MACOSX_CHECK_FILESYS">A Terminal window will open after you press 'OK' and check the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the check cannot be started, Disk Utility will be launched instead.</entry>
+    <entry lang="en" key="MACOSX_REPAIR_FILESYS">A Terminal window will open after you press 'OK' and attempt to repair the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the repair cannot be started, Disk Utility will be launched instead.</entry>
     <entry lang="zh-cn" key="LINUX_MOUNT_ALL_DEV">装载所有设备</entry>
     <entry lang="zh-cn" key="LINUX_ERROR_LOADING_CONFIG">加载此处的配置文件时出错：</entry>
     <entry lang="zh-cn" key="LINUX_SELECT_FREE_SLOT">请从列表中选择一个可用驱动器插槽。</entry>

--- a/Translations/Language.zh-hk.xml
+++ b/Translations/Language.zh-hk.xml
@@ -1498,6 +1498,8 @@
     <entry lang="zh-hk" key="LINUX_REMOUNT_BECAUSEOF_SETTING">請注意在可以使用這項設定之前需要重新掛載現正已掛載的加密區。</entry>
     <entry lang="zh-hk" key="LINUX_UNKNOWN_EXC_OCCURRED">發生未知的例外情況。</entry>
     <entry lang="zh-hk" key="LINUX_FIRST_AID">"磁碟工具將會在按下 [確定] 之後啟動。\n\n請在磁碟工具中選擇你的磁碟區，然後在 [救援] 頁面中按 [檢查磁碟] 或 [修復磁碟]。</entry>
+    <entry lang="en" key="MACOSX_CHECK_FILESYS">A Terminal window will open after you press 'OK' and check the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the check cannot be started, Disk Utility will be launched instead.</entry>
+    <entry lang="en" key="MACOSX_REPAIR_FILESYS">A Terminal window will open after you press 'OK' and attempt to repair the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the repair cannot be started, Disk Utility will be launched instead.</entry>
     <entry lang="zh-hk" key="LINUX_MOUNT_ALL_DEV">掛載所有裝置</entry>
     <entry lang="zh-hk" key="LINUX_ERROR_LOADING_CONFIG">載入設定檔案時發生錯誤位於</entry>
     <entry lang="zh-hk" key="LINUX_SELECT_FREE_SLOT">請在列表中選擇未使用的磁碟機位置。</entry>

--- a/Translations/Language.zh-tw.xml
+++ b/Translations/Language.zh-tw.xml
@@ -1498,6 +1498,8 @@
     <entry lang="zh-tw" key="LINUX_REMOUNT_BECAUSEOF_SETTING">請注意，目前已掛載的任何加密區都需要重新掛載才能使用此設定。</entry>
     <entry lang="zh-tw" key="LINUX_UNKNOWN_EXC_OCCURRED">發生未知異常。</entry>
     <entry lang="zh-tw" key="LINUX_FIRST_AID">「按『確定』後將啟動磁碟工具。\n\n請在「磁碟工具」視窗中選擇您的捲，然後按下「急救」頁面上的「驗證磁碟」或「修復磁碟」按鈕。</entry>
+    <entry lang="en" key="MACOSX_CHECK_FILESYS">A Terminal window will open after you press 'OK' and check the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the check cannot be started, Disk Utility will be launched instead.</entry>
+    <entry lang="en" key="MACOSX_REPAIR_FILESYS">A Terminal window will open after you press 'OK' and attempt to repair the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the repair cannot be started, Disk Utility will be launched instead.</entry>
     <entry lang="zh-tw" key="LINUX_MOUNT_ALL_DEV">掛載所有設備</entry>
     <entry lang="zh-tw" key="LINUX_ERROR_LOADING_CONFIG">載入位於以下位置的設定檔時發生錯誤 </entry>
     <entry lang="zh-tw" key="LINUX_SELECT_FREE_SLOT">請從清單中選擇一個空閒磁碟機插槽。</entry>

--- a/src/Common/Language.xml
+++ b/src/Common/Language.xml
@@ -1498,6 +1498,8 @@
     <entry lang="en" key="LINUX_REMOUNT_BECAUSEOF_SETTING">Please note that any currently mounted volumes need to be remounted before they can use this setting.</entry>
     <entry lang="en" key="LINUX_UNKNOWN_EXC_OCCURRED">Unknown exception occurred.</entry>
     <entry lang="en" key="LINUX_FIRST_AID">"Disk Utility will be launched after you press 'OK'.\n\nPlease select your volume in the Disk Utility window and press 'Verify Disk' or 'Repair Disk' button on the 'First Aid' page.</entry>
+    <entry lang="en" key="MACOSX_CHECK_FILESYS">A Terminal window will open after you press 'OK' and check the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the check cannot be started, Disk Utility will be launched instead.</entry>
+    <entry lang="en" key="MACOSX_REPAIR_FILESYS">A Terminal window will open after you press 'OK' and attempt to repair the file system on the selected VeraCrypt volume using 'diskutil'. The result will be shown in that window.\n\nIf the repair cannot be started, Disk Utility will be launched instead.</entry>
     <entry lang="en" key="LINUX_MOUNT_ALL_DEV">Mount All Devices</entry>
     <entry lang="en" key="LINUX_ERROR_LOADING_CONFIG">Error while loading configuration files located in </entry>
     <entry lang="en" key="LINUX_SELECT_FREE_SLOT">Please select a free drive slot from the list.</entry>

--- a/src/Core/Unix/CoreServiceProxy.h
+++ b/src/Core/Unix/CoreServiceProxy.h
@@ -27,7 +27,17 @@ namespace VeraCrypt
 
 		virtual void CheckFilesystem (shared_ptr <VolumeInfo> mountedVolume, bool repair) const
 		{
+#ifdef TC_MACOSX
+			// On macOS the check runs diskutil against the VeraCrypt virtual device
+			// and shows the result in a Terminal window; neither needs root. Run it
+			// in this (unprivileged) application process directly: once a device-hosted
+			// mount has started the elevated core service, every request is routed to
+			// that root process, which would create the helper script as root and open
+			// a Terminal the GUI-session user cannot read or execute.
+			T::CheckFilesystem (mountedVolume, repair);
+#else
 			CoreService::RequestCheckFilesystem (mountedVolume, repair);
+#endif
 		}
 
 		virtual void DismountFilesystem (const DirectoryPath &mountPoint, bool force) const

--- a/src/Core/Unix/MacOSX/CoreMacOSX.cpp
+++ b/src/Core/Unix/MacOSX/CoreMacOSX.cpp
@@ -11,7 +11,9 @@
 */
 
 #include <fstream>
+#include <errno.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <unistd.h>
 #include <vector>
 #include <CoreFoundation/CoreFoundation.h>
@@ -382,8 +384,151 @@ namespace VeraCrypt
 		}
 	}
 
+	// Strict /dev/diskN or /dev/rdiskN (optionally sN) device-node check so a value
+	// can be embedded safely in a generated shell command.
+	static bool IsPlainDiskDevicePath (const string &path)
+	{
+		size_t index;
+		if (path.compare (0, 10, "/dev/rdisk") == 0)
+			index = 10;
+		else if (path.compare (0, 9, "/dev/disk") == 0)
+			index = 9;
+		else
+			return false;
+
+		size_t digitsStart = index;
+		while (index < path.size() && path[index] >= '0' && path[index] <= '9')
+			++index;
+		if (index == digitsStart)
+			return false;
+
+		if (index == path.size())
+			return true;
+
+		if (path[index++] != 's')
+			return false;
+
+		size_t sliceStart = index;
+		while (index < path.size() && path[index] >= '0' && path[index] <= '9')
+			++index;
+
+		return index > sliceStart && index == path.size();
+	}
+
 	void CoreMacOSX::CheckFilesystem (shared_ptr <VolumeInfo> mountedVolume, bool repair) const
 	{
+		// Honor the check-vs-repair distinction by running diskutil on the VeraCrypt
+		// virtual device (diskutil unmounts the inner filesystem itself as needed).
+		// The Core layer has no GUI, so results are shown in a Terminal window via a
+		// temporary .command script. Falls back to launching Disk Utility.app.
+		if (mountedVolume && !mountedVolume->VirtualDevice.IsEmpty())
+		{
+			const string device = mountedVolume->VirtualDevice;
+
+			if (IsPlainDiskDevicePath (device))
+			{
+				try
+				{
+					const string verb = repair ? "repairVolume" : "verifyVolume";
+
+					// Create the script securely: a predictable name in the
+					// world-writable /tmp invites a symlink/race attack (the file is
+					// later executed, and this path can run elevated). Use the
+					// per-user temp directory (owned, 0700) and mkstemps(), which
+					// creates the file atomically with O_EXCL while keeping the
+					// ".command" suffix that makes /usr/bin/open launch Terminal.
+					string tempDir;
+					{
+						char dirBuf[MAXPATHLEN];
+						size_t n = confstr (_CS_DARWIN_USER_TEMP_DIR, dirBuf, sizeof (dirBuf));
+						if (n > 0 && n <= sizeof (dirBuf))
+							tempDir = dirBuf;
+						else if (const char *t = getenv ("TMPDIR"))
+							tempDir = t;
+						else
+							tempDir = "/tmp/";
+					}
+					if (tempDir.empty() || tempDir[tempDir.size() - 1] != '/')
+						tempDir += '/';
+
+					const char suffix[] = ".command";
+					string templ = tempDir + "VeraCrypt-fsck-XXXXXXXX" + suffix;
+					vector <char> templBuf (templ.begin(), templ.end());
+					templBuf.push_back ('\0');
+
+					int fd = mkstemps (&templBuf[0], static_cast <int> (sizeof (suffix) - 1));
+					if (fd == -1)
+						throw ParameterIncorrect (SRC_POS);
+
+					const string scriptPath (&templBuf[0]);
+
+					try
+					{
+						// Always show diskutil's result (including failures) and
+						// pause; this is why the script captures $? rather than
+						// using "set -e", which would abort before the prompt.
+						const string contents =
+							string ("#!/bin/sh\n")
+							+ "trap 'rm -f \"$0\"' EXIT\n"	// remove the script even if the window is closed early
+							+ "/usr/sbin/diskutil " + verb + " '" + device + "'\n"
+							+ "status=$?\n"
+							+ "echo\n"
+							+ "echo 'Press Enter to close this window.'\n"
+							+ "read dummy\n"
+							+ "exit $status\n";
+
+						size_t off = 0;
+						while (off < contents.size())
+						{
+							ssize_t written = write (fd, contents.data() + off, contents.size() - off);
+							if (written < 0)
+							{
+								if (errno == EINTR)
+									continue;
+								throw ParameterIncorrect (SRC_POS);
+							}
+							off += static_cast <size_t> (written);
+						}
+
+						// fchmod on the fd (not the path) keeps this race-free.
+						if (fchmod (fd, 0700) != 0)
+							throw ParameterIncorrect (SRC_POS);
+
+						if (close (fd) != 0)	// surfaces deferred write errors
+							throw ParameterIncorrect (SRC_POS);
+						fd = -1;
+					}
+					catch (...)
+					{
+						if (fd != -1)
+							close (fd);
+						unlink (scriptPath.c_str());
+						throw;
+					}
+
+					try
+					{
+						list <string> openArgs;
+						openArgs.push_back (scriptPath);
+						Process::Execute ("/usr/bin/open", openArgs);
+					}
+					catch (...)
+					{
+						// open failed before Terminal could take ownership of the
+						// script (the EXIT trap never runs), so remove it here
+						// rather than leaking it into the temp directory.
+						unlink (scriptPath.c_str());
+						throw;
+					}
+					return;
+				}
+				catch (...)
+				{
+					// Fall back to Disk Utility below.
+				}
+			}
+		}
+
 		list <string> args;
 		struct stat sb;
 

--- a/src/Main/Forms/MainFrame.cpp
+++ b/src/Main/Forms/MainFrame.cpp
@@ -228,7 +228,7 @@ namespace VeraCrypt
 					L"cmd.exe", args.c_str(), nullptr, SW_SHOW);
 #else
 #	ifdef TC_MACOSX
-				Gui->ShowInfo (LangString["LINUX_FIRST_AID"]);
+				Gui->ShowInfo (LangString[repair ? "MACOSX_REPAIR_FILESYS" : "MACOSX_CHECK_FILESYS"]);
 #	endif
 				Core->CheckFilesystem (selectedVolume, repair);
 				UpdateVolumeList();


### PR DESCRIPTION
Fixes #1789.

### Problem

On macOS, **Check Filesystem** and **Repair Filesystem** did not honor the selected operation. `CoreMacOSX::CheckFilesystem()` ignored the `repair` flag and only launched `Disk Utility.app` without targeting the selected VeraCrypt volume. As a result, the UI could not directly run a check or repair on the mounted volume.

### Fix

Run `diskutil` against the mounted VeraCrypt virtual device:

- **Check Filesystem** runs `diskutil verifyVolume`
- **Repair Filesystem** runs `diskutil repairVolume`

The result is shown in a Terminal window through a temporary `.command` helper script. If no suitable virtual device is available, VeraCrypt falls back to launching `Disk Utility.app`.

On macOS, `CoreServiceProxy::CheckFilesystem()` now calls the local macOS implementation directly instead of forwarding the request through `CoreService`. This keeps the helper script in the GUI user context even after an elevated device-hosted mount, avoiding root-owned temporary scripts and unreadable/unusable Terminal sessions.

### Safety

- The device path is strictly validated as `/dev/diskN`, `/dev/rdiskN`, or the corresponding slice form before it is embedded in the helper script.
- The helper script is created in the per-user temporary directory using `mkstemps()`, then permissioned with `fchmod()` on the open descriptor.
- The script is removed through an `EXIT` trap, and VeraCrypt also unlinks it if launching Terminal fails.
- Separate user-facing messages explain the Check and Repair flows.

### Validation

- Built successfully with FUSE-T using `src/Build/build_veracrypt_macosx.sh -f`.
- Manually tested Repair Filesystem on an elevated device-hosted mount.
- Verified that the temporary `VeraCrypt-fsck-*.command` helper is removed after completion.

