### PR TITLE
Tests: verify that CRYPTOPP_ALIGN_DATA delivers the requested alignment

### DIFF
--- a/src/Common/Tests.c
+++ b/src/Common/Tests.c
@@ -20,6 +20,7 @@
 #include <string.h>
 #include "Pkcs5.h"
 #include "cpu.h"
+#include "Volumes.h"
 
 typedef struct {
 	CRYPTOPP_ALIGN_DATA(16) unsigned __int8 key1[32];
@@ -1280,6 +1281,28 @@ BOOL TestSectorBufEncryption (PCRYPTO_INFO ci)
 	return (nTestsPerformed == 150);
 }
 
+#ifndef TC_WINDOWS_DRIVER
+// Must stay smaller than the alignment under test: the ABI aligns larger objects by itself.
+#define TC_ALIGNMENT_PROBE_SIZE	4
+
+/* Verifies that CRYPTOPP_ALIGN_DATA actually delivers the alignment it requests. It expands
+   to nothing for compilers that are neither MSVC nor GCC/Clang (see Crypto/config.h), and the
+   SIMD backends issue aligned loads against buffers declared with it. */
+static BOOL TestBufferAlignment (void)
+{
+	static CRYPTOPP_ALIGN_DATA(TC_DERIVED_KEY_BUFFER_ALIGNMENT) unsigned char derivedKeyProbe[TC_ALIGNMENT_PROBE_SIZE];
+	static CRYPTOPP_ALIGN_DATA(TC_KEY_INFO_BUFFER_ALIGNMENT) unsigned char keyInfoProbe[TC_ALIGNMENT_PROBE_SIZE];
+
+	if (!TC_IS_ALIGNED (derivedKeyProbe, TC_DERIVED_KEY_BUFFER_ALIGNMENT))
+		return FALSE;
+
+	if (!TC_IS_ALIGNED (keyInfoProbe, TC_KEY_INFO_BUFFER_ALIGNMENT))
+		return FALSE;
+
+	return TRUE;
+}
+#endif
+
 static BOOL DoAutoTestAlgorithms (void)
 {
 	PCRYPTO_INFO ci;
@@ -1489,6 +1512,13 @@ static BOOL DoAutoTestAlgorithms (void)
 		bFailed = TRUE;
 
 	crypto_close (ci);
+
+#ifndef TC_WINDOWS_DRIVER
+	/* Not run in the driver: a failing self-test there reaches TC_BUG_CHECK and would bugcheck the machine. */
+	if (!TestBufferAlignment ())
+		bFailed = TRUE;
+#endif
+
 	return !bFailed;
 }
 

