### PR TITLE
Windows: improve mounted volume storage identity

### DIFF
--- a/src/Driver/Ntdriver.c
+++ b/src/Driver/Ntdriver.c
@@ -15,6 +15,7 @@
 #include <ntddk.h>
 #include <initguid.h>
 #include <Ntddstor.h>
+#include <scsi.h>
 #include "Crypto.h"
 #include "Fat.h"
 #include "Tests.h"
@@ -149,6 +150,91 @@ int EncryptionIoRequestCount = 0;
 int EncryptionItemCount = 0;
 int EncryptionFragmentSize = 0;
 int EncryptionMaxWorkItems = 0;
+
+typedef struct
+{
+	__int64 VirtualDiskLength;
+	__int64 PartitionStartingOffset;
+	__int64 PartitionLength;
+	ULONG DeviceNumber;
+	ULONG PartitionNumber;
+	ULONG HiddenSectors;
+	BOOL HasPhysicalBacking;
+	BOOL ExtendedIoctlEnabled;
+	BOOL WindowsDefragEnabled;
+} TC_VOLUME_IDENTITY;
+
+static void TCGetVolumeIdentity (PEXTENSION Extension, TC_VOLUME_IDENTITY *identity)
+{
+	ULONGLONG start;
+	ULONGLONG end;
+	ULONGLONG hostEnd;
+	ULONGLONG hiddenSectors;
+	ULONGLONG partitionSectors;
+	BOOL extendedIoctlEnabled = EnableExtendedIoctlSupport;
+	BOOL windowsDefragEnabled = AllowWindowsDefrag;
+	BOOL physicalIdentityEnabled = extendedIoctlEnabled || windowsDefragEnabled;
+
+	identity->VirtualDiskLength = Extension->DiskLength + BYTES_PER_MB;
+	identity->PartitionStartingOffset = BYTES_PER_MB;
+	identity->PartitionLength = Extension->DiskLength;
+	identity->DeviceNumber = (ULONG) -1;
+	identity->PartitionNumber = 1;
+	identity->HiddenSectors = Extension->BytesPerSector != 0
+		? BYTES_PER_MB / Extension->BytesPerSector
+		: 0;
+	identity->HasPhysicalBacking = FALSE;
+	identity->ExtendedIoctlEnabled = extendedIoctlEnabled;
+	identity->WindowsDefragEnabled = windowsDefragEnabled;
+
+	// Keep the synthetic MBR view unless one raw backing extent maps to the normal volume data area.
+	if (!physicalIdentityEnabled
+		|| !Extension->bRawDevice
+		|| Extension->DeviceNumber == (ULONG) -1
+		|| Extension->PartitionNumber == (ULONG) -1
+		|| Extension->HostPartitionStartingOffset < 0
+		|| Extension->HostLength <= 0
+		|| Extension->DiskLength <= 0
+		|| !Extension->cryptoInfo
+		|| Extension->cryptoInfo->hiddenVolume
+		|| Extension->cryptoInfo->bProtectHiddenVolume
+		|| Extension->PartitionInInactiveSysEncScope)
+	{
+		return;
+	}
+
+	if (S_OK != ULongLongAdd (
+		(ULONGLONG) Extension->HostPartitionStartingOffset,
+		Extension->cryptoInfo->volDataAreaOffset,
+		&start)
+		|| S_OK != ULongLongAdd (start, (ULONGLONG) Extension->DiskLength, &end)
+		|| S_OK != ULongLongAdd (
+			(ULONGLONG) Extension->HostPartitionStartingOffset,
+			(ULONGLONG) Extension->HostLength,
+			&hostEnd)
+		|| end > hostEnd
+		|| end > (ULONGLONG) 0x7fffffffffffffffULL
+		|| Extension->BytesPerSector == 0
+		|| start % Extension->BytesPerSector != 0
+		|| end % Extension->BytesPerSector != 0)
+	{
+		return;
+	}
+
+	hiddenSectors = start / Extension->BytesPerSector;
+	partitionSectors = (ULONGLONG) Extension->DiskLength / Extension->BytesPerSector;
+	if (hiddenSectors > 0xffffffffUL
+		|| partitionSectors > 0xffffffffUL
+		|| end / Extension->BytesPerSector > 0x100000000ULL)
+		return;
+
+	identity->VirtualDiskLength = (__int64) end;
+	identity->PartitionStartingOffset = (__int64) start;
+	identity->DeviceNumber = Extension->DeviceNumber;
+	identity->PartitionNumber = Extension->PartitionNumber;
+	identity->HiddenSectors = (ULONG) hiddenSectors;
+	identity->HasPhysicalBacking = TRUE;
+}
 
 BOOL IsOrderedFlushBarriersEnabled ()
 {
@@ -1099,6 +1185,7 @@ IOCTL_STORAGE_QUERY_PROPERTY 0x002D1400
 NTSTATUS ProcessVolumeDeviceControlIrp (PDEVICE_OBJECT DeviceObject, PEXTENSION Extension, PIRP Irp)
 {
 	PIO_STACK_LOCATION irpSp = IoGetCurrentIrpStackLocation (Irp);
+	TC_VOLUME_IDENTITY identity;
 	UNREFERENCED_PARAMETER(DeviceObject);
 
 	switch (irpSp->Parameters.DeviceIoControl.IoControlCode)
@@ -1228,8 +1315,11 @@ NTSTATUS ProcessVolumeDeviceControlIrp (PDEVICE_OBJECT DeviceObject, PEXTENSION 
 			PDISK_GEOMETRY outputBuffer = (PDISK_GEOMETRY)
 			Irp->AssociatedIrp.SystemBuffer;
 
+			TCGetVolumeIdentity (Extension, &identity);
 			outputBuffer->MediaType = Extension->bRemovable ? RemovableMedia : FixedMedia;
-			outputBuffer->Cylinders.QuadPart = Extension->NumberOfCylinders;
+			outputBuffer->Cylinders.QuadPart = identity.HasPhysicalBacking
+				? identity.VirtualDiskLength / Extension->BytesPerSector
+				: Extension->NumberOfCylinders;
 			outputBuffer->TracksPerCylinder = Extension->TracksPerCylinder;
 			outputBuffer->SectorsPerTrack = Extension->SectorsPerTrack;
 			outputBuffer->BytesPerSector = Extension->BytesPerSector;
@@ -1249,13 +1339,15 @@ NTSTATUS ProcessVolumeDeviceControlIrp (PDEVICE_OBJECT DeviceObject, PEXTENSION 
 				BOOL bFullBuffer = (irpSp->Parameters.DeviceIoControl.OutputBufferLength >= fullOutputSize)? TRUE : FALSE;
 				PDISK_GEOMETRY_EX outputBuffer = (PDISK_GEOMETRY_EX) Irp->AssociatedIrp.SystemBuffer;
 
+				TCGetVolumeIdentity (Extension, &identity);
 				outputBuffer->Geometry.MediaType = Extension->bRemovable ? RemovableMedia : FixedMedia;
-				outputBuffer->Geometry.Cylinders.QuadPart = Extension->NumberOfCylinders;
+				outputBuffer->Geometry.Cylinders.QuadPart = identity.HasPhysicalBacking
+					? identity.VirtualDiskLength / Extension->BytesPerSector
+					: Extension->NumberOfCylinders;
 				outputBuffer->Geometry.TracksPerCylinder = Extension->TracksPerCylinder;
 				outputBuffer->Geometry.SectorsPerTrack = Extension->SectorsPerTrack;
 				outputBuffer->Geometry.BytesPerSector = Extension->BytesPerSector;
-				// Add 1MB to the disk size to emulate the geometry of a real MBR disk
-				outputBuffer->DiskSize.QuadPart = Extension->DiskLength + BYTES_PER_MB;
+				outputBuffer->DiskSize.QuadPart = identity.VirtualDiskLength;
 
 				if (bFullBuffer)
 				{
@@ -1291,6 +1383,7 @@ NTSTATUS ProcessVolumeDeviceControlIrp (PDEVICE_OBJECT DeviceObject, PEXTENSION 
 			Irp->AssociatedIrp.SystemBuffer;
 			PDEVICE_MEDIA_INFO mediaInfo = &outputBuffer->MediaInfo[0];
 
+			TCGetVolumeIdentity (Extension, &identity);
 			outputBuffer->DeviceType = FILE_DEVICE_DISK;
 			outputBuffer->MediaInfoCount = 1;
 
@@ -1302,7 +1395,9 @@ NTSTATUS ProcessVolumeDeviceControlIrp (PDEVICE_OBJECT DeviceObject, PEXTENSION 
 				else
 					mediaInfo->DeviceSpecific.RemovableDiskInfo.MediaCharacteristics = (MEDIA_CURRENTLY_MOUNTED | MEDIA_READ_WRITE);
 				mediaInfo->DeviceSpecific.RemovableDiskInfo.MediaType = (STORAGE_MEDIA_TYPE) RemovableMedia;
-				mediaInfo->DeviceSpecific.RemovableDiskInfo.Cylinders.QuadPart = Extension->NumberOfCylinders;
+				mediaInfo->DeviceSpecific.RemovableDiskInfo.Cylinders.QuadPart = identity.HasPhysicalBacking
+					? identity.VirtualDiskLength / Extension->BytesPerSector
+					: Extension->NumberOfCylinders;
 				mediaInfo->DeviceSpecific.RemovableDiskInfo.TracksPerCylinder = Extension->TracksPerCylinder;
 				mediaInfo->DeviceSpecific.RemovableDiskInfo.SectorsPerTrack = Extension->SectorsPerTrack;
 				mediaInfo->DeviceSpecific.RemovableDiskInfo.BytesPerSector = Extension->BytesPerSector;
@@ -1315,7 +1410,9 @@ NTSTATUS ProcessVolumeDeviceControlIrp (PDEVICE_OBJECT DeviceObject, PEXTENSION 
 				else
 					mediaInfo->DeviceSpecific.DiskInfo.MediaCharacteristics = (MEDIA_CURRENTLY_MOUNTED | MEDIA_READ_WRITE);
 				mediaInfo->DeviceSpecific.DiskInfo.MediaType = (STORAGE_MEDIA_TYPE) FixedMedia;
-				mediaInfo->DeviceSpecific.DiskInfo.Cylinders.QuadPart = Extension->NumberOfCylinders;
+				mediaInfo->DeviceSpecific.DiskInfo.Cylinders.QuadPart = identity.HasPhysicalBacking
+					? identity.VirtualDiskLength / Extension->BytesPerSector
+					: Extension->NumberOfCylinders;
 				mediaInfo->DeviceSpecific.DiskInfo.TracksPerCylinder = Extension->TracksPerCylinder;
 				mediaInfo->DeviceSpecific.DiskInfo.SectorsPerTrack = Extension->SectorsPerTrack;
 				mediaInfo->DeviceSpecific.DiskInfo.BytesPerSector = Extension->BytesPerSector;
@@ -1390,7 +1487,7 @@ NTSTATUS ProcessVolumeDeviceControlIrp (PDEVICE_OBJECT DeviceObject, PEXTENSION 
 
 										outputBuffer->Version = sizeof(STORAGE_DEVICE_DESCRIPTOR);
 										outputBuffer->Size = descriptorSize;
-										outputBuffer->DeviceType = FILE_DEVICE_DISK;
+										outputBuffer->DeviceType = DIRECT_ACCESS_DEVICE;
 										outputBuffer->RemovableMedia = Extension->bRemovable? TRUE : FALSE;
 										outputBuffer->ProductIdOffset = sizeof (STORAGE_DEVICE_DESCRIPTOR);
 										outputBuffer->SerialNumberOffset = sizeof (STORAGE_DEVICE_DESCRIPTOR);
@@ -1522,14 +1619,15 @@ NTSTATUS ProcessVolumeDeviceControlIrp (PDEVICE_OBJECT DeviceObject, PEXTENSION 
 			PPARTITION_INFORMATION outputBuffer = (PPARTITION_INFORMATION)
 			Irp->AssociatedIrp.SystemBuffer;
 
+			TCGetVolumeIdentity (Extension, &identity);
 			outputBuffer->PartitionType = Extension->PartitionType;
 			outputBuffer->BootIndicator = FALSE;
 			outputBuffer->RecognizedPartition = TRUE;
 			outputBuffer->RewritePartition = FALSE;
-			outputBuffer->StartingOffset.QuadPart = BYTES_PER_MB; // Set offset to 1MB to emulate the partition offset on a real MBR disk
-			outputBuffer->PartitionLength.QuadPart= Extension->DiskLength;
-			outputBuffer->PartitionNumber = 1;
-			outputBuffer->HiddenSectors = BYTES_PER_MB / Extension->BytesPerSector;
+			outputBuffer->StartingOffset.QuadPart = identity.PartitionStartingOffset;
+			outputBuffer->PartitionLength.QuadPart = identity.PartitionLength;
+			outputBuffer->PartitionNumber = identity.PartitionNumber;
+			outputBuffer->HiddenSectors = identity.HiddenSectors;
 			Irp->IoStatus.Status = STATUS_SUCCESS;
 			Irp->IoStatus.Information = sizeof (PARTITION_INFORMATION);
 		}
@@ -1541,15 +1639,16 @@ NTSTATUS ProcessVolumeDeviceControlIrp (PDEVICE_OBJECT DeviceObject, PEXTENSION 
 		{
 			PPARTITION_INFORMATION_EX outputBuffer = (PPARTITION_INFORMATION_EX) Irp->AssociatedIrp.SystemBuffer;
 
+			TCGetVolumeIdentity (Extension, &identity);
 			outputBuffer->PartitionStyle = PARTITION_STYLE_MBR;
 			outputBuffer->RewritePartition = FALSE;
-			outputBuffer->StartingOffset.QuadPart = BYTES_PER_MB; // Set offset to 1MB to emulate the partition offset on a real MBR disk
-			outputBuffer->PartitionLength.QuadPart= Extension->DiskLength;
-			outputBuffer->PartitionNumber = 1;
+			outputBuffer->StartingOffset.QuadPart = identity.PartitionStartingOffset;
+			outputBuffer->PartitionLength.QuadPart = identity.PartitionLength;
+			outputBuffer->PartitionNumber = identity.PartitionNumber;
 			outputBuffer->Mbr.PartitionType = Extension->PartitionType;
 			outputBuffer->Mbr.BootIndicator = FALSE;
 			outputBuffer->Mbr.RecognizedPartition = TRUE;
-			outputBuffer->Mbr.HiddenSectors = BYTES_PER_MB / Extension->BytesPerSector;
+			outputBuffer->Mbr.HiddenSectors = identity.HiddenSectors;
 			Irp->IoStatus.Status = STATUS_SUCCESS;
 			Irp->IoStatus.Information = sizeof (PARTITION_INFORMATION_EX);
 		}
@@ -1563,6 +1662,7 @@ NTSTATUS ProcessVolumeDeviceControlIrp (PDEVICE_OBJECT DeviceObject, PEXTENSION 
 			PDRIVE_LAYOUT_INFORMATION outputBuffer = (PDRIVE_LAYOUT_INFORMATION)
 			Irp->AssociatedIrp.SystemBuffer;
 
+			TCGetVolumeIdentity (Extension, &identity);
 			outputBuffer->PartitionCount = bFullBuffer? 4 : 1;
 			outputBuffer->Signature = GetCrc32((unsigned char*) &(Extension->UniqueVolumeId), 4);
 
@@ -1570,10 +1670,10 @@ NTSTATUS ProcessVolumeDeviceControlIrp (PDEVICE_OBJECT DeviceObject, PEXTENSION 
 			outputBuffer->PartitionEntry->BootIndicator = FALSE;
 			outputBuffer->PartitionEntry->RecognizedPartition = TRUE;
 			outputBuffer->PartitionEntry->RewritePartition = FALSE;
-			outputBuffer->PartitionEntry->StartingOffset.QuadPart = BYTES_PER_MB; // Set offset to 1MB to emulate the partition offset on a real MBR disk
-			outputBuffer->PartitionEntry->PartitionLength.QuadPart = Extension->DiskLength;
-			outputBuffer->PartitionEntry->PartitionNumber = 1;
-			outputBuffer->PartitionEntry->HiddenSectors = BYTES_PER_MB / Extension->BytesPerSector;		
+			outputBuffer->PartitionEntry->StartingOffset.QuadPart = identity.PartitionStartingOffset;
+			outputBuffer->PartitionEntry->PartitionLength.QuadPart = identity.PartitionLength;
+			outputBuffer->PartitionEntry->PartitionNumber = identity.PartitionNumber;
+			outputBuffer->PartitionEntry->HiddenSectors = identity.HiddenSectors;
 
 			Irp->IoStatus.Status = STATUS_SUCCESS;
 			Irp->IoStatus.Information = sizeof (DRIVE_LAYOUT_INFORMATION);
@@ -1589,9 +1689,10 @@ NTSTATUS ProcessVolumeDeviceControlIrp (PDEVICE_OBJECT DeviceObject, PEXTENSION 
 		Dump ("ProcessVolumeDeviceControlIrp (IOCTL_DISK_GET_DRIVE_LAYOUT_EX)\n");
 		Irp->IoStatus.Status = STATUS_INVALID_DEVICE_REQUEST;
 		Irp->IoStatus.Information = 0;
-		if (EnableExtendedIoctlSupport)
 		{
-			if (ValidateIOBufferSize (Irp, sizeof (DRIVE_LAYOUT_INFORMATION_EX), ValidateOutput))
+			TCGetVolumeIdentity (Extension, &identity);
+			if (identity.ExtendedIoctlEnabled
+				&& ValidateIOBufferSize (Irp, sizeof (DRIVE_LAYOUT_INFORMATION_EX), ValidateOutput))
 			{
 				BOOL bFullBuffer = (irpSp->Parameters.DeviceIoControl.OutputBufferLength >= (sizeof (DRIVE_LAYOUT_INFORMATION_EX) + 3*sizeof(PARTITION_INFORMATION_EX)))? TRUE : FALSE;
 				PDRIVE_LAYOUT_INFORMATION_EX outputBuffer = (PDRIVE_LAYOUT_INFORMATION_EX)
@@ -1605,10 +1706,10 @@ NTSTATUS ProcessVolumeDeviceControlIrp (PDEVICE_OBJECT DeviceObject, PEXTENSION 
 				outputBuffer->PartitionEntry->Mbr.BootIndicator = FALSE;
 				outputBuffer->PartitionEntry->Mbr.RecognizedPartition = TRUE;
 				outputBuffer->PartitionEntry->RewritePartition = FALSE;
-				outputBuffer->PartitionEntry->StartingOffset.QuadPart = BYTES_PER_MB; // Set offset to 1MB to emulate the partition offset on a real MBR disk
-				outputBuffer->PartitionEntry->PartitionLength.QuadPart = Extension->DiskLength;
-				outputBuffer->PartitionEntry->PartitionNumber = 1;
-				outputBuffer->PartitionEntry->Mbr.HiddenSectors = BYTES_PER_MB / Extension->BytesPerSector;
+				outputBuffer->PartitionEntry->StartingOffset.QuadPart = identity.PartitionStartingOffset;
+				outputBuffer->PartitionEntry->PartitionLength.QuadPart = identity.PartitionLength;
+				outputBuffer->PartitionEntry->PartitionNumber = identity.PartitionNumber;
+				outputBuffer->PartitionEntry->Mbr.HiddenSectors = identity.HiddenSectors;
 				outputBuffer->PartitionEntry->Mbr.PartitionType = Extension->PartitionType;
 
 				Irp->IoStatus.Status = STATUS_SUCCESS;
@@ -1750,25 +1851,48 @@ NTSTATUS ProcessVolumeDeviceControlIrp (PDEVICE_OBJECT DeviceObject, PEXTENSION 
 	case IOCTL_VOLUME_GET_VOLUME_DISK_EXTENTS:
 		Dump ("ProcessVolumeDeviceControlIrp (IOCTL_VOLUME_GET_VOLUME_DISK_EXTENTS)\n");
 		// Vista's, Windows 8.1 and later filesystem defragmenter fails if IOCTL_VOLUME_GET_VOLUME_DISK_EXTENTS does not succeed.
-		if (!AllowWindowsDefrag || !Extension->bRawDevice) // We don't support defragmentation for file-hosted volumes
 		{
-			Irp->IoStatus.Status = STATUS_INVALID_DEVICE_REQUEST;
-			Irp->IoStatus.Information = 0;
+			TCGetVolumeIdentity (Extension, &identity);
+			if (!identity.WindowsDefragEnabled
+				|| !identity.HasPhysicalBacking)
+			{
+				Irp->IoStatus.Status = STATUS_INVALID_DEVICE_REQUEST;
+				Irp->IoStatus.Information = 0;
+			}
+			else if (ValidateIOBufferSize(Irp, sizeof(VOLUME_DISK_EXTENTS), ValidateOutput))
+			{
+				VOLUME_DISK_EXTENTS* extents = (VOLUME_DISK_EXTENTS*)Irp->AssociatedIrp.SystemBuffer;
+
+				extents->NumberOfDiskExtents = 1;
+				extents->Extents[0].DiskNumber = identity.DeviceNumber;
+				extents->Extents[0].StartingOffset.QuadPart = identity.PartitionStartingOffset;
+				extents->Extents[0].ExtentLength.QuadPart = identity.PartitionLength;
+
+				Irp->IoStatus.Status = STATUS_SUCCESS;
+				Irp->IoStatus.Information = sizeof(*extents);
+			}
 		}
-		else if (ValidateIOBufferSize(Irp, sizeof(VOLUME_DISK_EXTENTS), ValidateOutput))
+		break;
+
+	case IOCTL_STORAGE_GET_DEVICE_NUMBER:
+		Dump ("ProcessVolumeDeviceControlIrp (IOCTL_STORAGE_GET_DEVICE_NUMBER)\n");
+		Irp->IoStatus.Status = STATUS_INVALID_DEVICE_REQUEST;
+		Irp->IoStatus.Information = 0;
 		{
-			VOLUME_DISK_EXTENTS* extents = (VOLUME_DISK_EXTENTS*)Irp->AssociatedIrp.SystemBuffer;
+			TCGetVolumeIdentity (Extension, &identity);
+			if (identity.ExtendedIoctlEnabled
+				&& identity.HasPhysicalBacking
+				&& ValidateIOBufferSize (Irp, sizeof (STORAGE_DEVICE_NUMBER), ValidateOutput))
+			{
+				STORAGE_DEVICE_NUMBER *storage = (STORAGE_DEVICE_NUMBER *) Irp->AssociatedIrp.SystemBuffer;
 
-			// Windows 10 filesystem defragmenter works only if we report an extent with a real disk number
-			// So in the case of a VeraCrypt disk based volume, we use the disk number
-			// of the underlaying physical disk and we report a single extent 
-			extents->NumberOfDiskExtents = 1;
-			extents->Extents[0].DiskNumber = Extension->DeviceNumber;
-			extents->Extents[0].StartingOffset.QuadPart = BYTES_PER_MB; // Set offset to 1MB to emulate the partition offset on a real MBR disk
-			extents->Extents[0].ExtentLength.QuadPart = Extension->DiskLength;
+				storage->DeviceType = FILE_DEVICE_DISK;
+				storage->DeviceNumber = identity.DeviceNumber;
+				storage->PartitionNumber = identity.PartitionNumber;
 
-			Irp->IoStatus.Status = STATUS_SUCCESS;
-			Irp->IoStatus.Information = sizeof(*extents);
+				Irp->IoStatus.Status = STATUS_SUCCESS;
+				Irp->IoStatus.Information = sizeof (STORAGE_DEVICE_NUMBER);
+			}
 		}
 		break;
 
@@ -1776,16 +1900,17 @@ NTSTATUS ProcessVolumeDeviceControlIrp (PDEVICE_OBJECT DeviceObject, PEXTENSION 
 		Dump ("ProcessVolumeDeviceControlIrp (IOCTL_STORAGE_READ_CAPACITY)\n");
 		Irp->IoStatus.Status = STATUS_INVALID_DEVICE_REQUEST;
 		Irp->IoStatus.Information = 0;
-		if (EnableExtendedIoctlSupport)
 		{
-			if (ValidateIOBufferSize (Irp, sizeof (STORAGE_READ_CAPACITY), ValidateOutput))
+			TCGetVolumeIdentity (Extension, &identity);
+			if (identity.ExtendedIoctlEnabled
+				&& ValidateIOBufferSize (Irp, sizeof (STORAGE_READ_CAPACITY), ValidateOutput))
 			{
 				STORAGE_READ_CAPACITY *capacity = (STORAGE_READ_CAPACITY *) Irp->AssociatedIrp.SystemBuffer;
 
 				capacity->Version = sizeof (STORAGE_READ_CAPACITY);
 				capacity->Size = sizeof (STORAGE_READ_CAPACITY);
 				capacity->BlockLength = Extension->BytesPerSector;
-				capacity->DiskLength.QuadPart = Extension->DiskLength + BYTES_PER_MB; // Add 1MB to the disk size to emulate the geometry of a real MBR disk
+				capacity->DiskLength.QuadPart = identity.VirtualDiskLength;
 				capacity->NumberOfBlocks.QuadPart = capacity->DiskLength.QuadPart / capacity->BlockLength;
 
 				Irp->IoStatus.Status = STATUS_SUCCESS;
@@ -1793,26 +1918,6 @@ NTSTATUS ProcessVolumeDeviceControlIrp (PDEVICE_OBJECT DeviceObject, PEXTENSION 
 			}
 		}
 		break;
-
-	/*case IOCTL_STORAGE_GET_DEVICE_NUMBER:
-		Dump ("ProcessVolumeDeviceControlIrp (IOCTL_STORAGE_GET_DEVICE_NUMBER)\n");
-		Irp->IoStatus.Status = STATUS_INVALID_DEVICE_REQUEST;
-		Irp->IoStatus.Information = 0;
-		if (EnableExtendedIoctlSupport)
-		{
-			if (ValidateIOBufferSize (Irp, sizeof (STORAGE_DEVICE_NUMBER), ValidateOutput))
-			{
-				STORAGE_DEVICE_NUMBER *storage = (STORAGE_DEVICE_NUMBER *) Irp->AssociatedIrp.SystemBuffer;
-
-				storage->DeviceType = FILE_DEVICE_DISK;
-				storage->DeviceNumber = (ULONG) -1;
-				storage->PartitionNumber = 1;
-
-				Irp->IoStatus.Status = STATUS_SUCCESS;
-				Irp->IoStatus.Information = sizeof (STORAGE_DEVICE_NUMBER);
-			}
-		}
-		break;*/
 
 	case IOCTL_STORAGE_GET_HOTPLUG_INFO:
 		Dump ("ProcessVolumeDeviceControlIrp (IOCTL_STORAGE_GET_HOTPLUG_INFO)\n");
@@ -2158,7 +2263,6 @@ NTSTATUS ProcessVolumeDeviceControlIrp (PDEVICE_OBJECT DeviceObject, PEXTENSION 
 	case IOCTL_STORAGE_CHECK_PRIORITY_HINT_SUPPORT:
 	case IOCTL_VOLUME_QUERY_ALLOCATION_HINT:
 	case FT_BALANCED_READ_MODE:
-	case IOCTL_STORAGE_GET_DEVICE_NUMBER:
 	case IOCTL_MOUNTDEV_LINK_CREATED:
 		Dump ("ProcessVolumeDeviceControlIrp: returning STATUS_INVALID_DEVICE_REQUEST for %ls\n", TCTranslateCode (irpSp->Parameters.DeviceIoControl.IoControlCode));
 		Irp->IoStatus.Status = STATUS_INVALID_DEVICE_REQUEST;

--- a/src/Driver/Ntdriver.h
+++ b/src/Driver/Ntdriver.h
@@ -71,6 +71,7 @@ typedef struct EXTENSION
 	CRYPTO_INFO *cryptoInfo;	/* Cryptographic and other information for this device */
 
 	__int64	HostLength;
+	__int64 HostPartitionStartingOffset;
 	__int64 DiskLength;			/* The length of the disk referred to by this device */
 	__int64 NumberOfCylinders;		/* Partition info */
 	ULONG TracksPerCylinder;	/* Partition info */
@@ -84,6 +85,7 @@ typedef struct EXTENSION
 	ULONG HostMaximumPhysicalPages;
 	ULONG HostAlignmentMask;
 	ULONG DeviceNumber;
+	ULONG PartitionNumber;
 
 	BOOL IncursSeekPenalty;
 	BOOL TrimEnabled;

--- a/src/Driver/Ntvol.c
+++ b/src/Driver/Ntvol.c
@@ -88,6 +88,8 @@ NTSTATUS TCOpenVolume (PDEVICE_OBJECT DeviceObject,
 	Extension->TrimEnabled = FALSE;
 
 	Extension->DeviceNumber = (ULONG) -1;
+	Extension->PartitionNumber = (ULONG) -1;
+	Extension->HostPartitionStartingOffset = -1;
 
 	RtlInitUnicodeString (&FullFileName, pwszMountVolume);
 	InitializeObjectAttributes (&oaFileAttributes, &FullFileName, OBJ_CASE_INSENSITIVE | (forceAccessCheck ? OBJ_FORCE_ACCESS_CHECK : 0) | OBJ_KERNEL_HANDLE, NULL, NULL);
@@ -113,7 +115,9 @@ NTSTATUS TCOpenVolume (PDEVICE_OBJECT DeviceObject,
 		DISK_GEOMETRY_EX dg;
 		STORAGE_PROPERTY_QUERY storagePropertyQuery = { 0 };
 		uint8* dgBuffer;
-		STORAGE_DEVICE_NUMBER storageDeviceNumber;
+		STORAGE_DEVICE_NUMBER storageDeviceNumber = { 0 };
+		BOOL hostDeviceNumberValid = FALSE;
+		BOOL hostPartitionOffsetKnown = FALSE;
 
 		ntStatus = IoGetDeviceObjectPointer(&FullFileName,
 			FILE_READ_DATA | FILE_READ_ATTRIBUTES,
@@ -168,7 +172,14 @@ NTSTATUS TCOpenVolume (PDEVICE_OBJECT DeviceObject,
 			IOCTL_STORAGE_GET_DEVICE_NUMBER,
 			(char*)&storageDeviceNumber, sizeof(storageDeviceNumber))))
 		{
-			Extension->DeviceNumber = storageDeviceNumber.DeviceNumber;
+			if (storageDeviceNumber.DeviceType == FILE_DEVICE_DISK
+				&& storageDeviceNumber.DeviceNumber != (ULONG) -1
+				&& storageDeviceNumber.PartitionNumber != (ULONG) -1)
+			{
+				Extension->DeviceNumber = storageDeviceNumber.DeviceNumber;
+				Extension->PartitionNumber = storageDeviceNumber.PartitionNumber;
+				hostDeviceNumberValid = TRUE;
+			}
 		}
 
 		lDiskLength.QuadPart = dg.DiskSize.QuadPart;
@@ -233,17 +244,24 @@ NTSTATUS TCOpenVolume (PDEVICE_OBJECT DeviceObject,
 		{
 			lDiskLength.QuadPart = pix.PartitionLength.QuadPart;
 			partitionStartingOffset = pix.StartingOffset.QuadPart;
+			hostPartitionOffsetKnown = TRUE;
 		}
 		// If IOCTL_DISK_GET_PARTITION_INFO_EX fails, switch to IOCTL_DISK_GET_PARTITION_INFO
 		else if (NT_SUCCESS(TCSendHostDeviceIoControlRequest(DeviceObject, Extension, IOCTL_DISK_GET_PARTITION_INFO, (char*)&pi, sizeof(pi))))
 		{
 			lDiskLength.QuadPart = pi.PartitionLength.QuadPart;
 			partitionStartingOffset = pi.StartingOffset.QuadPart;
+			hostPartitionOffsetKnown = TRUE;
 		}
 		else if (NT_SUCCESS(TCSendHostDeviceIoControlRequest(DeviceObject, Extension, IOCTL_DISK_GET_LENGTH_INFO, &diskLengthInfo, sizeof(diskLengthInfo))))
 		{
 			lDiskLength = diskLengthInfo;
+			if (hostDeviceNumberValid && storageDeviceNumber.PartitionNumber == 0)
+				hostPartitionOffsetKnown = TRUE;
 		}
+
+		if (hostPartitionOffsetKnown)
+			Extension->HostPartitionStartingOffset = partitionStartingOffset;
 
 		ProbingHostDeviceForWrite = TRUE;
 


### PR DESCRIPTION
## Summary

This improves the Windows storage identity reported by mounted VeraCrypt volumes without introducing a new driver ABI or registry option.

It fixes two separate contract problems:

1. `STORAGE_DEVICE_DESCRIPTOR.DeviceType` was populated with `FILE_DEVICE_DISK` (`0x07`). In a storage device descriptor this field uses SCSI peripheral device types, where `0x07` means optical memory. Mounted volumes now report `DIRECT_ACCESS_DEVICE` (`0x00`).
2. Device-hosted volumes retained VeraCrypt's synthetic 1 MiB partition view even when the driver had a real lower disk and partition. The driver now captures a complete backing identity and reports a coherent view of the encrypted volume's data area.

No debug fields, performance counters, direct-I/O changes, DCS changes, or new registry gates are included.

## Raw-volume identity

For a normal volume mounted from a raw partition or whole disk, the driver records the complete lower-stack `STORAGE_DEVICE_NUMBER` tuple and the host partition starting offset.

When the identity is complete and representable, responses are derived from:

```text
start  = host partition start + encrypted volume data-area offset
length = mounted volume data length
end    = start + length
```

The same values are then used for:

- `IOCTL_STORAGE_GET_DEVICE_NUMBER`
- `IOCTL_VOLUME_GET_VOLUME_DISK_EXTENTS`
- `IOCTL_DISK_GET_PARTITION_INFO[_EX]`
- `IOCTL_DISK_GET_DRIVE_LAYOUT[_EX]`
- disk geometry and media responses
- `IOCTL_STORAGE_READ_CAPACITY`

This preserves valid whole-disk `PartitionNumber == 0` values and avoids mixing fields from unrelated lower-stack queries.

The existing opt-in controls remain authoritative:

- `TC_DRIVER_CONFIG_ENABLE_EXTENDED_IOCTL` gates the extended storage IOCTLs.
- `VC_DRIVER_CONFIG_ALLOW_WINDOWS_DEFRAG` gates volume disk extents.

## Fail-closed cases

Physical identity is not published when the backing tuple is incomplete, arithmetic or host bounds fail, sector alignment is invalid, or the result cannot be represented by the MBR-compatible view currently returned by this driver.

The physical view is also excluded for:

- file-hosted containers
- hidden volumes
- hidden-volume protection
- partitions in an inactive system-encryption scope

File containers therefore receive the corrected direct-access device type but keep the existing synthetic partition geometry. They intentionally do not receive an invented physical disk number or extent: no matching `PhysicalDriveN`/PnP disk exists for such a number.

## Validation

Development and runtime validation were performed only on Windows 11 ARM64 in a Parallels VM with a locally test-signed driver.

The final one-commit tree built successfully as an ARM64 Release driver:

- commit: `33c7eb2dbc68e851ef3a9c5ab8901b5cef2a5a5c`
- `veracrypt.sys` SHA-256: `8FD4B559E884E3E9D3E6873161BD48083012363BB673F0693D81364FEA62C4E1`

Runtime validation combined this commit with the ARM64 system-encryption branch and verified the installed driver hash before loading it as a demand-start test driver.

File-container checks:

- `STORAGE_DEVICE_DESCRIPTOR.DeviceType = 0`
- `BusType = BusTypeVirtual`
- synthetic partition/layout/capacity remained coherent
- device number and physical extents remained unsupported by design
- `chkdsk` completed without errors

Raw VHD-backed partition checks:

- backing identity: Disk 1, Partition 1
- reported data extent: start `196608`, length `262144`
- partition info and drive layout reported the same start and length
- reported capacity ended at `458752`
- `STORAGE_DEVICE_DESCRIPTOR.DeviceType = 0`
- three mount/dismount cycles completed
- `chkdsk` completed without errors

No VM snapshot was created. Testsigning, the test service, driver file, and VHD were removed afterward, and Secure Boot was restored.

## Scope boundary

This is an IOCTL compatibility change, not a new Windows PnP storage architecture. It does not create a disk PDO or partition PDO for `\Device\VeraCryptVolumeX`.

Consequently, consumers that query the mounted handle directly can correlate a raw VeraCrypt volume with its real backing disk and extent, but the modern Storage module (`Get-Volume` / `Get-Partition`) still does not enumerate the decrypted view as a separate PnP disk or partition. Solving that requires a real storage-stack participant and should be reviewed independently.

x64 Windows, bare-metal hardware, Windows Backup and Restore, and third-party imaging products have not yet been tested.

Related background: #1664, #1036.
