### PR TITLE
macOS/FUSE-T: Terminate auxiliary FUSE service on dismount

### DIFF
--- a/src/Core/Unix/MacOSX/CoreMacOSX.cpp
+++ b/src/Core/Unix/MacOSX/CoreMacOSX.cpp
@@ -317,12 +317,25 @@ namespace VeraCrypt
 				mountedVolume = ml.front();
 		}
 
+#ifdef VC_MACOSX_FUSET
+		pid_t fuseServiceProcessId = FuseService::RequestDismount (mountedVolume->AuxMountPoint,
+			mountedVolume->SerialInstanceNumber, mountedVolume->SlotNumber);
+#endif
+
 		list <string> args;
 		args.push_back ("--");
 		args.push_back (mountedVolume->AuxMountPoint);
 
 		for (int t = 0; true; t++)
 		{
+#ifdef VC_MACOSX_FUSET
+			try
+			{
+				if (GetMountedFilesystems (DevicePath(), mountedVolume->AuxMountPoint).empty())
+					break;
+			}
+			catch (...) { }
+#endif
 			try
 			{
 				Process::Execute ("/sbin/umount", args);
@@ -335,6 +348,10 @@ namespace VeraCrypt
 				Thread::Sleep (200);
 			}
 		}
+
+#ifdef VC_MACOSX_FUSET
+		FuseService::WaitForDismount (fuseServiceProcessId, mountedVolume->AuxMountPoint, mountedVolume->SlotNumber);
+#endif
 
 		try
 		{

--- a/src/Driver/Fuse/FuseService.cpp
+++ b/src/Driver/Fuse/FuseService.cpp
@@ -34,8 +34,10 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <fuse.h>
+#include <atomic>
 #include <iostream>
 #include <signal.h>
+#include <sstream>
 #include <string.h>
 #include <stdio.h>
 #include <unistd.h>
@@ -46,6 +48,13 @@
 #include <sys/wait.h>
 
 #include "FuseService.h"
+#if defined(TC_MACOSX) && defined(VC_MACOSX_FUSET)
+#include <fuse_lowlevel.h>
+#undef fuse_unmount
+#ifdef ERR_SUCCESS
+#undef ERR_SUCCESS
+#endif
+#endif
 #include "Platform/FileStream.h"
 #include "Platform/MemoryStream.h"
 #include "Platform/Serializable.h"
@@ -62,6 +71,16 @@ namespace VeraCrypt
 	static const ino_t VC_FUSE_INODE_VOLUME = 2;
 	static const ino_t VC_FUSE_INODE_CONTROL = 3;
 	static const ino_t VC_FUSE_INODE_AUX_DEVICE_INFO = 4;
+#if defined(TC_MACOSX) && defined(VC_MACOSX_FUSET)
+	static const ino_t VC_FUSE_INODE_SHUTDOWN = 5;
+	static atomic <bool> FuseServiceShutdownRequested (false);
+
+	struct FuseServiceShutdownContext
+	{
+		explicit FuseServiceShutdownContext (struct fuse *fuseHandle) : FuseHandle (fuseHandle) { }
+		struct fuse *FuseHandle;
+	};
+#endif
 	static const uint64 VC_FUSE_BLOCK_SIZE = 4096;
 	static const uint64 VC_FUSE_METADATA_SIZE = 64 * 1024;
 	static const uint64 VC_FUSE_STAT_BLOCK_SIZE = 512;
@@ -84,6 +103,51 @@ namespace VeraCrypt
 
 		return FuseService::GetVolumeInfo();
 	}
+
+#if defined(TC_MACOSX) && defined(VC_MACOSX_FUSET)
+	static string fuse_service_get_shutdown_identity ()
+	{
+		stringstream identity;
+		identity << getpid() << " " << FuseService::GetSerialInstanceNumber() << " " << FuseService::GetSlotNumber() << "\n";
+		return identity.str();
+	}
+
+	static bool fuse_service_parse_shutdown_identity (const string &identity, pid_t &processId, uint64 &serialInstanceNumber, VolumeSlotNumber &slotNumber)
+	{
+		long long parsedProcessId;
+		uint64 parsedSerialInstanceNumber;
+		VolumeSlotNumber parsedSlotNumber;
+		stringstream parser (identity);
+
+		if (!(parser >> parsedProcessId >> parsedSerialInstanceNumber >> parsedSlotNumber))
+			return false;
+
+		parser >> ws;
+		if (!parser.eof() || parsedProcessId <= 1 || static_cast <pid_t> (parsedProcessId) != parsedProcessId)
+			return false;
+
+		processId = static_cast <pid_t> (parsedProcessId);
+		serialInstanceNumber = parsedSerialInstanceNumber;
+		slotNumber = parsedSlotNumber;
+		return true;
+	}
+
+	static TC_THREAD_PROC fuse_service_shutdown (void *contextArg)
+	{
+		unique_ptr <FuseServiceShutdownContext> context (static_cast <FuseServiceShutdownContext *> (contextArg));
+
+		// Let the write reply reach the caller before closing FUSE-T's channel.
+		Thread::Sleep (100);
+		fuse_exit (context->FuseHandle);
+
+		struct fuse_session *session = fuse_get_session (context->FuseHandle);
+		struct fuse_chan *channel = session ? fuse_session_next_chan (session, NULL) : NULL;
+		if (channel)
+			fuse_unmount (NULL, channel);
+
+		return 0;
+	}
+#endif
 
 	static int fuse_service_fill_dir_entry (void *buf, fuse_fill_dir_t filler, const char *name, mode_t mode, ino_t ino, off_t nextOff)
 	{
@@ -234,6 +298,16 @@ namespace VeraCrypt
 					statData->st_ino = VC_FUSE_INODE_CONTROL;
 					fuse_service_set_stat_blocks (statData);
 				}