--- a/src/Common/Volumes.h
+++ b/src/Common/Volumes.h
@@ -41,6 +41,9 @@ extern "C" {
 // Required 16-byte alignment for KEY_INFO buffer to ensure optimal performance and compatibility with SIMD instructions.
 #define TC_KEY_INFO_BUFFER_ALIGNMENT			16
 
+// TRUE if the address meets the given alignment.
+#define TC_IS_ALIGNED(address, alignment)		((((uint64) (address)) % (alignment)) == 0)
+
 // Current volume format version (created by TrueCrypt 6.0+)
 #define TC_VOLUME_FORMAT_VERSION				2
 

--- a/src/Volume/EncryptionTest.cpp
+++ b/src/Volume/EncryptionTest.cpp
@@ -70,8 +70,28 @@ namespace VeraCrypt
 
 	void EncryptionTest::TestAll ()
 	{
+		TestAlignment();
 		TestAll (false);
 		TestAll (true);
+	}
+
+	// Must stay smaller than the alignment under test: the ABI aligns larger objects by itself.
+	#define TC_ALIGNMENT_PROBE_SIZE 4
+
+	// Verifies that CRYPTOPP_ALIGN_DATA actually delivers the alignment it requests.
+	// It expands to nothing for compilers that are neither MSVC nor GCC/Clang (see
+	// Crypto/config.h), and the SIMD backends issue aligned loads against buffers
+	// declared with it, so a silent expansion to nothing would fault at run time.
+	void EncryptionTest::TestAlignment ()
+	{
+		static CRYPTOPP_ALIGN_DATA(TC_DERIVED_KEY_BUFFER_ALIGNMENT) uint8 derivedKeyProbe[TC_ALIGNMENT_PROBE_SIZE];
+		static CRYPTOPP_ALIGN_DATA(TC_KEY_INFO_BUFFER_ALIGNMENT) uint8 keyInfoProbe[TC_ALIGNMENT_PROBE_SIZE];
+
+		if (!TC_IS_ALIGNED (derivedKeyProbe, TC_DERIVED_KEY_BUFFER_ALIGNMENT))
+			throw TestFailed (SRC_POS);
+
+		if (!TC_IS_ALIGNED (keyInfoProbe, TC_KEY_INFO_BUFFER_ALIGNMENT))
+			throw TestFailed (SRC_POS);
 	}
 
 	void EncryptionTest::TestAll (bool enableCpuEncryptionSupport)

--- a/src/Volume/EncryptionTest.h
+++ b/src/Volume/EncryptionTest.h
@@ -25,6 +25,7 @@ namespace VeraCrypt
 		static void TestAll (bool enableCpuEncryptionSupport);
 
 	protected:
+		static void TestAlignment ();
 		static void TestCiphers ();
 		static void TestLegacyModes ();
 		static void TestPkcs5 ();


### PR DESCRIPTION
### What

Adds an alignment check to both platform self-test suites:

- `src/Volume/EncryptionTest.cpp` — `EncryptionTest::TestAlignment()`, called from `TestAll()`
- `src/Common/Tests.c` — `TestBufferAlignment()`, called from `DoAutoTestAlgorithms()`
- `src/Common/Volumes.h` — `TC_IS_ALIGNED(address, alignment)`, next to the existing alignment constants

### Why

Around 79 declarations across the code base rely on `CRYPTOPP_ALIGN_DATA`, and the SIMD backends issue **aligned** loads (`_mm_load_si128` / `_mm_store_si128`, ~66 sites) against buffers declared with it. If the macro ever expands to nothing — it has an empty fallback branch for compilers that are neither MSVC nor GCC/Clang — those loads fault. In kernel mode that is a bugcheck.

Nothing verified this so far.

### Design notes

**Probe size.** The probe buffers are deliberately smaller than the alignment under test. The x86-64 ABI already aligns objects of 16 bytes or more on its own, so a large probe would pass even with the macro removed, making the test vacuous. This was measured, not assumed:

```
with attribute,    64 bytes : addr % 16 = 0
without attribute, 64 bytes : addr % 16 = 0    <-- vacuous
without attribute,  4 bytes : addr % 16 = 1    <-- meaningful
```

**Driver excluded.** The check is skipped under `TC_WINDOWS_DRIVER`. A failing self-test in a boot-start driver reaches `TC_BUG_CHECK` (`Ntdriver.c`), which would leave a system-encrypted machine unbootable — too high a price for a check whose failure mode the SIMD code would surface anyway. The guard wraps both the call and the function definition, the latter because an unreferenced static function trips C4505 and the driver builds with `TreatWarningAsError`.

### Verification

The test was confirmed to actually fail when the macro is broken. Neutering `CRYPTOPP_ALIGN_DATA` in a scratch build produces:

```
Error: TestFailed at VeraCrypt::EncryptionTest::TestAlignment:91
```

Unmodified, the suite passes. Additionally:

- MSVC user-mode `/W4` and kernel-mode `/W4 /WX`: clean, `Tests.c` warning-free
- Linux build + `veracrypt --text --test`: pass

### Limitation

Only the Linux side runs automatically — the repository has no Windows CI job. The `Tests.c` half covers the MSVC branch of the macro but executes only when Format/Mount/ExpandVolume/FormatDLL starts.