### PR TITLE
Crypto: document that CRYPTOPP_ALIGN_DATA can expand to nothing

### DIFF
--- a/src/Crypto/config.h
+++ b/src/Crypto/config.h
@@ -56,6 +56,8 @@
 #endif
 
 #ifndef CRYPTOPP_ALIGN_DATA
+	// Note: expands to nothing for TC_WINDOWS_BOOT and for compilers that are neither
+	// MSVC nor GCC/Clang, so alignment is not guaranteed in those builds.
 	#if defined(_MSC_VER) && !defined(TC_WINDOWS_BOOT)
 		#define CRYPTOPP_ALIGN_DATA(x) __declspec(align(x))
 	#elif defined(__GNUC__)


### PR DESCRIPTION
### What

Adds a two-line comment to the `CRYPTOPP_ALIGN_DATA` definition in `src/Crypto/config.h`. No functional change.

### Why

The macro has three branches, and the last one is empty:

```c
#ifndef CRYPTOPP_ALIGN_DATA
    #if defined(_MSC_VER) && !defined(TC_WINDOWS_BOOT)
        #define CRYPTOPP_ALIGN_DATA(x) __declspec(align(x))
    #elif defined(__GNUC__)
        #define CRYPTOPP_ALIGN_DATA(x) __attribute__((aligned(x)))
    #else
        #define CRYPTOPP_ALIGN_DATA(x)      // <-- silently no alignment
    #endif
#endif
```

Under MSVC with `TC_WINDOWS_BOOT` the first branch is skipped, `__GNUC__` is not defined either, so the macro expands to nothing. This is not visible at the ~79 call sites that use it.

The caveat is reachable, not hypothetical: `src/Common/Xts.c` contains **no** `TC_WINDOWS_BOOT` guards and is compiled into the bootloader, where its two `CRYPTOPP_ALIGN_DATA(16) whiteningValue[]` declarations lose their alignment. That is harmless there — bootloader code is real-mode without SSE — but it is not obvious from reading either file.

### Scope

Documentation only. The behaviour is intentional and is deliberately left unchanged.