### PR TITLE
Common: make derived key buffer alignment explicit in CreateVolumeHeaderInMemory

### DIFF
--- a/src/Common/Volumes.c
+++ b/src/Common/Volumes.c
@@ -1022,7 +1022,7 @@ int CreateVolumeHeaderInMemory (HWND hwndDlg, BOOL bBoot, unsigned char *header,
 
 	int nUserKeyLen = password? password->Length : 0;
 	PCRYPTO_INFO cryptoInfo = crypto_open ();
-	static char dk[MASTER_KEYDATA_SIZE];
+	static CRYPTOPP_ALIGN_DATA(TC_DERIVED_KEY_BUFFER_ALIGNMENT) char dk[MASTER_KEYDATA_SIZE];
 	int x;
 	int retVal = 0;
 	int primaryKeyOffset;


### PR DESCRIPTION
### What

One line in `src/Common/Volumes.c`:

```diff
-	static char dk[MASTER_KEYDATA_SIZE];
+	static CRYPTOPP_ALIGN_DATA(TC_DERIVED_KEY_BUFFER_ALIGNMENT) char dk[MASTER_KEYDATA_SIZE];
```

### Why

`ReadVolumeHeaderWithAbort` declares its derived key buffer with `TC_DERIVED_KEY_BUFFER_ALIGNMENT` (introduced in #1526), and the `KEY_INFO` object three lines above this one uses `TC_KEY_INFO_BUFFER_ALIGNMENT`. The equivalent buffer in `CreateVolumeHeaderInMemory` was the only one left without an explicit alignment.

### This is not a bug fix

The buffer already ends up 16-byte aligned, because the `KEY_INFO` object above it raises the alignment of the whole section. Verified with `dumpbin` on the emitted object: section alignment 16, `dk` at offset `0x1F0` (= 16 × 31).

Consequently **the generated code does not change** — compiling `Volumes.c` before and after with identical flags produces a byte-identical `.obj` (MSVC `/Brepro`, Release|x64). The change only removes the dependence on that coincidence.

### Verification

- MSVC user-mode `/W4` — `Volumes.c`, `InPlace.c`, `BootEncryption.cpp`, `Tests.c`: clean
- MSVC kernel-mode `/W4 /WX` — `DriveFilter.c`, `Volumes.c`, `Tests.c`: clean
- `Volumes.obj` SHA-256 unchanged before/after
- Linux build + `veracrypt --test`: pass

Note that `src/Common/Volumes.c` is not part of the Linux build, so the Linux run only guards against collateral damage.