+#if defined(TC_MACOSX) && defined(VC_MACOSX_FUSET)
+				else if (strcmp (path, FuseService::GetShutdownPath()) == 0)
+				{
+					statData->st_mode = S_IFREG | 0600;
+					statData->st_nlink = 1;
+					statData->st_size = fuse_service_get_shutdown_identity().size();
+					statData->st_ino = VC_FUSE_INODE_SHUTDOWN;
+					fuse_service_set_stat_blocks (statData);
+				}
+#endif
 				else
 				{
 					return -ENOENT;
@@ -330,6 +404,14 @@ namespace VeraCrypt
 				fi->direct_io = 1;
 				return 0;
 			}
+
+#if defined(TC_MACOSX) && defined(VC_MACOSX_FUSET)
+			if (strcmp (path, FuseService::GetShutdownPath()) == 0)
+			{
+				fi->direct_io = 1;
+				return 0;
+			}
+#endif
 		}
 		catch (...)
 		{
@@ -412,6 +494,24 @@ namespace VeraCrypt
 				outBuf.CopyFrom (infoBuf->GetRange (offset, size));
 				return size;
 			}
+
+#if defined(TC_MACOSX) && defined(VC_MACOSX_FUSET)
+			if (strcmp (path, FuseService::GetShutdownPath()) == 0)
+			{
+				string identity = fuse_service_get_shutdown_identity();
+				if (offset < 0)
+					return -EINVAL;
+
+				if (offset >= (off_t) identity.size())
+					return 0;
+
+				if (offset + size > identity.size())
+					size = identity.size() - offset;
+
+				memcpy (buf, identity.data() + offset, size);
+				return size;
+			}
+#endif
 		}
 		catch (...)
 		{
@@ -461,6 +561,10 @@ namespace VeraCrypt
 				return 0;
 			if (fuse_service_fill_dir_entry (buf, filler, FuseService::GetAuxDeviceInfoPath() + 1, S_IFREG | 0600, VC_FUSE_INODE_AUX_DEVICE_INFO, 0) != 0)
 				return 0;
+#if defined(TC_MACOSX) && defined(VC_MACOSX_FUSET)
+			if (fuse_service_fill_dir_entry (buf, filler, FuseService::GetShutdownPath() + 1, S_IFREG | 0600, VC_FUSE_INODE_SHUTDOWN, 0) != 0)
+				return 0;
+#endif
 		}
 		catch (...)
 		{
@@ -506,6 +610,42 @@ namespace VeraCrypt
 				FuseService::ReceiveAuxDeviceInfo (ConstBufferPtr ((const uint8 *) buf, size));
 				return size;
 			}
+
+#if defined(TC_MACOSX) && defined(VC_MACOSX_FUSET)
+			if (strcmp (path, FuseService::GetShutdownPath()) == 0)
+			{
+				pid_t processId;
+				uint64 serialInstanceNumber;
+				VolumeSlotNumber slotNumber;
+				struct fuse_context *context = fuse_get_context();
+
+				if (offset != 0 || !context || !context->fuse
+					|| !fuse_service_parse_shutdown_identity (string (buf, size), processId, serialInstanceNumber, slotNumber)
+					|| processId != getpid()
+					|| serialInstanceNumber != FuseService::GetSerialInstanceNumber()
+					|| slotNumber != FuseService::GetSlotNumber())
+					return -EINVAL;
+
+				bool expected = false;
+				if (FuseServiceShutdownRequested.compare_exchange_strong (expected, true))
+				{
+					try
+					{
+						unique_ptr <FuseServiceShutdownContext> shutdownContext (new FuseServiceShutdownContext (context->fuse));
+						Thread shutdownThread;
+						shutdownThread.Start (fuse_service_shutdown, shutdownContext.get());
+						shutdownContext.release();
+						shutdownThread.Detach();
+					}
+					catch (...)
+					{
+						FuseServiceShutdownRequested = false;
+						throw;
+					}
+				}
+				return size;
+			}
+#endif
 		}
 #ifdef TC_FREEBSD
 		// FreeBSD apparently retries failed write operations forever, which may lead to a system crash.
