### PR TITLE
macOS: replace deprecated Carbon foregrounding with post-wx AppKit activation

### DIFF
--- a/src/Main/GraphicUserInterface.cpp
+++ b/src/Main/GraphicUserInterface.cpp
@@ -29,6 +29,7 @@
 #include "GraphicUserInterface.h"
 #include "FatalErrorHandler.h"
 #ifdef TC_MACOSX
+#include "MacOSXAppActivation.h"
 #include "MacOSXSecureTextFieldHotkeys.h"
 #endif
 #include "Forms/DeviceSelectionDialog.h"
@@ -1044,6 +1045,10 @@ namespace VeraCrypt
 		InterfaceType = UserInterfaceType::Graphic;
 		try
 		{
+#ifdef TC_MACOSX
+			if (argc > 1)
+				ActivateMacOSXApp();
+#endif
 			FatalErrorHandler::Register();
 			Init();
 

--- a/src/Main/MacOSXAppActivation.h
+++ b/src/Main/MacOSXAppActivation.h
@@ -1,0 +1,19 @@
+/*
+ Copyright (c) 2013-2026 AM Crypto. All rights reserved.
+
+ Governed by the Apache License 2.0 the full text of which is
+ contained in the file License.txt included in VeraCrypt binary and source
+ code distribution packages.
+*/
+
+#ifndef TC_HEADER_Main_MacOSXAppActivation
+#define TC_HEADER_Main_MacOSXAppActivation
+
+#ifdef TC_MACOSX
+namespace VeraCrypt
+{
+	void ActivateMacOSXApp ();
+}
+#endif
+
+#endif // TC_HEADER_Main_MacOSXAppActivation

--- a/src/Main/MacOSXAppActivation.mm
+++ b/src/Main/MacOSXAppActivation.mm
@@ -1,0 +1,36 @@
+/*
+ Copyright (c) 2013-2026 AM Crypto. All rights reserved.
+
+ Governed by the Apache License 2.0 the full text of which is
+ contained in the file License.txt included in VeraCrypt binary and source
+ code distribution packages.
+*/
+
+#include "System.h"
+#include "MacOSXAppActivation.h"
+
+#ifdef TC_MACOSX
+#import <Cocoa/Cocoa.h>
+
+namespace VeraCrypt
+{
+	// Call only after wxWidgets has created wxNSApplication; never create NSApplication here.
+	// Using sharedApplication before wx initialization prevents wx from installing its subclass.
+	// On macOS 14+, activate is cooperative and may complete asynchronously.
+	void ActivateMacOSXApp ()
+	{
+		if (NSApp == nil)
+			return;
+
+#if defined(MAC_OS_VERSION_14_0) && MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_VERSION_14_0
+		if (@available(macOS 14.0, *))
+		{
+			[NSApp activate];
+			return;
+		}
+#endif
+
+		[NSApp activateIgnoringOtherApps:YES];
+	}
+}
+#endif

--- a/src/Main/Main.make
+++ b/src/Main/Main.make
@@ -27,6 +27,7 @@ ifndef TC_NO_GUI
 OBJS += FatalErrorHandler.o
 OBJS += GraphicUserInterface.o
 ifeq "$(PLATFORM)" "MacOSX"
+OBJS += MacOSXAppActivation.o
 OBJS += MacOSXSecureTextFieldHotkeys.o
 endif
 OBJS += VolumeHistory.o

--- a/src/Main/Unix/Main.cpp
+++ b/src/Main/Unix/Main.cpp
@@ -22,10 +22,6 @@
 #include "Main/Main.h"
 #include "Main/UserInterface.h"
 
-#if defined (TC_MACOSX) && !defined (TC_NO_GUI)
-#include <ApplicationServices/ApplicationServices.h>
-#endif
-
 using namespace VeraCrypt;
 
 int main (int argc, char **argv)
@@ -92,17 +88,6 @@ int main (int argc, char **argv)
 		}
 		else
 		{
-#if defined (TC_MACOSX) && !defined (TC_NO_GUI)
-			if (argc > 1 && !(argc == 2 && strstr (argv[1], "-psn_") == argv[1]))
-			{
-				ProcessSerialNumber p;
-				if (GetCurrentProcess (&p) == noErr)
-				{
-					TransformProcessType (&p, kProcessTransformToForegroundApplication);
-					SetFrontProcess (&p);
-				}
-			}
-#endif
 			Application::Initialize (UserInterfaceType::Graphic);
 		}
 


### PR DESCRIPTION
## Summary

VeraCrypt brought argument-bearing macOS GUI launches to the foreground with the deprecated Carbon Process Manager APIs `GetCurrentProcess`, `TransformProcessType`, and `SetFrontProcess`.

Removing that block alone is insufficient for the bundled inner-executable case. The executable resolves to its enclosing `.app` and already has regular activation policy, so wxWidgets does not run its unbundled/accessory activation path. The process can therefore be classified as `Foreground` without actually becoming frontmost, leaving command-line modal dialogs inactive.

This change removes VeraCrypt's Carbon foregrounding and activates the existing wx-created `NSApp` after Cocoa initialization instead.

## Implementation

- Remove the Carbon foregrounding block and `ApplicationServices` include from `Main.cpp`.
- Add a private Objective-C++ helper that only uses the existing `NSApp`; it never calls `sharedApplication` and never changes activation policy.
- Call the helper at the start of `GraphicUserInterface::OnInit()`, after wxWidgets has created `wxNSApplication` and before `Init()` or command-line processing can display modal UI.
- Preserve the previous argument condition with `argc > 1`. wxWidgets has already removed a leading `-psn_`, so Finder, LaunchServices, and no-argument launches retain their existing behavior.
- Use `[NSApp activate]` on macOS 14 and later, with compile-time and runtime availability guards and `activateIgnoringOtherApps:YES` as the macOS 12-13 fallback.
- Leave text mode outside the AppKit activation path.

No public API or command-line interface changes are introduced.

## Verification

Built a signed thin arm64 application with wxWidgets 3.2.10, SDK 26.5, and deployment target macOS 12.

- `git diff --check` passes.
- The helper compiles with deprecated-declaration and unguarded-availability diagnostics treated as errors.
- `--text --test` passes; debugger breakpoints on both AppKit activation selectors receive zero hits in text mode.
- Finder and LaunchServices bundle launches, including an explicit `-psn_` launch, become frontmost normally.
- Direct inner-executable launch with no arguments preserves the previous no-activation behavior.
- Direct inner-executable launch with a disposable valid volume path makes VeraCrypt the result of `lsappinfo front`, does not leave `LSWantsAttention` set, focuses the password field, and accepts keyboard input immediately.
- With another application confirmed frontmost immediately before the process started, the volume-path password dialog still became frontmost; three typed characters appeared immediately and Cmd+A replaced them with one character.
- The activation receiver remains `wxNSApplication` with regular activation policy under LLDB. Cmd-key/menu behavior, Cmd+A in the password field, and Cmd+Q remain functional.
- A representative change-password dialog was opened and cancelled before any operation. The disposable test volume was removed.
- `--background-task` returns success and exits immediately in both builds. The AppKit build did not briefly take focus in 10/10 trials, while the released Carbon build did in 10/10. The functional background-task behavior is unchanged; the short-lived, UI-less process exits before cooperative asynchronous activation becomes visible.

The macOS 12-13 `activateIgnoringOtherApps:` branch is compile-verified but was not runtime-tested on those OS versions.
