### PR TITLE
Use direct burn in BufferPtr::Erase and guard token keyfile data

### DIFF
--- a/src/Main/Forms/SecurityTokenKeyfilesDialog.cpp
+++ b/src/Main/Forms/SecurityTokenKeyfilesDialog.cpp
@@ -104,10 +104,17 @@ namespace VeraCrypt
 					wxBusyCursor busy;
 
 					vector <uint8> keyfileData;
+					finally_do_arg (
+						vector <uint8> *, &keyfileData,
+						{ if (!finally_arg->empty()) burn (&finally_arg->front(), finally_arg->size()); }
+					);
+
 					keyfile->GetKeyfileData (keyfileData);
 
+					if (keyfileData.empty())
+						throw InsufficientData (SRC_POS);
+
 					BufferPtr keyfileDataBuf (&keyfileData.front(), keyfileData.size());
-					finally_do_arg (BufferPtr, keyfileDataBuf, { finally_arg.Erase(); });
 
 					File keyfile;
 					keyfile.Open (*files.front(), File::CreateWrite);
@@ -142,10 +149,14 @@ namespace VeraCrypt
 			if (keyfile.Length() > 0)
 			{
 				vector <uint8> keyfileData (keyfile.Length());
+				finally_do_arg (
+					vector <uint8> *, &keyfileData,
+					{ if (!finally_arg->empty()) burn (&finally_arg->front(), finally_arg->size()); }
+				);
+
 				BufferPtr keyfileDataBuf (&keyfileData.front(), keyfileData.size());
 
 				keyfile.ReadCompleteBuffer (keyfileDataBuf);
-				finally_do_arg (BufferPtr, keyfileDataBuf, { finally_arg.Erase(); });
 
 				NewSecurityTokenKeyfileDialog newKeyfileDialog (this, keyfilePath.ToBaseName());
 

--- a/src/Main/TextUserInterface.cpp
+++ b/src/Main/TextUserInterface.cpp
@@ -1269,10 +1269,17 @@ namespace VeraCrypt
         shared_ptr<TokenKeyfile> tokenKeyfile = Token::getTokenKeyfile(keyfilePath);
 
 		vector <uint8> keyfileData;
+		finally_do_arg (
+			vector <uint8> *, &keyfileData,
+			{ if (!finally_arg->empty()) burn (&finally_arg->front(), finally_arg->size()); }
+		);
+
 		tokenKeyfile->GetKeyfileData (keyfileData);
 
+		if (keyfileData.empty())
+			throw InsufficientData (SRC_POS);
+
 		BufferPtr keyfileDataBuf (&keyfileData.front(), keyfileData.size());
-		finally_do_arg (BufferPtr, keyfileDataBuf, { finally_arg.Erase(); });
 
 		FilePath exportFilePath = AskFilePath();
 
@@ -1336,10 +1343,14 @@ namespace VeraCrypt
 			if (keyfile.Length() > 0)
 			{
 				vector <uint8> keyfileData (keyfile.Length());
+				finally_do_arg (
+					vector <uint8> *, &keyfileData,
+					{ if (!finally_arg->empty()) burn (&finally_arg->front(), finally_arg->size()); }
+				);
+
 				BufferPtr keyfileDataBuf (&keyfileData.front(), keyfileData.size());
 
 				keyfile.ReadCompleteBuffer (keyfileDataBuf);
-				finally_do_arg (BufferPtr, keyfileDataBuf, { finally_arg.Erase(); });
 
 				SecurityToken::CreateKeyfile (slotId, keyfileData, string (FilePath (keyfilePath).ToBaseName()));
 			}

--- a/src/Platform/Buffer.h
+++ b/src/Platform/Buffer.h
@@ -53,7 +53,11 @@ namespace VeraCrypt
 
 		operator uint8 * () const { return DataPtr; }
 		void CopyFrom (const ConstBufferPtr &bufferPtr) const;
-		void Erase () const { Zero(); }
+		void Erase () const
+		{
+			if (DataSize > 0)
+				burn (DataPtr, DataSize);
+		}
 		uint8 *Get () const { return DataPtr; }
 		BufferPtr GetRange (size_t offset, size_t size) const;
 		void Set (uint8 *data, size_t size) { DataPtr = data; DataSize = size; }


### PR DESCRIPTION
## Problem

`BufferPtr::Erase()` currently delegates to `Zero()`, which uses `memset()`. Since sensitive buffers are not subsequently read, that wipe may be removed as a dead store.

The four GUI and text-mode token import/export paths also install their cleanup guards only after `GetKeyfileData()` or `ReadCompleteBuffer()`. If either operation throws after allocating or partially populating the vector, its contents can be released without being wiped.

## Changes

- Expand `burn()` directly inside `BufferPtr::Erase()`, following VeraCrypt’s established direct-erasure design from commit `885cc1d0`.
- Leave `Memory::Zero()` and the existing direct-`burn` implementation of `Buffer::Erase()` unchanged.
- Install vector-referencing cleanup guards before the sensitive operations in the four GUI/text token paths.
- Reject unexpectedly empty token exports before accessing `vector::front()`.

The existing password cleanup guards are already installed before their sensitive operations and remain unchanged.

## Validation

- macOS arm64 GUI build
- `VeraCrypt --text --test`
- Linux GUI and console GitHub Actions build and test workflow