@@ -741,6 +881,64 @@ namespace VeraCrypt
 		fuseServiceControl.Write (dynamic_cast <MemoryStream&> (*stream));
 		fuseServiceControl.Close();
 	}
+
+#if defined(TC_MACOSX) && defined(VC_MACOSX_FUSET)
+	pid_t FuseService::RequestDismount (const DirectoryPath &fuseMountPoint, uint64 serialInstanceNumber, VolumeSlotNumber slotNumber)
+	{
+		shared_ptr <File> shutdownFile (new File);
+		shutdownFile->Open (string (fuseMountPoint) + GetShutdownPath());
+
+		FileStream shutdownReader (shutdownFile);
+		string identity = shutdownReader.ReadToEnd();
+		shutdownFile->Close();
+		if (identity.empty() || identity.size() > 256)
+			throw ParameterIncorrect (SRC_POS);
+
+		pid_t processId;
+		uint64 serviceSerialInstanceNumber;
+		VolumeSlotNumber serviceSlotNumber;
+		if (!fuse_service_parse_shutdown_identity (identity, processId, serviceSerialInstanceNumber, serviceSlotNumber)
+			|| serviceSerialInstanceNumber != serialInstanceNumber || serviceSlotNumber != slotNumber)
+		{
+			stringstream logMessage;
+			logMessage << "Refusing to shut down mismatched VeraCrypt FUSE service: slot=" << slotNumber
+				<< ", auxiliary mount=" << string (fuseMountPoint);
+			SystemLog::WriteError (logMessage.str());
+			throw ParameterIncorrect (SRC_POS);
+		}
+
+		shutdownFile->Open (string (fuseMountPoint) + GetShutdownPath(), File::OpenWrite);
+		shutdownFile->Write (ConstBufferPtr (reinterpret_cast <const uint8 *> (identity.data()), identity.size()));
+		shutdownFile->Close();
+		return processId;
+	}
+
+	void FuseService::WaitForDismount (pid_t processId, const DirectoryPath &fuseMountPoint, VolumeSlotNumber slotNumber, int timeOut)
+	{
+		for (int timeTaken = 0; ; timeTaken += 100)
+		{
+			if (kill (processId, 0) == -1)
+			{
+				if (errno == ESRCH)
+					return;
+
+				if (errno != EPERM)
+					throw SystemException (SRC_POS);
+			}
+
+			if (timeTaken >= timeOut)
+			{
+				stringstream logMessage;
+				logMessage << "VeraCrypt FUSE service did not terminate after shutdown request: pid=" << processId
+					<< ", slot=" << slotNumber << ", auxiliary mount=" << string (fuseMountPoint);
+				SystemLog::WriteError (logMessage.str());
+				throw TimeOut (SRC_POS);
+			}
+
+			Thread::Sleep (100);
+		}
+	}
+#endif
 
 	void FuseService::WriteVolumeSectors (const ConstBufferPtr &buffer, uint64 byteOffset)
 	{

--- a/src/Driver/Fuse/FuseService.h
+++ b/src/Driver/Fuse/FuseService.h
@@ -48,9 +48,14 @@ namespace VeraCrypt
 		static const char *GetAuxDeviceInfoPath () { return "/aux-device-info"; }
 		static const char *GetControlPath () { return "/control"; }
 		static const char *GetVolumeImagePath ();
+#if defined(TC_MACOSX) && defined(VC_MACOSX_FUSET)
+		static const char *GetShutdownPath () { return "/shutdown"; }
+#endif
 		static string GetDeviceType () { return "veracrypt"; }
 		static gid_t GetGroupId () { return GroupId; }
 		static uid_t GetUserId () { return UserId; }
+		static uint64 GetSerialInstanceNumber () { return OpenVolumeInfo.SerialInstanceNumber; }
+		static VolumeSlotNumber GetSlotNumber () { return SlotNumber; }
 		static shared_ptr <Buffer> GetAuxDeviceInfo ();
 		static shared_ptr <Buffer> GetVolumeInfo ();
 		static uint64 GetVolumeSize ();
@@ -59,6 +64,10 @@ namespace VeraCrypt
 		static void ReadVolumeSectors (const BufferPtr &buffer, uint64 byteOffset);
 		static void ReceiveAuxDeviceInfo (const ConstBufferPtr &buffer);
 		static void SendAuxDeviceInfo (const DirectoryPath &fuseMountPoint, const DevicePath &virtualDevice, const DevicePath &loopDevice = DevicePath());
+#if defined(TC_MACOSX) && defined(VC_MACOSX_FUSET)
+		static pid_t RequestDismount (const DirectoryPath &fuseMountPoint, uint64 serialInstanceNumber, VolumeSlotNumber slotNumber);
+		static void WaitForDismount (pid_t processId, const DirectoryPath &fuseMountPoint, VolumeSlotNumber slotNumber, int timeOut = 10000);
+#endif
 		static void WriteVolumeSectors (const ConstBufferPtr &buffer, uint64 byteOffset);
 
 	protected:


### PR DESCRIPTION
This PR fixes the FUSE-T service remaining alive after a VeraCrypt volume is dismounted on macOS.

It addresses the FUSE-T process/session leak reported in #1845.

## Problem

With FUSE-T, the auxiliary mount can disappear while the corresponding VeraCrypt FUSE service is still running in `fuse_main()`.

As a result, VeraCrypt may report that a volume has been dismounted even though the FUSE-T session is still alive and access to the decrypted volume has not been fully revoked.

This has two serious consequences.

### 1. The dismounted volume can become accessible again without a password

With the official VeraCrypt 1.26.29 FUSE-T build, the following sequence is reproducible:

1. Mount a VeraCrypt volume.
2. Open a `.png` file from the mounted volume in Preview.app, then close Preview.app.
3. Dismount the volume from the VeraCrypt GUI.
4. Select the same file from Preview's `Open Recent` menu.

The volume disappears from the VeraCrypt volume list and appears to have been dismounted. However, selecting the same file from Preview's `Open Recent` menu causes the stale FUSE-T session to reconnect, allowing the file to be opened without entering the VeraCrypt password.

If the remaining VeraCrypt/FUSE-T processes are terminated after dismount, this reconnection does not occur, and the file can no longer be opened from `Open Recent` without remounting the VeraCrypt volume normally.

This means that dismount does not reliably revoke access as long as the auxiliary FUSE service remains alive.


### 2. The leaked service can keep the raw device open across sleep/wake

For device-hosted volumes, the remaining VeraCrypt/FUSE-T processes may continue holding `/dev/rdiskN` or `/dev/rdiskNsN` after dismount.

This prevents normal device eject.

On affected systems, putting the Mac to sleep while the raw device remains held can also lead to a kernel panic after wake:

```text
busy timeout[1], (60s): 'IOMediaBSDClient'
```

In testing reported in #1845, the panic stopped reproducing when the leaked VeraCrypt/FUSE-T processes were terminated before sleep.

Therefore, successful `umount` alone is not sufficient to complete the VeraCrypt dismount operation.

## Solution

This patch explicitly terminates the corresponding auxiliary FUSE service during dismount.

The shutdown sequence is:

1. Read the FUSE service PID, `SerialInstanceNumber`, and slot number.
2. Verify that they match the volume being dismounted.
3. Request shutdown through the auxiliary FUSE filesystem.
4. Call `fuse_exit()` and `fuse_unmount()`.
5. Wait until the matching service process has actually terminated before removing the auxiliary mount point.

The shutdown handler runs asynchronously after a short delay so that the FUSE write response can complete before the channel is closed.

## Testing

Tested on a MacBook Air M4 running macOS 26.6.2 with FUSE-T 1.2.7.
I compared the official VeraCrypt 1.26.29 FUSE-T build with this patch using the same container and the same FUSE-T SMB backend.

### VeraCrypt 1.26.29

After mounting the container, the mount-specific processes included:

```text
VeraCrypt
go-nfsv4 ... --backend smb .../.veracrypt_aux_mnt1
VeraCrypt
```

The auxiliary filesystem was mounted through FUSE-T/SMB, and `hdiutil info` showed the VeraCrypt `volume.dmg`.

After dismounting from the VeraCrypt GUI, the auxiliary SMB mount disappeared and the `volume.dmg` was detached.

However, the mount-specific VeraCrypt processes and `go-nfsv4` remained alive.


Thus, the macOS-visible mount was gone while the corresponding FUSE-T service was still running.


### Patched build

I repeated the same test with the existing `backend=smb` behavior unchanged.

After dismounting from the GUI:

* the auxiliary SMB mount disappeared,
* the `volume.dmg` was detached,
* the mount-specific VeraCrypt service processes terminated, and
* the corresponding `go-nfsv4` process terminated.

Only the VeraCrypt GUI processes that existed before the mount remained.

This confirms that explicitly terminating the auxiliary FUSE-T service fixes the leak without changing the FUSE-T backend selection.
